### PR TITLE
Fix Fatal error: Call to undefined function wc_next_scheduled_action()

### DIFF
--- a/classes/ActionScheduler.php
+++ b/classes/ActionScheduler.php
@@ -41,17 +41,16 @@ abstract class ActionScheduler {
 	}
 
 	/**
-	 * Get the absolute system path to the plugin directory, or a file therein
+	 * Get the plugin directory path, or a file therein
 	 * @static
 	 * @param string $path
 	 * @return string
 	 */
 	public static function plugin_path( $path ) {
-		$base = dirname(self::$plugin_file);
 		if ( $path ) {
-			return trailingslashit($base).$path;
+			return plugin_dir_path( self::$plugin_file ) . $path;
 		} else {
-			return untrailingslashit($base);
+			return untrailingslashit( plugin_dir_path( self::$plugin_file ) );
 		}
 	}
 
@@ -115,4 +114,4 @@ abstract class ActionScheduler {
 
 	final private function __construct() {}
 }
- 
+


### PR DESCRIPTION
On some systems dirname() is not creating the correct path. Using
plugin_dir_path() does find the correct path.