### PR TITLE
fix fatal error process_action()

### DIFF
--- a/classes/ActionScheduler_QueueRunner.php
+++ b/classes/ActionScheduler_QueueRunner.php
@@ -89,7 +89,7 @@ class ActionScheduler_QueueRunner {
 		return $processed_actions;
 	}
 
-	protected function process_action( $action_id ) {
+	public function process_action( $action_id ) {
 		try {
 			do_action( 'action_scheduler_before_execute', $action_id );
 			$action = $this->store->fetch_action( $action_id );
@@ -136,4 +136,4 @@ class ActionScheduler_QueueRunner {
 		return $schedules;
 	}
 }
- 
+


### PR DESCRIPTION
Fatal error: Call to protected method
ActionScheduler_QueueRunner::process_action() from context. Changing
visibility to public allows action link to be used from a CPT dashboard.