### PR TITLE
Catch fatal errors when fetching action in queue

### DIFF
--- a/classes/ActionScheduler_QueueRunner.php
+++ b/classes/ActionScheduler_QueueRunner.php
@@ -91,8 +91,8 @@ class ActionScheduler_QueueRunner {
 
 	protected function process_action( $action_id ) {
 		try {
-			$action = $this->store->fetch_action( $action_id );
 			do_action( 'action_scheduler_before_execute', $action_id );
+			$action = $this->store->fetch_action( $action_id );
 			$this->store->log_execution( $action_id );
 			$action->execute();
 			do_action( 'action_scheduler_after_execute', $action_id );

--- a/classes/ActionScheduler_QueueRunner.php
+++ b/classes/ActionScheduler_QueueRunner.php
@@ -90,9 +90,9 @@ class ActionScheduler_QueueRunner {
 	}
 
 	protected function process_action( $action_id ) {
-		$action = $this->store->fetch_action( $action_id );
-		do_action( 'action_scheduler_before_execute', $action_id );
 		try {
+			$action = $this->store->fetch_action( $action_id );
+			do_action( 'action_scheduler_before_execute', $action_id );
 			$this->store->log_execution( $action_id );
 			$action->execute();
 			do_action( 'action_scheduler_after_execute', $action_id );


### PR DESCRIPTION
To ensure that any catchable fatal exceptions that occur while fetching the
action do not block the entire queue (like invalid JSON in `post_content`).

Fixes #26.