### PR TITLE
Do not include log entries in comment counts

### DIFF
--- a/classes/ActionScheduler_wpCommentLogger.php
+++ b/classes/ActionScheduler_wpCommentLogger.php
@@ -113,6 +113,54 @@ class ActionScheduler_wpCommentLogger extends ActionScheduler_Logger {
 	}
 
 	/**
+	 * Remove action log entries from wp_count_comments()
+	 *
+	 * @param array $stats
+	 * @param int $post_id
+	 *
+	 * @return object
+	 */
+	public function filter_comment_count( $stats, $post_id ) {
+		global $wpdb;
+
+		if ( 0 === $post_id ) {
+
+			$count = wp_cache_get( 'comments-0', 'counts' );
+			if ( false !== $count ) {
+				return $count;
+			}
+
+			$count = $wpdb->get_results( "SELECT comment_approved, COUNT( * ) AS num_comments FROM {$wpdb->comments} WHERE comment_type NOT IN('order_note','action_log') GROUP BY comment_approved", ARRAY_A );
+
+			$total = 0;
+			$stats = array();
+			$approved = array( '0' => 'moderated', '1' => 'approved', 'spam' => 'spam', 'trash' => 'trash', 'post-trashed' => 'post-trashed' );
+
+			foreach ( (array) $count as $row ) {
+				// Don't count post-trashed toward totals
+				if ( 'post-trashed' != $row['comment_approved'] && 'trash' != $row['comment_approved'] ) {
+					$total += $row['num_comments'];
+				}
+				if ( isset( $approved[ $row['comment_approved'] ] ) ) {
+					$stats[ $approved[ $row['comment_approved'] ] ] = $row['num_comments'];
+				}
+			}
+
+			$stats['total_comments'] = $total;
+			foreach ( $approved as $key ) {
+				if ( empty( $stats[ $key ] ) ) {
+					$stats[ $key ] = 0;
+				}
+			}
+
+			$stats = (object) $stats;
+			wp_cache_set( 'comments-0', $stats, 'counts' );
+		}
+
+		return $stats;
+	}
+
+	/**
 	 * @codeCoverageIgnore
 	 */
 	public function init() {
@@ -126,6 +174,7 @@ class ActionScheduler_wpCommentLogger extends ActionScheduler_Logger {
 		add_action( 'action_scheduler_unexpected_shutdown', array( $this, 'log_unexpected_shutdown' ), 10, 2 );
 		add_action( 'action_scheduler_reset_action', array( $this, 'log_reset_action' ), 10, 1 );
 		add_action( 'pre_get_comments', array( $this, 'filter_comment_queries' ), 10, 1 );
+		add_action( 'wp_count_comments', array( $this, 'filter_comment_count' ), 9, 2 ); // run before WC_Comments::wp_count_comments()
 	}
 
 	public function disable_comment_counting() {


### PR DESCRIPTION
So they are not included in the comment count of the **At A Glance** widget.

![WordPress At a Glance Widget](https://cldup.com/6VTNt9jkqK.png)