### PR TITLE
Bugfix: flush cache if not using external cache or if filter is modified

### DIFF
--- a/classes/ActionScheduler_QueueRunner.php
+++ b/classes/ActionScheduler_QueueRunner.php
@@ -122,7 +122,7 @@ class ActionScheduler_QueueRunner {
 	 * @return void
 	 */
 	protected function clear_caches() {
-		if ( wp_using_ext_object_cache() && !apply_filters( 'action_scheduler_queue_runner_flush_cache', false ) ) {
+		if ( ! wp_using_ext_object_cache() || apply_filters( 'action_scheduler_queue_runner_flush_cache', false ) ) {
 			wp_cache_flush();
 		}
 	}


### PR DESCRIPTION
Currently it will ONLY flush caches if using an external cache and if the filter is not modified, the inverse of what we want.