### PR TITLE
Used call_user_func function to call action_scheduler_initialize_1_do…

### DIFF
--- a/classes/ActionScheduler_Versions.php
+++ b/classes/ActionScheduler_Versions.php
@@ -15,7 +15,7 @@ class ActionScheduler_Versions {
 		if ( isset($this->versions[$version_string]) ) {
 			return FALSE;
 		}
-		$this->versions[$version_string] = $initialization_callback;
+		$this->versions[$version_string] = call_user_func ( $initialization_callback );
 		return TRUE;
 	}
 


### PR DESCRIPTION
…t_2_dev function

It was unable to call the action_scheduler_initialize_1_dot_2_dev
function , the error was undefined function
action_scheduler_initialize_1_dot_2_dev in WC_Subscriptions_Manager
class of  woocommerce-subscriptions plugin