### PR TITLE
Timezone fixes

### DIFF
--- a/classes/ActionScheduler.php
+++ b/classes/ActionScheduler.php
@@ -32,14 +32,30 @@ abstract class ActionScheduler {
 		return ActionScheduler_AdminView::instance();
 	}
 
-	public static function get_datetime_object( $when ) {
-		$when = empty($when) ? time() : $when;
+	/**
+	 * Helper function to create an instance of DateTime based on a given
+	 * string and timezone. By default, will return the current date/time
+	 * in the UTC timezone.
+	 *
+	 * Needed because new DateTime() called without an explicit timezone
+	 * will create a date/time in PHP's timezone, but we need to have
+	 * assurance that a date/time uses the right timezone (which we almost
+	 * always want to be UTC), which means we need to always include the
+	 * timezone when instantiating datetimes rather than leaving it up to
+	 * the PHP default.
+	 *
+	 * @param mixed $date_string A date/time string. Valid formats are explained in http://php.net/manual/en/datetime.formats.php
+	 * @param string $timezone A timezone identifier, like UTC or Europe/Lisbon. The list of valid identifiers is available http://php.net/manual/en/timezones.php
+	 *
+	 * @return DateTime
+	 */
+	public static function get_datetime_object( $when = null, $timezone = 'UTC' ) {
 		if ( is_object($when) && $when instanceof DateTime ) {
-			$date = $when;
+			$date = $when->setTimezone(new DateTimeZone( $timezone ) );
 		} elseif ( is_numeric( $when ) ) {
-			$date = new DateTime( '@'.$when );
+			$date = new DateTime( '@'.$when, new DateTimeZone( $timezone ) );
 		} else {
-			$date = new DateTime( $when );
+			$date = new DateTime( $when, new DateTimeZone( $timezone ) );
 		}
 		return $date;
 	}

--- a/classes/ActionScheduler.php
+++ b/classes/ActionScheduler.php
@@ -33,34 +33,6 @@ abstract class ActionScheduler {
 	}
 
 	/**
-	 * Helper function to create an instance of DateTime based on a given
-	 * string and timezone. By default, will return the current date/time
-	 * in the UTC timezone.
-	 *
-	 * Needed because new DateTime() called without an explicit timezone
-	 * will create a date/time in PHP's timezone, but we need to have
-	 * assurance that a date/time uses the right timezone (which we almost
-	 * always want to be UTC), which means we need to always include the
-	 * timezone when instantiating datetimes rather than leaving it up to
-	 * the PHP default.
-	 *
-	 * @param mixed $date_string A date/time string. Valid formats are explained in http://php.net/manual/en/datetime.formats.php
-	 * @param string $timezone A timezone identifier, like UTC or Europe/Lisbon. The list of valid identifiers is available http://php.net/manual/en/timezones.php
-	 *
-	 * @return DateTime
-	 */
-	public static function get_datetime_object( $when = null, $timezone = 'UTC' ) {
-		if ( is_object($when) && $when instanceof DateTime ) {
-			$date = $when->setTimezone(new DateTimeZone( $timezone ) );
-		} elseif ( is_numeric( $when ) ) {
-			$date = new DateTime( '@'.$when, new DateTimeZone( $timezone ) );
-		} else {
-			$date = new DateTime( $when, new DateTimeZone( $timezone ) );
-		}
-		return $date;
-	}
-
-	/**
 	 * Get the absolute system path to the plugin directory, or a file therein
 	 * @static
 	 * @param string $path
@@ -137,5 +109,12 @@ abstract class ActionScheduler {
 	}
 
 	final private function __construct() {}
+
+	/** Deprecated **/
+
+	public static function get_datetime_object( $when = null, $timezone = 'UTC' ) {
+		_deprecated_function( __METHOD__, '2.0', 'wcs_add_months()' );
+		return as_get_datetime_object( $when, $timezone );
+	}
 }
  

--- a/classes/ActionScheduler_ActionFactory.php
+++ b/classes/ActionScheduler_ActionFactory.php
@@ -13,7 +13,7 @@ class ActionScheduler_ActionFactory {
 	 * @return string The ID of the stored action
 	 */
 	public function single( $hook, $args = array(), $when = NULL, $group = '' ) {
-		$date = ActionScheduler::get_datetime_object( $when );
+		$date = as_get_datetime_object( $when );
 		$schedule = new ActionScheduler_SimpleSchedule( $date );
 		$action = new ActionScheduler_Action( $hook, $args, $schedule, $group );
 		return $this->store( $action );
@@ -32,7 +32,7 @@ class ActionScheduler_ActionFactory {
 		if ( empty($interval) ) {
 			return $this->single( $hook, $args, $first, $group );
 		}
-		$date = ActionScheduler::get_datetime_object( $first );
+		$date = as_get_datetime_object( $first );
 		$schedule = new ActionScheduler_IntervalSchedule( $date, $interval );
 		$action = new ActionScheduler_Action( $hook, $args, $schedule, $group );
 		return $this->store( $action );
@@ -52,7 +52,7 @@ class ActionScheduler_ActionFactory {
 		if ( empty($schedule) ) {
 			return $this->single( $hook, $args, $first, $group );
 		}
-		$date = ActionScheduler::get_datetime_object( $first );
+		$date = as_get_datetime_object( $first );
 		$cron = CronExpression::factory( $schedule );
 		$schedule = new ActionScheduler_CronSchedule( $date, $cron );
 		$action = new ActionScheduler_Action( $hook, $args, $schedule, $group );

--- a/classes/ActionScheduler_AdminView.php
+++ b/classes/ActionScheduler_AdminView.php
@@ -166,7 +166,7 @@ class ActionScheduler_AdminView {
 
 		$action_title   = ( 'trash' == $post->post_status ) ? $post->post_title : $action->get_hook();
 		$recurrence     = ( 'trash' == $post->post_status ) ? 0 : $action->get_schedule();
-		$next_timestamp = strtotime( $post->post_date_gmt . ' GMT' );
+		$next_timestamp = strtotime( $post->post_date_gmt . ' UTC' );
 		$status         = get_post_status( $post_id );
 
 		switch ( $column_name ) {

--- a/classes/ActionScheduler_AdminView.php
+++ b/classes/ActionScheduler_AdminView.php
@@ -166,7 +166,7 @@ class ActionScheduler_AdminView {
 
 		$action_title   = ( 'trash' == $post->post_status ) ? $post->post_title : $action->get_hook();
 		$recurrence     = ( 'trash' == $post->post_status ) ? 0 : $action->get_schedule();
-		$next_timestamp = ( function_exists( 'wcs_date_to_time' ) ) ? wcs_date_to_time( $post->post_date_gmt ) : strtotime( $post->post_date_gmt . ' GMT' ); //get_post_time( 'U', true, $post_id );
+		$next_timestamp = ( function_exists( 'wcs_date_to_time' ) ) ? wcs_date_to_time( $post->post_date_gmt ) : strtotime( $post->post_date_gmt . ' GMT' );
 		$status         = get_post_status( $post_id );
 
 		switch ( $column_name ) {

--- a/classes/ActionScheduler_AdminView.php
+++ b/classes/ActionScheduler_AdminView.php
@@ -166,7 +166,7 @@ class ActionScheduler_AdminView {
 
 		$action_title   = ( 'trash' == $post->post_status ) ? $post->post_title : $action->get_hook();
 		$recurrence     = ( 'trash' == $post->post_status ) ? 0 : $action->get_schedule();
-		$next_timestamp = ActionScheduler::get_datetime_object( $post->post_date_gmt )->format( 'U' );
+		$next_timestamp = as_get_datetime_object( $post->post_date_gmt )->format( 'U' );
 		$status         = get_post_status( $post_id );
 
 		switch ( $column_name ) {

--- a/classes/ActionScheduler_AdminView.php
+++ b/classes/ActionScheduler_AdminView.php
@@ -166,7 +166,7 @@ class ActionScheduler_AdminView {
 
 		$action_title   = ( 'trash' == $post->post_status ) ? $post->post_title : $action->get_hook();
 		$recurrence     = ( 'trash' == $post->post_status ) ? 0 : $action->get_schedule();
-		$next_timestamp = ( function_exists( 'wcs_date_to_time' ) ) ? wcs_date_to_time( $post->post_date_gmt ) : strtotime( $post->post_date_gmt . ' GMT' );
+		$next_timestamp = strtotime( $post->post_date_gmt . ' GMT' );
 		$status         = get_post_status( $post_id );
 
 		switch ( $column_name ) {

--- a/classes/ActionScheduler_AdminView.php
+++ b/classes/ActionScheduler_AdminView.php
@@ -166,7 +166,7 @@ class ActionScheduler_AdminView {
 
 		$action_title   = ( 'trash' == $post->post_status ) ? $post->post_title : $action->get_hook();
 		$recurrence     = ( 'trash' == $post->post_status ) ? 0 : $action->get_schedule();
-		$next_timestamp = strtotime( $post->post_date_gmt . ' UTC' );
+		$next_timestamp = ActionScheduler::get_datetime_object( $post->post_date_gmt )->format( 'U' );
 		$status         = get_post_status( $post_id );
 
 		switch ( $column_name ) {

--- a/classes/ActionScheduler_AdminView.php
+++ b/classes/ActionScheduler_AdminView.php
@@ -196,7 +196,7 @@ class ActionScheduler_AdminView {
 				}
 				break;
 			case 'scheduled':
-				echo get_date_from_gmt( date( 'Y-m-d H:i:s', $next_timestamp ), 'Y-m-d H:i:s' );
+				echo get_date_from_gmt( gmdate( 'Y-m-d H:i:s', $next_timestamp ), 'Y-m-d H:i:s' );
 				if ( gmdate( 'U' ) > $next_timestamp ) {
 					printf( __( ' (%s ago)', 'action-scheduler' ), human_time_diff( gmdate( 'U' ), $next_timestamp ) );
 				} else {

--- a/classes/ActionScheduler_AdminView.php
+++ b/classes/ActionScheduler_AdminView.php
@@ -166,7 +166,7 @@ class ActionScheduler_AdminView {
 
 		$action_title   = ( 'trash' == $post->post_status ) ? $post->post_title : $action->get_hook();
 		$recurrence     = ( 'trash' == $post->post_status ) ? 0 : $action->get_schedule();
-		$next_timestamp = get_post_time( 'U', true, $post_id );
+		$next_timestamp = ( function_exists( 'wcs_date_to_time' ) ) ? wcs_date_to_time( $post->post_date_gmt ) : strtotime( $post->post_date_gmt . ' GMT' ); //get_post_time( 'U', true, $post_id );
 		$status         = get_post_status( $post_id );
 
 		switch ( $column_name ) {

--- a/classes/ActionScheduler_CronSchedule.php
+++ b/classes/ActionScheduler_CronSchedule.php
@@ -38,7 +38,7 @@ class ActionScheduler_CronSchedule implements ActionScheduler_Schedule {
 	}
 
 	public function __wakeup() {
-		$this->start = new DateTime('@'.$this->start_timestamp);
+		$this->start = ActionScheduler::get_datetime_object($this->start_timestamp);
 	}
 }
  

--- a/classes/ActionScheduler_CronSchedule.php
+++ b/classes/ActionScheduler_CronSchedule.php
@@ -38,7 +38,7 @@ class ActionScheduler_CronSchedule implements ActionScheduler_Schedule {
 	}
 
 	public function __wakeup() {
-		$this->start = ActionScheduler::get_datetime_object($this->start_timestamp);
+		$this->start = as_get_datetime_object($this->start_timestamp);
 	}
 }
  

--- a/classes/ActionScheduler_IntervalSchedule.php
+++ b/classes/ActionScheduler_IntervalSchedule.php
@@ -20,7 +20,7 @@ class ActionScheduler_IntervalSchedule implements ActionScheduler_Schedule {
 	 * @return DateTime|null
 	 */
 	public function next( DateTime $after = NULL ) {
-		$after = empty($after) ? new DateTime('@0') : clone($after);
+		$after = empty($after) ? ActionScheduler::get_datetime_object('@0') : clone($after);
 		if ( $after > $this->start ) {
 			$after->modify('+'.$this->interval_in_seconds.' seconds');
 			return $after;
@@ -50,7 +50,7 @@ class ActionScheduler_IntervalSchedule implements ActionScheduler_Schedule {
 	}
 
 	public function __wakeup() {
-		$this->start = new DateTime('@'.$this->start_timestamp);
+		$this->start = ActionScheduler::get_datetime_object($this->start_timestamp);
 	}
 }
  

--- a/classes/ActionScheduler_IntervalSchedule.php
+++ b/classes/ActionScheduler_IntervalSchedule.php
@@ -20,7 +20,7 @@ class ActionScheduler_IntervalSchedule implements ActionScheduler_Schedule {
 	 * @return DateTime|null
 	 */
 	public function next( DateTime $after = NULL ) {
-		$after = empty($after) ? ActionScheduler::get_datetime_object('@0') : clone($after);
+		$after = empty($after) ? as_get_datetime_object('@0') : clone($after);
 		if ( $after > $this->start ) {
 			$after->modify('+'.$this->interval_in_seconds.' seconds');
 			return $after;
@@ -50,7 +50,7 @@ class ActionScheduler_IntervalSchedule implements ActionScheduler_Schedule {
 	}
 
 	public function __wakeup() {
-		$this->start = ActionScheduler::get_datetime_object($this->start_timestamp);
+		$this->start = as_get_datetime_object($this->start_timestamp);
 	}
 }
  

--- a/classes/ActionScheduler_QueueCleaner.php
+++ b/classes/ActionScheduler_QueueCleaner.php
@@ -16,7 +16,7 @@ class ActionScheduler_QueueCleaner {
 
 	public function delete_old_actions() {
 		$lifespan = apply_filters( 'action_scheduler_retention_period', $this->month_in_seconds );
-		$cutoff = new DateTime($lifespan.' seconds ago');
+		$cutoff = ActionScheduler::get_datetime_object($lifespan.' seconds ago');
 
 		$actions_to_delete = $this->store->query_actions( array(
 			'status' => ActionScheduler_Store::STATUS_COMPLETE,
@@ -35,7 +35,7 @@ class ActionScheduler_QueueCleaner {
 		if ( $timeout < 0 ) {
 			return;
 		}
-		$cutoff = new DateTime($timeout.' seconds ago');
+		$cutoff = ActionScheduler::get_datetime_object($timeout.' seconds ago');
 		$actions_to_reset = $this->store->query_actions( array(
 			'status' => ActionScheduler_Store::STATUS_PENDING,
 			'modified' => $cutoff,
@@ -55,7 +55,7 @@ class ActionScheduler_QueueCleaner {
 		if ( $timeout < 0 ) {
 			return;
 		}
-		$cutoff = new DateTime($timeout.' seconds ago');
+		$cutoff = ActionScheduler::get_datetime_object($timeout.' seconds ago');
 		$actions_to_reset = $this->store->query_actions( array(
 			'status' => ActionScheduler_Store::STATUS_RUNNING,
 			'modified' => $cutoff,

--- a/classes/ActionScheduler_QueueCleaner.php
+++ b/classes/ActionScheduler_QueueCleaner.php
@@ -16,7 +16,7 @@ class ActionScheduler_QueueCleaner {
 
 	public function delete_old_actions() {
 		$lifespan = apply_filters( 'action_scheduler_retention_period', $this->month_in_seconds );
-		$cutoff = ActionScheduler::get_datetime_object($lifespan.' seconds ago');
+		$cutoff = as_get_datetime_object($lifespan.' seconds ago');
 
 		$actions_to_delete = $this->store->query_actions( array(
 			'status' => ActionScheduler_Store::STATUS_COMPLETE,
@@ -35,7 +35,7 @@ class ActionScheduler_QueueCleaner {
 		if ( $timeout < 0 ) {
 			return;
 		}
-		$cutoff = ActionScheduler::get_datetime_object($timeout.' seconds ago');
+		$cutoff = as_get_datetime_object($timeout.' seconds ago');
 		$actions_to_reset = $this->store->query_actions( array(
 			'status' => ActionScheduler_Store::STATUS_PENDING,
 			'modified' => $cutoff,
@@ -55,7 +55,7 @@ class ActionScheduler_QueueCleaner {
 		if ( $timeout < 0 ) {
 			return;
 		}
-		$cutoff = ActionScheduler::get_datetime_object($timeout.' seconds ago');
+		$cutoff = as_get_datetime_object($timeout.' seconds ago');
 		$actions_to_reset = $this->store->query_actions( array(
 			'status' => ActionScheduler_Store::STATUS_RUNNING,
 			'modified' => $cutoff,

--- a/classes/ActionScheduler_QueueRunner.php
+++ b/classes/ActionScheduler_QueueRunner.php
@@ -105,7 +105,7 @@ class ActionScheduler_QueueRunner {
 	}
 
 	protected function schedule_next_instance( ActionScheduler_Action $action ) {
-		$next = $action->get_schedule()->next( new DateTime() );
+		$next = $action->get_schedule()->next( ActionScheduler::get_datetime_object() );
 		if ( $next ) {
 			$this->store->save_action( $action, $next );
 		}

--- a/classes/ActionScheduler_QueueRunner.php
+++ b/classes/ActionScheduler_QueueRunner.php
@@ -105,7 +105,7 @@ class ActionScheduler_QueueRunner {
 	}
 
 	protected function schedule_next_instance( ActionScheduler_Action $action ) {
-		$next = $action->get_schedule()->next( ActionScheduler::get_datetime_object() );
+		$next = $action->get_schedule()->next( as_get_datetime_object() );
 		if ( $next ) {
 			$this->store->save_action( $action, $next );
 		}

--- a/classes/ActionScheduler_SimpleSchedule.php
+++ b/classes/ActionScheduler_SimpleSchedule.php
@@ -16,7 +16,7 @@ class ActionScheduler_SimpleSchedule implements ActionScheduler_Schedule {
 	 * @return DateTime|null
 	 */
 	public function next( DateTime $after = NULL ) {
-		$after = empty($after) ? ActionScheduler::get_datetime_object('@0') : $after;
+		$after = empty($after) ? as_get_datetime_object('@0') : $after;
 		return ( $after > $this->date ) ? NULL : clone( $this->date );
 	}
 
@@ -32,7 +32,7 @@ class ActionScheduler_SimpleSchedule implements ActionScheduler_Schedule {
 	}
 
 	public function __wakeup() {
-		$this->date = ActionScheduler::get_datetime_object($this->timestamp);
+		$this->date = as_get_datetime_object($this->timestamp);
 	}
 }
  

--- a/classes/ActionScheduler_SimpleSchedule.php
+++ b/classes/ActionScheduler_SimpleSchedule.php
@@ -16,7 +16,7 @@ class ActionScheduler_SimpleSchedule implements ActionScheduler_Schedule {
 	 * @return DateTime|null
 	 */
 	public function next( DateTime $after = NULL ) {
-		$after = empty($after) ? new DateTime('@0') : $after;
+		$after = empty($after) ? ActionScheduler::get_datetime_object('@0') : $after;
 		return ( $after > $this->date ) ? NULL : clone( $this->date );
 	}
 
@@ -32,7 +32,7 @@ class ActionScheduler_SimpleSchedule implements ActionScheduler_Schedule {
 	}
 
 	public function __wakeup() {
-		$this->date = new DateTime('@'.$this->timestamp);
+		$this->date = ActionScheduler::get_datetime_object($this->timestamp);
 	}
 }
  

--- a/classes/ActionScheduler_wpCommentLogger.php
+++ b/classes/ActionScheduler_wpCommentLogger.php
@@ -16,7 +16,7 @@ class ActionScheduler_wpCommentLogger extends ActionScheduler_Logger {
 	 */
 	public function log( $action_id, $message, DateTime $date = NULL ) {
 		if ( empty($date) ) {
-			$date = ActionScheduler::get_datetime_object();
+			$date = as_get_datetime_object();
 		} else {
 			$date = clone( $date );
 		}

--- a/classes/ActionScheduler_wpCommentLogger.php
+++ b/classes/ActionScheduler_wpCommentLogger.php
@@ -16,7 +16,7 @@ class ActionScheduler_wpCommentLogger extends ActionScheduler_Logger {
 	 */
 	public function log( $action_id, $message, DateTime $date = NULL ) {
 		if ( empty($date) ) {
-			$date = new DateTime();
+			$date = ActionScheduler::get_datetime_object();
 		} else {
 			$date = clone( $date );
 		}
@@ -25,10 +25,12 @@ class ActionScheduler_wpCommentLogger extends ActionScheduler_Logger {
 	}
 
 	protected function create_wp_comment( $action_id, $message, DateTime $date ) {
+		$comment_date_gmt = $date->format('Y-m-d H:i:s');
 		$date->setTimezone( ActionScheduler_TimezoneHelper::get_local_timezone() );
 		$comment_data = array(
 			'comment_post_ID' => $action_id,
 			'comment_date' => $date->format('Y-m-d H:i:s'),
+			'comment_date_gmt' => $comment_date_gmt,
 			'comment_author' => self::AGENT,
 			'comment_content' => $message,
 			'comment_agent' => self::AGENT,

--- a/classes/ActionScheduler_wpPostStore.php
+++ b/classes/ActionScheduler_wpPostStore.php
@@ -336,17 +336,27 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 	 * @return DateTime The date the action is schedule to run, or the date that it ran.
 	 */
 	public function get_date( $action_id ) {
+		$date = $this->get_date_gmt( $action_id );
+		return $date->setTimezone( $this->get_local_timezone() );
+	}
+
+	/**
+	 * @param string $action_id
+	 *
+	 * @throws InvalidArgumentException
+	 * @return DateTime The date the action is schedule to run, or the date that it ran.
+	 */
+	public function get_date_gmt( $action_id ) {
 		$post = get_post($action_id);
 		if ( empty($post) || ($post->post_type != self::POST_TYPE) ) {
 			throw new InvalidArgumentException(sprintf(__('Unidentified action %s', 'action-scheduler'), $action_id));
 		}
 		if ( $post->post_status == 'publish' ) {
-			return new DateTime($post->post_modified, ActionScheduler_TimezoneHelper::get_local_timezone());
+			return ActionScheduler::get_datetime_object($post->post_modified_gmt);
 		} else {
-			return new DateTime($post->post_date, ActionScheduler_TimezoneHelper::get_local_timezone());
+			return ActionScheduler::get_datetime_object($post->post_date_gmt);
 		}
 	}
-
 
 	/**
 	 * @param int $max_actions

--- a/classes/ActionScheduler_wpPostStore.php
+++ b/classes/ActionScheduler_wpPostStore.php
@@ -176,7 +176,7 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 				$order = 'ASC';
 				break;
 		}
-		$query .= " ORDER BY post_date $order LIMIT 1";
+		$query .= " ORDER BY post_date_gmt $order LIMIT 1";
 
 		$query = $wpdb->prepare( $query, $args );
 
@@ -240,19 +240,19 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 
 		if ( $query['date'] instanceof DateTime ) {
 			$date = clone( $query['date'] );
-			$date->setTimezone( $this->get_local_timezone() );
+			$date->setTimezone( new DateTimeZone('UTC') );
 			$date_string = $date->format('Y-m-d H:i:s');
 			$comparator = $this->validate_sql_comparator($query['date_compare']);
-			$sql .= " AND p.post_date $comparator %s";
+			$sql .= " AND p.post_date_gmt $comparator %s";
 			$sql_params[] = $date_string;
 		}
 
 		if ( $query['modified'] instanceof DateTime ) {
 			$modified = clone( $query['modified'] );
-			$modified->setTimezone( $this->get_local_timezone() );
+			$modified->setTimezone( new DateTimeZone('UTC') );
 			$date_string = $modified->format('Y-m-d H:i:s');
 			$comparator = $this->validate_sql_comparator($query['modified_compare']);
-			$sql .= " AND p.post_modified $comparator %s";
+			$sql .= " AND p.post_modified_gmt $comparator %s";
 			$sql_params[] = $date_string;
 		}
 
@@ -277,7 +277,7 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 				break;
 			case 'date':
 			default:
-				$orderby = 'p.post_date';
+				$orderby = 'p.post_date_gmt';
 				break;
 		}
 		if ( strtoupper($query['order']) == 'ASC' ) {
@@ -389,9 +389,9 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 		/** @var wpdb $wpdb */
 		global $wpdb;
 		$date = is_null($before_date) ? new DateTime() : clone( $before_date );
-		$date->setTimezone( $this->get_local_timezone() ); // using post_modified to take advantage of indexes
+		$date->setTimezone( new DateTimeZone('UTC') ); // using post_modified to take advantage of indexes
 		// can't use $wpdb->update() because of the <= condition
-		$sql = "UPDATE {$wpdb->posts} SET post_password = %s, post_modified_gmt = %s, post_modified = %s WHERE post_type = %s AND post_status = %s AND post_password = '' AND post_date <= %s ORDER BY menu_order ASC, post_date ASC LIMIT %d";
+		$sql = "UPDATE {$wpdb->posts} SET post_password = %s, post_modified_gmt = %s, post_modified = %s WHERE post_type = %s AND post_status = %s AND post_password = '' AND post_date_gmt <= %s ORDER BY menu_order ASC, post_date_gmt ASC LIMIT %d";
 		$sql = $wpdb->prepare( $sql, array( $claim_id, current_time('mysql', true), current_time('mysql'), self::POST_TYPE, 'pending', $date->format('Y-m-d H:i:s'), $limit ) );
 		$rows_affected = $wpdb->query($sql);
 		if ( $rows_affected === false ) {

--- a/classes/ActionScheduler_wpPostStore.php
+++ b/classes/ActionScheduler_wpPostStore.php
@@ -381,16 +381,15 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 	/**
 	 * @param string $claim_id
 	 * @param int $limit
-	 * @param DateTime $before_date
+	 * @param DateTime $before_date Should use UTC timezone.
 	 * @return int The number of actions that were claimed
 	 * @throws RuntimeException
 	 */
 	protected function claim_actions( $claim_id, $limit, DateTime $before_date = NULL ) {
 		/** @var wpdb $wpdb */
 		global $wpdb;
-		$date = is_null($before_date) ? new DateTime() : clone( $before_date );
-		$date->setTimezone( new DateTimeZone('UTC') ); // using post_modified to take advantage of indexes
-		// can't use $wpdb->update() because of the <= condition
+		$date = is_null($before_date) ? ActionScheduler::get_datetime_object() : clone( $before_date );
+		// can't use $wpdb->update() because of the <= condition, using post_modified to take advantage of indexes
 		$sql = "UPDATE {$wpdb->posts} SET post_password = %s, post_modified_gmt = %s, post_modified = %s WHERE post_type = %s AND post_status = %s AND post_password = '' AND post_date_gmt <= %s ORDER BY menu_order ASC, post_date_gmt ASC LIMIT %d";
 		$sql = $wpdb->prepare( $sql, array( $claim_id, current_time('mysql', true), current_time('mysql'), self::POST_TYPE, 'pending', $date->format('Y-m-d H:i:s'), $limit ) );
 		$rows_affected = $wpdb->query($sql);

--- a/classes/ActionScheduler_wpPostStore.php
+++ b/classes/ActionScheduler_wpPostStore.php
@@ -352,9 +352,9 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 			throw new InvalidArgumentException(sprintf(__('Unidentified action %s', 'action-scheduler'), $action_id));
 		}
 		if ( $post->post_status == 'publish' ) {
-			return ActionScheduler::get_datetime_object($post->post_modified_gmt);
+			return as_get_datetime_object($post->post_modified_gmt);
 		} else {
-			return ActionScheduler::get_datetime_object($post->post_date_gmt);
+			return as_get_datetime_object($post->post_date_gmt);
 		}
 	}
 
@@ -398,7 +398,7 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 	protected function claim_actions( $claim_id, $limit, DateTime $before_date = NULL ) {
 		/** @var wpdb $wpdb */
 		global $wpdb;
-		$date = is_null($before_date) ? ActionScheduler::get_datetime_object() : clone( $before_date );
+		$date = is_null($before_date) ? as_get_datetime_object() : clone( $before_date );
 		// can't use $wpdb->update() because of the <= condition, using post_modified to take advantage of indexes
 		$sql = "UPDATE {$wpdb->posts} SET post_password = %s, post_modified_gmt = %s, post_modified = %s WHERE post_type = %s AND post_status = %s AND post_password = '' AND post_date_gmt <= %s ORDER BY menu_order ASC, post_date_gmt ASC LIMIT %d";
 		$sql = $wpdb->prepare( $sql, array( $claim_id, current_time('mysql', true), current_time('mysql'), self::POST_TYPE, 'pending', $date->format('Y-m-d H:i:s'), $limit ) );

--- a/functions.php
+++ b/functions.php
@@ -116,9 +116,9 @@ function wc_next_scheduled_action( $hook, $args = NULL, $group = '' ) {
  * @param array $args Possible arguments, with their default values:
  *        'hook' => '' - the name of the action that will be triggered
  *        'args' => NULL - the args array that will be passed with the action
- *        'date' => NULL - the scheduled date of the action. Expects a DateTime object, a unix timestamp, or a string that can parsed with strtotime().
+ *        'date' => NULL - the scheduled date of the action. Expects a DateTime object, a unix timestamp, or a string that can parsed with strtotime(). Used in UTC timezone.
  *        'date_compare' => '<=' - operator for testing "date". accepted values are '!=', '>', '>=', '<', '<=', '='
- *        'modified' => NULL - the date the action was last updated. Expects a DateTime object, a unix timestamp, or a string that can parsed with strtotime().
+ *        'modified' => NULL - the date the action was last updated. Expects a DateTime object, a unix timestamp, or a string that can parsed with strtotime(). Used in UTC timezone.
  *        'modified_compare' => '<=' - operator for testing "modified". accepted values are '!=', '>', '>=', '<', '<=', '='
  *        'group' => '' - the group the action belongs to
  *        'status' => '' - ActionScheduler_Store::STATUS_COMPLETE or ActionScheduler_Store::STATUS_PENDING

--- a/functions.php
+++ b/functions.php
@@ -136,7 +136,7 @@ function wc_get_scheduled_actions( $args = array(), $return_format = OBJECT ) {
 	$store = ActionScheduler::store();
 	foreach ( array('date', 'modified') as $key ) {
 		if ( isset($args[$key]) ) {
-			$args[$key] = ActionScheduler::get_datetime_object($args[$key]);
+			$args[$key] = as_get_datetime_object($args[$key]);
 		}
 	}
 	$ids = $store->query_actions( $args );
@@ -157,4 +157,32 @@ function wc_get_scheduled_actions( $args = array(), $return_format = OBJECT ) {
 	}
 
 	return $actions;
+}
+
+/**
+ * Helper function to create an instance of DateTime based on a given
+ * string and timezone. By default, will return the current date/time
+ * in the UTC timezone.
+ *
+ * Needed because new DateTime() called without an explicit timezone
+ * will create a date/time in PHP's timezone, but we need to have
+ * assurance that a date/time uses the right timezone (which we almost
+ * always want to be UTC), which means we need to always include the
+ * timezone when instantiating datetimes rather than leaving it up to
+ * the PHP default.
+ *
+ * @param mixed $date_string A date/time string. Valid formats are explained in http://php.net/manual/en/datetime.formats.php
+ * @param string $timezone A timezone identifier, like UTC or Europe/Lisbon. The list of valid identifiers is available http://php.net/manual/en/timezones.php
+ *
+ * @return DateTime
+ */
+function as_get_datetime_object( $date_string = null, $timezone = 'UTC' ) {
+	if ( is_object($date_string) && $date_string instanceof DateTime ) {
+		$date = $date_string->setTimezone(new DateTimeZone( $timezone ) );
+	} elseif ( is_numeric( $date_string ) ) {
+		$date = new DateTime( '@'.$date_string, new DateTimeZone( $timezone ) );
+	} else {
+		$date = new DateTime( $date_string, new DateTimeZone( $timezone ) );
+	}
+	return $date;
 }

--- a/tests/ActionScheduler_UnitTestCase.php
+++ b/tests/ActionScheduler_UnitTestCase.php
@@ -5,5 +5,32 @@
  */
 class ActionScheduler_UnitTestCase extends WP_UnitTestCase {
 
+	protected $exiting_timezone;
+
+	/**
+	 * We want to run every test multiple times using a different timezone to make sure
+	 * that they are unaffected by changes to PHP's timezone.
+	 */
+	public function run( PHPUnit_Framework_TestResult $result = NULL ){
+
+		if ($result === NULL) {
+			$result = $this->createResult();
+		}
+
+		if ( 'UTC' != ( $this->exiting_timezone = date_default_timezone_get() ) ) {
+			date_default_timezone_set( 'UTC' );
+			$result->run( $this );
+		}
+
+		date_default_timezone_set( 'Pacific/Fiji' ); // UTC+12
+		$result->run( $this );
+
+		date_default_timezone_set( 'Pacific/Tahiti' ); // UTC-10: it's a magical place
+		$result->run( $this );
+
+		date_default_timezone_set( $this->exiting_timezone );
+
+		return $result;
+	}
 }
  

--- a/tests/phpunit/jobs/ActionScheduler_Action_Test.php
+++ b/tests/phpunit/jobs/ActionScheduler_Action_Test.php
@@ -6,7 +6,7 @@
  */
 class ActionScheduler_Action_Test extends ActionScheduler_UnitTestCase {
 	public function test_set_schedule() {
-		$time = new DateTime(null, new DateTimeZone('UTC'));
+		$time = ActionScheduler::get_datetime_object();
 		$schedule = new ActionScheduler_SimpleSchedule($time);
 		$action = new ActionScheduler_Action('my_hook', array(), $schedule);
 		$this->assertEquals( $schedule, $action->get_schedule() );

--- a/tests/phpunit/jobs/ActionScheduler_Action_Test.php
+++ b/tests/phpunit/jobs/ActionScheduler_Action_Test.php
@@ -6,7 +6,7 @@
  */
 class ActionScheduler_Action_Test extends ActionScheduler_UnitTestCase {
 	public function test_set_schedule() {
-		$time = new DateTime();
+		$time = new DateTime(null, new DateTimeZone('UTC'));
 		$schedule = new ActionScheduler_SimpleSchedule($time);
 		$action = new ActionScheduler_Action('my_hook', array(), $schedule);
 		$this->assertEquals( $schedule, $action->get_schedule() );

--- a/tests/phpunit/jobs/ActionScheduler_Action_Test.php
+++ b/tests/phpunit/jobs/ActionScheduler_Action_Test.php
@@ -6,7 +6,7 @@
  */
 class ActionScheduler_Action_Test extends ActionScheduler_UnitTestCase {
 	public function test_set_schedule() {
-		$time = ActionScheduler::get_datetime_object();
+		$time = as_get_datetime_object();
 		$schedule = new ActionScheduler_SimpleSchedule($time);
 		$action = new ActionScheduler_Action('my_hook', array(), $schedule);
 		$this->assertEquals( $schedule, $action->get_schedule() );

--- a/tests/phpunit/jobstore/ActionScheduler_wpPostStore_Test.php
+++ b/tests/phpunit/jobstore/ActionScheduler_wpPostStore_Test.php
@@ -7,7 +7,7 @@
 class ActionScheduler_wpPostStore_Test extends ActionScheduler_UnitTestCase {
 
 	public function test_create_action() {
-		$time = new DateTime(null, new DateTimeZone('UTC'));
+		$time = ActionScheduler::get_datetime_object();
 		$schedule = new ActionScheduler_SimpleSchedule($time);
 		$action = new ActionScheduler_Action('my_hook', array(), $schedule);
 		$store = new ActionScheduler_wpPostStore();
@@ -17,7 +17,7 @@ class ActionScheduler_wpPostStore_Test extends ActionScheduler_UnitTestCase {
 	}
 
 	public function test_retrieve_action() {
-		$time = new DateTime(null, new DateTimeZone('UTC'));
+		$time = ActionScheduler::get_datetime_object();
 		$schedule = new ActionScheduler_SimpleSchedule($time);
 		$action = new ActionScheduler_Action('my_hook', array(), $schedule, 'my_group');
 		$store = new ActionScheduler_wpPostStore();
@@ -31,7 +31,7 @@ class ActionScheduler_wpPostStore_Test extends ActionScheduler_UnitTestCase {
 	}
 
 	public function test_cancel_action() {
-		$time = new DateTime(null, new DateTimeZone('UTC'));
+		$time = ActionScheduler::get_datetime_object();
 		$schedule = new ActionScheduler_SimpleSchedule($time);
 		$action = new ActionScheduler_Action('my_hook', array(), $schedule, 'my_group');
 		$store = new ActionScheduler_wpPostStore();
@@ -46,7 +46,7 @@ class ActionScheduler_wpPostStore_Test extends ActionScheduler_UnitTestCase {
 		$created_actions = array();
 		$store = new ActionScheduler_wpPostStore();
 		for ( $i = 3 ; $i > -3 ; $i-- ) {
-			$time = new DateTime($i.' hours', new DateTimeZone('UTC'));
+			$time = ActionScheduler::get_datetime_object($i.' hours');
 			$schedule = new ActionScheduler_SimpleSchedule($time);
 			$action = new ActionScheduler_Action('my_hook', array($i), $schedule, 'my_group');
 			$created_actions[] = $store->save_action($action);
@@ -63,7 +63,7 @@ class ActionScheduler_wpPostStore_Test extends ActionScheduler_UnitTestCase {
 		$created_actions = array();
 		$store = new ActionScheduler_wpPostStore();
 		for ( $i = 0 ; $i > -3 ; $i-- ) {
-			$time = new DateTime($i.' hours', new DateTimeZone('UTC'));
+			$time = ActionScheduler::get_datetime_object($i.' hours');
 			$schedule = new ActionScheduler_SimpleSchedule($time);
 			$action = new ActionScheduler_Action('my_hook', array($i), $schedule, 'my_group');
 			$created_actions[] = $store->save_action($action);
@@ -79,7 +79,7 @@ class ActionScheduler_wpPostStore_Test extends ActionScheduler_UnitTestCase {
 		$created_actions = array();
 		$store = new ActionScheduler_wpPostStore();
 		for ( $i = 0 ; $i > -3 ; $i-- ) {
-			$time = new DateTime($i.' hours', new DateTimeZone('UTC'));
+			$time = ActionScheduler::get_datetime_object($i.' hours');
 			$schedule = new ActionScheduler_SimpleSchedule($time);
 			$action = new ActionScheduler_Action('my_hook', array($i), $schedule, 'my_group');
 			$created_actions[] = $store->save_action($action);
@@ -97,7 +97,7 @@ class ActionScheduler_wpPostStore_Test extends ActionScheduler_UnitTestCase {
 		$created_actions = array();
 		$store = new ActionScheduler_wpPostStore();
 		for ( $i = -3 ; $i <= 3 ; $i++ ) {
-			$time = new DateTime($i.' hours', new DateTimeZone('UTC'));
+			$time = ActionScheduler::get_datetime_object($i.' hours');
 			$schedule = new ActionScheduler_SimpleSchedule($time);
 			$action = new ActionScheduler_Action('my_hook', array($i), $schedule, 'my_group');
 			$created_actions[] = $store->save_action($action);
@@ -115,7 +115,7 @@ class ActionScheduler_wpPostStore_Test extends ActionScheduler_UnitTestCase {
 
 	public function test_search_by_group() {
 		$store = new ActionScheduler_wpPostStore();
-		$schedule = new ActionScheduler_SimpleSchedule(new DateTime('tomorrow', new DateTimeZone('UTC')));
+		$schedule = new ActionScheduler_SimpleSchedule(ActionScheduler::get_datetime_object('tomorrow'));
 		$abc = $store->save_action(new ActionScheduler_Action('my_hook', array(1), $schedule, 'abc'));
 		$def = $store->save_action(new ActionScheduler_Action('my_hook', array(1), $schedule, 'def'));
 		$ghi = $store->save_action(new ActionScheduler_Action('my_hook', array(1), $schedule, 'ghi'));
@@ -128,7 +128,7 @@ class ActionScheduler_wpPostStore_Test extends ActionScheduler_UnitTestCase {
 	public function test_post_author() {
 		$current_user = get_current_user_id();
 
-		$time = new DateTime(null, new DateTimeZone('UTC'));
+		$time = ActionScheduler::get_datetime_object();
 		$schedule = new ActionScheduler_SimpleSchedule($time);
 		$action = new ActionScheduler_Action('my_hook', array(), $schedule);
 		$store = new ActionScheduler_wpPostStore();
@@ -157,7 +157,7 @@ class ActionScheduler_wpPostStore_Test extends ActionScheduler_UnitTestCase {
 	 * @issue 13
 	 */
 	public function test_post_status_for_recurring_action() {
-		$time = new DateTime('10 minutes', new DateTimeZone('UTC'));
+		$time = ActionScheduler::get_datetime_object('10 minutes');
 		$schedule = new ActionScheduler_IntervalSchedule($time, HOUR_IN_SECONDS);
 		$action = new ActionScheduler_Action('my_hook', array(), $schedule);
 		$store = new ActionScheduler_wpPostStore();
@@ -167,7 +167,7 @@ class ActionScheduler_wpPostStore_Test extends ActionScheduler_UnitTestCase {
 		$action->execute();
 		$store->mark_complete( $action_id );
 
-		$next = $action->get_schedule()->next( new DateTime( null, new DateTimeZone( 'UTC' ) ) );
+		$next = $action->get_schedule()->next( ActionScheduler::get_datetime_object() );
 		$new_action_id = $store->save_action( $action, $next );
 
 		$this->assertEquals('publish', get_post_status($action_id));
@@ -175,7 +175,7 @@ class ActionScheduler_wpPostStore_Test extends ActionScheduler_UnitTestCase {
 	}
 
 	public function test_get_run_date() {
-		$time = new DateTime('-10 minutes', new DateTimeZone('UTC'));
+		$time = ActionScheduler::get_datetime_object('-10 minutes');
 		$schedule = new ActionScheduler_IntervalSchedule($time, HOUR_IN_SECONDS);
 		$action = new ActionScheduler_Action('my_hook', array(), $schedule);
 		$store = new ActionScheduler_wpPostStore();
@@ -185,7 +185,7 @@ class ActionScheduler_wpPostStore_Test extends ActionScheduler_UnitTestCase {
 
 		$action = $store->fetch_action($action_id);
 		$action->execute();
-		$now = new DateTime(null, new DateTimeZone('UTC'));
+		$now = ActionScheduler::get_datetime_object();
 		$store->mark_complete( $action_id );
 
 		$this->assertEquals( $store->get_date($action_id)->format('U'), $now->format('U') );

--- a/tests/phpunit/jobstore/ActionScheduler_wpPostStore_Test.php
+++ b/tests/phpunit/jobstore/ActionScheduler_wpPostStore_Test.php
@@ -7,7 +7,7 @@
 class ActionScheduler_wpPostStore_Test extends ActionScheduler_UnitTestCase {
 
 	public function test_create_action() {
-		$time = new DateTime();
+		$time = new DateTime(null, new DateTimeZone('UTC'));
 		$schedule = new ActionScheduler_SimpleSchedule($time);
 		$action = new ActionScheduler_Action('my_hook', array(), $schedule);
 		$store = new ActionScheduler_wpPostStore();
@@ -17,7 +17,7 @@ class ActionScheduler_wpPostStore_Test extends ActionScheduler_UnitTestCase {
 	}
 
 	public function test_retrieve_action() {
-		$time = new DateTime();
+		$time = new DateTime(null, new DateTimeZone('UTC'));
 		$schedule = new ActionScheduler_SimpleSchedule($time);
 		$action = new ActionScheduler_Action('my_hook', array(), $schedule, 'my_group');
 		$store = new ActionScheduler_wpPostStore();
@@ -31,7 +31,7 @@ class ActionScheduler_wpPostStore_Test extends ActionScheduler_UnitTestCase {
 	}
 
 	public function test_cancel_action() {
-		$time = new DateTime();
+		$time = new DateTime(null, new DateTimeZone('UTC'));
 		$schedule = new ActionScheduler_SimpleSchedule($time);
 		$action = new ActionScheduler_Action('my_hook', array(), $schedule, 'my_group');
 		$store = new ActionScheduler_wpPostStore();
@@ -46,7 +46,7 @@ class ActionScheduler_wpPostStore_Test extends ActionScheduler_UnitTestCase {
 		$created_actions = array();
 		$store = new ActionScheduler_wpPostStore();
 		for ( $i = 3 ; $i > -3 ; $i-- ) {
-			$time = new DateTime($i.' hours');
+			$time = new DateTime($i.' hours', new DateTimeZone('UTC'));
 			$schedule = new ActionScheduler_SimpleSchedule($time);
 			$action = new ActionScheduler_Action('my_hook', array($i), $schedule, 'my_group');
 			$created_actions[] = $store->save_action($action);
@@ -63,7 +63,7 @@ class ActionScheduler_wpPostStore_Test extends ActionScheduler_UnitTestCase {
 		$created_actions = array();
 		$store = new ActionScheduler_wpPostStore();
 		for ( $i = 0 ; $i > -3 ; $i-- ) {
-			$time = new DateTime($i.' hours');
+			$time = new DateTime($i.' hours', new DateTimeZone('UTC'));
 			$schedule = new ActionScheduler_SimpleSchedule($time);
 			$action = new ActionScheduler_Action('my_hook', array($i), $schedule, 'my_group');
 			$created_actions[] = $store->save_action($action);
@@ -79,7 +79,7 @@ class ActionScheduler_wpPostStore_Test extends ActionScheduler_UnitTestCase {
 		$created_actions = array();
 		$store = new ActionScheduler_wpPostStore();
 		for ( $i = 0 ; $i > -3 ; $i-- ) {
-			$time = new DateTime($i.' hours');
+			$time = new DateTime($i.' hours', new DateTimeZone('UTC'));
 			$schedule = new ActionScheduler_SimpleSchedule($time);
 			$action = new ActionScheduler_Action('my_hook', array($i), $schedule, 'my_group');
 			$created_actions[] = $store->save_action($action);
@@ -97,7 +97,7 @@ class ActionScheduler_wpPostStore_Test extends ActionScheduler_UnitTestCase {
 		$created_actions = array();
 		$store = new ActionScheduler_wpPostStore();
 		for ( $i = -3 ; $i <= 3 ; $i++ ) {
-			$time = new DateTime($i.' hours');
+			$time = new DateTime($i.' hours', new DateTimeZone('UTC'));
 			$schedule = new ActionScheduler_SimpleSchedule($time);
 			$action = new ActionScheduler_Action('my_hook', array($i), $schedule, 'my_group');
 			$created_actions[] = $store->save_action($action);
@@ -115,7 +115,7 @@ class ActionScheduler_wpPostStore_Test extends ActionScheduler_UnitTestCase {
 
 	public function test_search_by_group() {
 		$store = new ActionScheduler_wpPostStore();
-		$schedule = new ActionScheduler_SimpleSchedule(new DateTime('tomorrow'));
+		$schedule = new ActionScheduler_SimpleSchedule(new DateTime('tomorrow', new DateTimeZone('UTC')));
 		$abc = $store->save_action(new ActionScheduler_Action('my_hook', array(1), $schedule, 'abc'));
 		$def = $store->save_action(new ActionScheduler_Action('my_hook', array(1), $schedule, 'def'));
 		$ghi = $store->save_action(new ActionScheduler_Action('my_hook', array(1), $schedule, 'ghi'));
@@ -128,7 +128,7 @@ class ActionScheduler_wpPostStore_Test extends ActionScheduler_UnitTestCase {
 	public function test_post_author() {
 		$current_user = get_current_user_id();
 
-		$time = new DateTime();
+		$time = new DateTime(null, new DateTimeZone('UTC'));
 		$schedule = new ActionScheduler_SimpleSchedule($time);
 		$action = new ActionScheduler_Action('my_hook', array(), $schedule);
 		$store = new ActionScheduler_wpPostStore();
@@ -157,7 +157,7 @@ class ActionScheduler_wpPostStore_Test extends ActionScheduler_UnitTestCase {
 	 * @issue 13
 	 */
 	public function test_post_status_for_recurring_action() {
-		$time = new DateTime('10 minutes');
+		$time = new DateTime('10 minutes', new DateTimeZone('UTC'));
 		$schedule = new ActionScheduler_IntervalSchedule($time, HOUR_IN_SECONDS);
 		$action = new ActionScheduler_Action('my_hook', array(), $schedule);
 		$store = new ActionScheduler_wpPostStore();
@@ -167,7 +167,7 @@ class ActionScheduler_wpPostStore_Test extends ActionScheduler_UnitTestCase {
 		$action->execute();
 		$store->mark_complete( $action_id );
 
-		$next = $action->get_schedule()->next( new DateTime() );
+		$next = $action->get_schedule()->next( new DateTime( null, new DateTimeZone( 'UTC' ) ) );
 		$new_action_id = $store->save_action( $action, $next );
 
 		$this->assertEquals('publish', get_post_status($action_id));
@@ -175,7 +175,7 @@ class ActionScheduler_wpPostStore_Test extends ActionScheduler_UnitTestCase {
 	}
 
 	public function test_get_run_date() {
-		$time = new DateTime('-10 minutes');
+		$time = new DateTime('-10 minutes', new DateTimeZone('UTC'));
 		$schedule = new ActionScheduler_IntervalSchedule($time, HOUR_IN_SECONDS);
 		$action = new ActionScheduler_Action('my_hook', array(), $schedule);
 		$store = new ActionScheduler_wpPostStore();
@@ -185,7 +185,7 @@ class ActionScheduler_wpPostStore_Test extends ActionScheduler_UnitTestCase {
 
 		$action = $store->fetch_action($action_id);
 		$action->execute();
-		$now = new DateTime();
+		$now = new DateTime(null, new DateTimeZone('UTC'));
 		$store->mark_complete( $action_id );
 
 		$this->assertEquals( $store->get_date($action_id)->format('U'), $now->format('U') );

--- a/tests/phpunit/jobstore/ActionScheduler_wpPostStore_Test.php
+++ b/tests/phpunit/jobstore/ActionScheduler_wpPostStore_Test.php
@@ -7,7 +7,7 @@
 class ActionScheduler_wpPostStore_Test extends ActionScheduler_UnitTestCase {
 
 	public function test_create_action() {
-		$time = ActionScheduler::get_datetime_object();
+		$time = as_get_datetime_object();
 		$schedule = new ActionScheduler_SimpleSchedule($time);
 		$action = new ActionScheduler_Action('my_hook', array(), $schedule);
 		$store = new ActionScheduler_wpPostStore();
@@ -17,7 +17,7 @@ class ActionScheduler_wpPostStore_Test extends ActionScheduler_UnitTestCase {
 	}
 
 	public function test_retrieve_action() {
-		$time = ActionScheduler::get_datetime_object();
+		$time = as_get_datetime_object();
 		$schedule = new ActionScheduler_SimpleSchedule($time);
 		$action = new ActionScheduler_Action('my_hook', array(), $schedule, 'my_group');
 		$store = new ActionScheduler_wpPostStore();
@@ -31,7 +31,7 @@ class ActionScheduler_wpPostStore_Test extends ActionScheduler_UnitTestCase {
 	}
 
 	public function test_cancel_action() {
-		$time = ActionScheduler::get_datetime_object();
+		$time = as_get_datetime_object();
 		$schedule = new ActionScheduler_SimpleSchedule($time);
 		$action = new ActionScheduler_Action('my_hook', array(), $schedule, 'my_group');
 		$store = new ActionScheduler_wpPostStore();
@@ -46,7 +46,7 @@ class ActionScheduler_wpPostStore_Test extends ActionScheduler_UnitTestCase {
 		$created_actions = array();
 		$store = new ActionScheduler_wpPostStore();
 		for ( $i = 3 ; $i > -3 ; $i-- ) {
-			$time = ActionScheduler::get_datetime_object($i.' hours');
+			$time = as_get_datetime_object($i.' hours');
 			$schedule = new ActionScheduler_SimpleSchedule($time);
 			$action = new ActionScheduler_Action('my_hook', array($i), $schedule, 'my_group');
 			$created_actions[] = $store->save_action($action);
@@ -63,7 +63,7 @@ class ActionScheduler_wpPostStore_Test extends ActionScheduler_UnitTestCase {
 		$created_actions = array();
 		$store = new ActionScheduler_wpPostStore();
 		for ( $i = 0 ; $i > -3 ; $i-- ) {
-			$time = ActionScheduler::get_datetime_object($i.' hours');
+			$time = as_get_datetime_object($i.' hours');
 			$schedule = new ActionScheduler_SimpleSchedule($time);
 			$action = new ActionScheduler_Action('my_hook', array($i), $schedule, 'my_group');
 			$created_actions[] = $store->save_action($action);
@@ -79,7 +79,7 @@ class ActionScheduler_wpPostStore_Test extends ActionScheduler_UnitTestCase {
 		$created_actions = array();
 		$store = new ActionScheduler_wpPostStore();
 		for ( $i = 0 ; $i > -3 ; $i-- ) {
-			$time = ActionScheduler::get_datetime_object($i.' hours');
+			$time = as_get_datetime_object($i.' hours');
 			$schedule = new ActionScheduler_SimpleSchedule($time);
 			$action = new ActionScheduler_Action('my_hook', array($i), $schedule, 'my_group');
 			$created_actions[] = $store->save_action($action);
@@ -97,7 +97,7 @@ class ActionScheduler_wpPostStore_Test extends ActionScheduler_UnitTestCase {
 		$created_actions = array();
 		$store = new ActionScheduler_wpPostStore();
 		for ( $i = -3 ; $i <= 3 ; $i++ ) {
-			$time = ActionScheduler::get_datetime_object($i.' hours');
+			$time = as_get_datetime_object($i.' hours');
 			$schedule = new ActionScheduler_SimpleSchedule($time);
 			$action = new ActionScheduler_Action('my_hook', array($i), $schedule, 'my_group');
 			$created_actions[] = $store->save_action($action);
@@ -115,7 +115,7 @@ class ActionScheduler_wpPostStore_Test extends ActionScheduler_UnitTestCase {
 
 	public function test_search_by_group() {
 		$store = new ActionScheduler_wpPostStore();
-		$schedule = new ActionScheduler_SimpleSchedule(ActionScheduler::get_datetime_object('tomorrow'));
+		$schedule = new ActionScheduler_SimpleSchedule(as_get_datetime_object('tomorrow'));
 		$abc = $store->save_action(new ActionScheduler_Action('my_hook', array(1), $schedule, 'abc'));
 		$def = $store->save_action(new ActionScheduler_Action('my_hook', array(1), $schedule, 'def'));
 		$ghi = $store->save_action(new ActionScheduler_Action('my_hook', array(1), $schedule, 'ghi'));
@@ -128,7 +128,7 @@ class ActionScheduler_wpPostStore_Test extends ActionScheduler_UnitTestCase {
 	public function test_post_author() {
 		$current_user = get_current_user_id();
 
-		$time = ActionScheduler::get_datetime_object();
+		$time = as_get_datetime_object();
 		$schedule = new ActionScheduler_SimpleSchedule($time);
 		$action = new ActionScheduler_Action('my_hook', array(), $schedule);
 		$store = new ActionScheduler_wpPostStore();
@@ -157,7 +157,7 @@ class ActionScheduler_wpPostStore_Test extends ActionScheduler_UnitTestCase {
 	 * @issue 13
 	 */
 	public function test_post_status_for_recurring_action() {
-		$time = ActionScheduler::get_datetime_object('10 minutes');
+		$time = as_get_datetime_object('10 minutes');
 		$schedule = new ActionScheduler_IntervalSchedule($time, HOUR_IN_SECONDS);
 		$action = new ActionScheduler_Action('my_hook', array(), $schedule);
 		$store = new ActionScheduler_wpPostStore();
@@ -167,7 +167,7 @@ class ActionScheduler_wpPostStore_Test extends ActionScheduler_UnitTestCase {
 		$action->execute();
 		$store->mark_complete( $action_id );
 
-		$next = $action->get_schedule()->next( ActionScheduler::get_datetime_object() );
+		$next = $action->get_schedule()->next( as_get_datetime_object() );
 		$new_action_id = $store->save_action( $action, $next );
 
 		$this->assertEquals('publish', get_post_status($action_id));
@@ -175,7 +175,7 @@ class ActionScheduler_wpPostStore_Test extends ActionScheduler_UnitTestCase {
 	}
 
 	public function test_get_run_date() {
-		$time = ActionScheduler::get_datetime_object('-10 minutes');
+		$time = as_get_datetime_object('-10 minutes');
 		$schedule = new ActionScheduler_IntervalSchedule($time, HOUR_IN_SECONDS);
 		$action = new ActionScheduler_Action('my_hook', array(), $schedule);
 		$store = new ActionScheduler_wpPostStore();
@@ -185,7 +185,7 @@ class ActionScheduler_wpPostStore_Test extends ActionScheduler_UnitTestCase {
 
 		$action = $store->fetch_action($action_id);
 		$action->execute();
-		$now = ActionScheduler::get_datetime_object();
+		$now = as_get_datetime_object();
 		$store->mark_complete( $action_id );
 
 		$this->assertEquals( $store->get_date($action_id)->format('U'), $now->format('U') );

--- a/tests/phpunit/procedural_api/procedural_api_Test.php
+++ b/tests/phpunit/procedural_api/procedural_api_Test.php
@@ -66,5 +66,68 @@ class procedural_api_Test extends ActionScheduler_UnitTestCase {
 		$this->assertNull($action->get_schedule()->next());
 		$this->assertEmpty($action->get_hook());
 	}
+
+	public function test_as_get_datetime_object_default() {
+
+		$utc_now = new DateTime(null, new DateTimeZone('UTC'));
+		$as_now  = as_get_datetime_object();
+
+		// Don't want to use 'U' as timestamps will always be in UTC
+		$this->assertEquals($utc_now->format('Y-m-d H:i:s'),$as_now->format('Y-m-d H:i:s'));
+	}
+
+	public function test_as_get_datetime_object_relative() {
+
+		$utc_tomorrow = new DateTime('tomorrow', new DateTimeZone('UTC'));
+		$as_tomorrow  = as_get_datetime_object('tomorrow');
+
+		$this->assertEquals($utc_tomorrow->format('Y-m-d H:i:s'),$as_tomorrow->format('Y-m-d H:i:s'));
+
+		$utc_tomorrow = new DateTime('yesterday', new DateTimeZone('UTC'));
+		$as_tomorrow  = as_get_datetime_object('yesterday');
+
+		$this->assertEquals($utc_tomorrow->format('Y-m-d H:i:s'),$as_tomorrow->format('Y-m-d H:i:s'));
+	}
+
+	public function test_as_get_datetime_object_fixed() {
+
+		$utc_tomorrow = new DateTime('29 February 2016', new DateTimeZone('UTC'));
+		$as_tomorrow  = as_get_datetime_object('29 February 2016');
+
+		$this->assertEquals($utc_tomorrow->format('Y-m-d H:i:s'),$as_tomorrow->format('Y-m-d H:i:s'));
+
+		$utc_tomorrow = new DateTime('1st January 2024', new DateTimeZone('UTC'));
+		$as_tomorrow  = as_get_datetime_object('1st January 2024');
+
+		$this->assertEquals($utc_tomorrow->format('Y-m-d H:i:s'),$as_tomorrow->format('Y-m-d H:i:s'));
+	}
+
+	public function test_as_get_datetime_object_timezone() {
+
+		$timezone_au      = 'Australia/Brisbane';
+		$timezone_default = date_default_timezone_get();
+
+		date_default_timezone_set( $timezone_au );
+
+		$au_now = new DateTime(null);
+		$as_now = as_get_datetime_object();
+
+		// Make sure they're for the same time
+		$this->assertEquals($au_now->format('U'),$as_now->format('U'));
+
+		// But not in the same timezone, as $as_now should be using UTC
+		$this->assertNotEquals($au_now->format('Y-m-d H:i:s'),$as_now->format('Y-m-d H:i:s'));
+
+		$au_now    = new DateTime(null);
+		$as_au_now = as_get_datetime_object();
+
+		$this->assertEquals($au_now->format('U'),$as_now->format('U'));
+
+		// But not in the same timezone, as $as_now should be using UTC
+		$this->assertNotEquals($au_now->format('Y-m-d H:i:s'),$as_now->format('Y-m-d H:i:s'));
+
+		// Just in cases
+		date_default_timezone_set( $timezone_default );
+	}
 }
  

--- a/tests/phpunit/procedural_api/procedural_api_Test.php
+++ b/tests/phpunit/procedural_api/procedural_api_Test.php
@@ -24,24 +24,24 @@ class procedural_api_Test extends ActionScheduler_UnitTestCase {
 		$store = ActionScheduler::store();
 		$action = $store->fetch_action($action_id);
 		$this->assertEquals( $time, $action->get_schedule()->next()->format('U') );
-		$this->assertEquals( $time + HOUR_IN_SECONDS + 2, $action->get_schedule()->next(new DateTime('@'.($time + 2)))->format('U'));
+		$this->assertEquals( $time + HOUR_IN_SECONDS + 2, $action->get_schedule()->next(new DateTime('@'.($time + 2), new DateTimeZone('UTC')))->format('U'));
 		$this->assertEquals( $hook, $action->get_hook() );
 	}
 
 	public function test_cron_schedule() {
-		$time = new DateTime('2014-01-01');
+		$time = new DateTime('2014-01-01', new DateTimeZone('UTC'));
 		$hook = md5(rand());
 		$action_id = wc_schedule_cron_action( $time->format('U'), '0 0 10 10 *', $hook );
 
 		$store = ActionScheduler::store();
 		$action = $store->fetch_action($action_id);
-		$expected_date = new DateTime('2014-10-10');
+		$expected_date = new DateTime('2014-10-10', new DateTimeZone('UTC'));
 		$this->assertEquals( $expected_date->format('U'), $action->get_schedule()->next()->format('U') );
 		$this->assertEquals( $hook, $action->get_hook() );
 	}
 
 	public function test_get_next() {
-		$time = new DateTime('tomorrow');
+		$time = new DateTime('tomorrow', new DateTimeZone('UTC'));
 		$hook = md5(rand());
 		wc_schedule_recurring_action( $time->format('U'), HOUR_IN_SECONDS, $hook );
 

--- a/tests/phpunit/procedural_api/procedural_api_Test.php
+++ b/tests/phpunit/procedural_api/procedural_api_Test.php
@@ -24,24 +24,24 @@ class procedural_api_Test extends ActionScheduler_UnitTestCase {
 		$store = ActionScheduler::store();
 		$action = $store->fetch_action($action_id);
 		$this->assertEquals( $time, $action->get_schedule()->next()->format('U') );
-		$this->assertEquals( $time + HOUR_IN_SECONDS + 2, $action->get_schedule()->next(ActionScheduler::get_datetime_object($time + 2))->format('U'));
+		$this->assertEquals( $time + HOUR_IN_SECONDS + 2, $action->get_schedule()->next(as_get_datetime_object($time + 2))->format('U'));
 		$this->assertEquals( $hook, $action->get_hook() );
 	}
 
 	public function test_cron_schedule() {
-		$time = ActionScheduler::get_datetime_object('2014-01-01');
+		$time = as_get_datetime_object('2014-01-01');
 		$hook = md5(rand());
 		$action_id = wc_schedule_cron_action( $time->format('U'), '0 0 10 10 *', $hook );
 
 		$store = ActionScheduler::store();
 		$action = $store->fetch_action($action_id);
-		$expected_date = ActionScheduler::get_datetime_object('2014-10-10');
+		$expected_date = as_get_datetime_object('2014-10-10');
 		$this->assertEquals( $expected_date->format('U'), $action->get_schedule()->next()->format('U') );
 		$this->assertEquals( $hook, $action->get_hook() );
 	}
 
 	public function test_get_next() {
-		$time = ActionScheduler::get_datetime_object('tomorrow');
+		$time = as_get_datetime_object('tomorrow');
 		$hook = md5(rand());
 		wc_schedule_recurring_action( $time->format('U'), HOUR_IN_SECONDS, $hook );
 

--- a/tests/phpunit/procedural_api/procedural_api_Test.php
+++ b/tests/phpunit/procedural_api/procedural_api_Test.php
@@ -24,24 +24,24 @@ class procedural_api_Test extends ActionScheduler_UnitTestCase {
 		$store = ActionScheduler::store();
 		$action = $store->fetch_action($action_id);
 		$this->assertEquals( $time, $action->get_schedule()->next()->format('U') );
-		$this->assertEquals( $time + HOUR_IN_SECONDS + 2, $action->get_schedule()->next(new DateTime('@'.($time + 2), new DateTimeZone('UTC')))->format('U'));
+		$this->assertEquals( $time + HOUR_IN_SECONDS + 2, $action->get_schedule()->next(ActionScheduler::get_datetime_object($time + 2))->format('U'));
 		$this->assertEquals( $hook, $action->get_hook() );
 	}
 
 	public function test_cron_schedule() {
-		$time = new DateTime('2014-01-01', new DateTimeZone('UTC'));
+		$time = ActionScheduler::get_datetime_object('2014-01-01');
 		$hook = md5(rand());
 		$action_id = wc_schedule_cron_action( $time->format('U'), '0 0 10 10 *', $hook );
 
 		$store = ActionScheduler::store();
 		$action = $store->fetch_action($action_id);
-		$expected_date = new DateTime('2014-10-10', new DateTimeZone('UTC'));
+		$expected_date = ActionScheduler::get_datetime_object('2014-10-10');
 		$this->assertEquals( $expected_date->format('U'), $action->get_schedule()->next()->format('U') );
 		$this->assertEquals( $hook, $action->get_hook() );
 	}
 
 	public function test_get_next() {
-		$time = new DateTime('tomorrow', new DateTimeZone('UTC'));
+		$time = ActionScheduler::get_datetime_object('tomorrow');
 		$hook = md5(rand());
 		wc_schedule_recurring_action( $time->format('U'), HOUR_IN_SECONDS, $hook );
 

--- a/tests/phpunit/procedural_api/wc_get_scheduled_actions_Test.php
+++ b/tests/phpunit/procedural_api/wc_get_scheduled_actions_Test.php
@@ -21,7 +21,7 @@ class wc_get_scheduled_actions_Test extends ActionScheduler_UnitTestCase {
 
 		for ( $i = 0 ; $i < 10 ; $i++ ) {
 			for ( $j = 0 ; $j < 10 ; $j++  ) {
-				$schedule = new ActionScheduler_SimpleSchedule( new DateTime( $j - 3 . 'days', new DateTimeZone('UTC') ) );
+				$schedule = new ActionScheduler_SimpleSchedule( ActionScheduler::get_datetime_object( $j - 3 . 'days') );
 				$group = $this->groups[ ( $i + $j ) % 10 ];
 				$action = new ActionScheduler_Action( $this->hooks[$i], array($this->args[$j]), $schedule, $group );
 				$store->save_action( $action );
@@ -31,13 +31,13 @@ class wc_get_scheduled_actions_Test extends ActionScheduler_UnitTestCase {
 
 	public function test_date_queries() {
 		$actions = wc_get_scheduled_actions(array(
-			'date' => new DateTime(date('Y-m-d 00:00:00'), new DateTimeZone('UTC')),
+			'date' => ActionScheduler::get_datetime_object(gmdate('Y-m-d 00:00:00')),
 			'per_page' => -1,
 		), 'ids');
 		$this->assertCount(30, $actions);
 
 		$actions = wc_get_scheduled_actions(array(
-			'date' => new DateTime(date('Y-m-d 00:00:00'), new DateTimeZone('UTC')),
+			'date' => ActionScheduler::get_datetime_object(gmdate('Y-m-d 00:00:00')),
 			'date_compare' => '>=',
 			'per_page' => -1,
 		), 'ids');
@@ -53,7 +53,7 @@ class wc_get_scheduled_actions_Test extends ActionScheduler_UnitTestCase {
 
 		$actions = wc_get_scheduled_actions(array(
 			'hook' => $this->hooks[2],
-			'date' => new DateTime(date('Y-m-d 00:00:00'), new DateTimeZone('UTC')),
+			'date' => ActionScheduler::get_datetime_object(gmdate('Y-m-d 00:00:00')),
 			'per_page' => -1,
 		), 'ids');
 		$this->assertCount(3, $actions);
@@ -76,7 +76,7 @@ class wc_get_scheduled_actions_Test extends ActionScheduler_UnitTestCase {
 		$actions = wc_get_scheduled_actions(array(
 			'args' => array($this->args[5]),
 			'hook' => $this->hooks[3],
-			'date' => new DateTime(date('Y-m-d 00:00:00'), new DateTimeZone('UTC')),
+			'date' => ActionScheduler::get_datetime_object(gmdate('Y-m-d 00:00:00')),
 			'per_page' => -1,
 		), 'ids');
 		$this->assertCount(0, $actions);

--- a/tests/phpunit/procedural_api/wc_get_scheduled_actions_Test.php
+++ b/tests/phpunit/procedural_api/wc_get_scheduled_actions_Test.php
@@ -21,7 +21,7 @@ class wc_get_scheduled_actions_Test extends ActionScheduler_UnitTestCase {
 
 		for ( $i = 0 ; $i < 10 ; $i++ ) {
 			for ( $j = 0 ; $j < 10 ; $j++  ) {
-				$schedule = new ActionScheduler_SimpleSchedule( new DateTime( $j - 3 . 'days' ) );
+				$schedule = new ActionScheduler_SimpleSchedule( new DateTime( $j - 3 . 'days', new DateTimeZone('UTC') ) );
 				$group = $this->groups[ ( $i + $j ) % 10 ];
 				$action = new ActionScheduler_Action( $this->hooks[$i], array($this->args[$j]), $schedule, $group );
 				$store->save_action( $action );
@@ -31,13 +31,13 @@ class wc_get_scheduled_actions_Test extends ActionScheduler_UnitTestCase {
 
 	public function test_date_queries() {
 		$actions = wc_get_scheduled_actions(array(
-			'date' => new DateTime(date('Y-m-d 00:00:00')),
+			'date' => new DateTime(date('Y-m-d 00:00:00'), new DateTimeZone('UTC')),
 			'per_page' => -1,
 		), 'ids');
 		$this->assertCount(30, $actions);
 
 		$actions = wc_get_scheduled_actions(array(
-			'date' => new DateTime(date('Y-m-d 00:00:00')),
+			'date' => new DateTime(date('Y-m-d 00:00:00'), new DateTimeZone('UTC')),
 			'date_compare' => '>=',
 			'per_page' => -1,
 		), 'ids');
@@ -53,7 +53,7 @@ class wc_get_scheduled_actions_Test extends ActionScheduler_UnitTestCase {
 
 		$actions = wc_get_scheduled_actions(array(
 			'hook' => $this->hooks[2],
-			'date' => new DateTime(date('Y-m-d 00:00:00')),
+			'date' => new DateTime(date('Y-m-d 00:00:00'), new DateTimeZone('UTC')),
 			'per_page' => -1,
 		), 'ids');
 		$this->assertCount(3, $actions);
@@ -76,7 +76,7 @@ class wc_get_scheduled_actions_Test extends ActionScheduler_UnitTestCase {
 		$actions = wc_get_scheduled_actions(array(
 			'args' => array($this->args[5]),
 			'hook' => $this->hooks[3],
-			'date' => new DateTime(date('Y-m-d 00:00:00')),
+			'date' => new DateTime(date('Y-m-d 00:00:00'), new DateTimeZone('UTC')),
 			'per_page' => -1,
 		), 'ids');
 		$this->assertCount(0, $actions);

--- a/tests/phpunit/procedural_api/wc_get_scheduled_actions_Test.php
+++ b/tests/phpunit/procedural_api/wc_get_scheduled_actions_Test.php
@@ -21,7 +21,7 @@ class wc_get_scheduled_actions_Test extends ActionScheduler_UnitTestCase {
 
 		for ( $i = 0 ; $i < 10 ; $i++ ) {
 			for ( $j = 0 ; $j < 10 ; $j++  ) {
-				$schedule = new ActionScheduler_SimpleSchedule( ActionScheduler::get_datetime_object( $j - 3 . 'days') );
+				$schedule = new ActionScheduler_SimpleSchedule( as_get_datetime_object( $j - 3 . 'days') );
 				$group = $this->groups[ ( $i + $j ) % 10 ];
 				$action = new ActionScheduler_Action( $this->hooks[$i], array($this->args[$j]), $schedule, $group );
 				$store->save_action( $action );
@@ -31,13 +31,13 @@ class wc_get_scheduled_actions_Test extends ActionScheduler_UnitTestCase {
 
 	public function test_date_queries() {
 		$actions = wc_get_scheduled_actions(array(
-			'date' => ActionScheduler::get_datetime_object(gmdate('Y-m-d 00:00:00')),
+			'date' => as_get_datetime_object(gmdate('Y-m-d 00:00:00')),
 			'per_page' => -1,
 		), 'ids');
 		$this->assertCount(30, $actions);
 
 		$actions = wc_get_scheduled_actions(array(
-			'date' => ActionScheduler::get_datetime_object(gmdate('Y-m-d 00:00:00')),
+			'date' => as_get_datetime_object(gmdate('Y-m-d 00:00:00')),
 			'date_compare' => '>=',
 			'per_page' => -1,
 		), 'ids');
@@ -53,7 +53,7 @@ class wc_get_scheduled_actions_Test extends ActionScheduler_UnitTestCase {
 
 		$actions = wc_get_scheduled_actions(array(
 			'hook' => $this->hooks[2],
-			'date' => ActionScheduler::get_datetime_object(gmdate('Y-m-d 00:00:00')),
+			'date' => as_get_datetime_object(gmdate('Y-m-d 00:00:00')),
 			'per_page' => -1,
 		), 'ids');
 		$this->assertCount(3, $actions);
@@ -76,7 +76,7 @@ class wc_get_scheduled_actions_Test extends ActionScheduler_UnitTestCase {
 		$actions = wc_get_scheduled_actions(array(
 			'args' => array($this->args[5]),
 			'hook' => $this->hooks[3],
-			'date' => ActionScheduler::get_datetime_object(gmdate('Y-m-d 00:00:00')),
+			'date' => as_get_datetime_object(gmdate('Y-m-d 00:00:00')),
 			'per_page' => -1,
 		), 'ids');
 		$this->assertCount(0, $actions);

--- a/tests/phpunit/runner/ActionScheduler_QueueCleaner_Test.php
+++ b/tests/phpunit/runner/ActionScheduler_QueueCleaner_Test.php
@@ -10,7 +10,7 @@ class ActionScheduler_QueueCleaner_Test extends ActionScheduler_UnitTestCase {
 		$runner = new ActionScheduler_QueueRunner( $store );
 
 		$random = md5(rand());
-		$schedule = new ActionScheduler_SimpleSchedule(ActionScheduler::get_datetime_object('1 day ago'));
+		$schedule = new ActionScheduler_SimpleSchedule(as_get_datetime_object('1 day ago'));
 
 		$created_actions = array();
 		for ( $i = 0 ; $i < 5 ; $i++ ) {
@@ -36,7 +36,7 @@ class ActionScheduler_QueueCleaner_Test extends ActionScheduler_UnitTestCase {
 		$runner = new ActionScheduler_QueueRunner( $store );
 
 		$random = md5(rand());
-		$schedule = new ActionScheduler_SimpleSchedule(ActionScheduler::get_datetime_object('1 day ago'));
+		$schedule = new ActionScheduler_SimpleSchedule(as_get_datetime_object('1 day ago'));
 
 		$created_actions = array();
 		for ( $i = 0 ; $i < 5 ; $i++ ) {
@@ -59,7 +59,7 @@ class ActionScheduler_QueueCleaner_Test extends ActionScheduler_UnitTestCase {
 		$store = new ActionScheduler_wpPostStore();
 
 		$random = md5(rand());
-		$schedule = new ActionScheduler_SimpleSchedule(ActionScheduler::get_datetime_object('1 day ago'));
+		$schedule = new ActionScheduler_SimpleSchedule(as_get_datetime_object('1 day ago'));
 
 		$created_actions = array();
 		for ( $i = 0 ; $i < 5 ; $i++ ) {
@@ -85,7 +85,7 @@ class ActionScheduler_QueueCleaner_Test extends ActionScheduler_UnitTestCase {
 		$store = new ActionScheduler_wpPostStore();
 
 		$random = md5(rand());
-		$schedule = new ActionScheduler_SimpleSchedule(ActionScheduler::get_datetime_object('1 day ago'));
+		$schedule = new ActionScheduler_SimpleSchedule(as_get_datetime_object('1 day ago'));
 
 		$created_actions = array();
 		for ( $i = 0 ; $i < 5 ; $i++ ) {

--- a/tests/phpunit/runner/ActionScheduler_QueueCleaner_Test.php
+++ b/tests/phpunit/runner/ActionScheduler_QueueCleaner_Test.php
@@ -10,7 +10,7 @@ class ActionScheduler_QueueCleaner_Test extends ActionScheduler_UnitTestCase {
 		$runner = new ActionScheduler_QueueRunner( $store );
 
 		$random = md5(rand());
-		$schedule = new ActionScheduler_SimpleSchedule(new DateTime('1 day ago', new DateTimeZone('UTC')));
+		$schedule = new ActionScheduler_SimpleSchedule(ActionScheduler::get_datetime_object('1 day ago'));
 
 		$created_actions = array();
 		for ( $i = 0 ; $i < 5 ; $i++ ) {
@@ -36,7 +36,7 @@ class ActionScheduler_QueueCleaner_Test extends ActionScheduler_UnitTestCase {
 		$runner = new ActionScheduler_QueueRunner( $store );
 
 		$random = md5(rand());
-		$schedule = new ActionScheduler_SimpleSchedule(new DateTime('1 day ago', new DateTimeZone('UTC')));
+		$schedule = new ActionScheduler_SimpleSchedule(ActionScheduler::get_datetime_object('1 day ago'));
 
 		$created_actions = array();
 		for ( $i = 0 ; $i < 5 ; $i++ ) {
@@ -59,7 +59,7 @@ class ActionScheduler_QueueCleaner_Test extends ActionScheduler_UnitTestCase {
 		$store = new ActionScheduler_wpPostStore();
 
 		$random = md5(rand());
-		$schedule = new ActionScheduler_SimpleSchedule(new DateTime('1 day ago', new DateTimeZone('UTC')));
+		$schedule = new ActionScheduler_SimpleSchedule(ActionScheduler::get_datetime_object('1 day ago'));
 
 		$created_actions = array();
 		for ( $i = 0 ; $i < 5 ; $i++ ) {
@@ -85,7 +85,7 @@ class ActionScheduler_QueueCleaner_Test extends ActionScheduler_UnitTestCase {
 		$store = new ActionScheduler_wpPostStore();
 
 		$random = md5(rand());
-		$schedule = new ActionScheduler_SimpleSchedule(new DateTime('1 day ago', new DateTimeZone('UTC')));
+		$schedule = new ActionScheduler_SimpleSchedule(ActionScheduler::get_datetime_object('1 day ago'));
 
 		$created_actions = array();
 		for ( $i = 0 ; $i < 5 ; $i++ ) {

--- a/tests/phpunit/runner/ActionScheduler_QueueCleaner_Test.php
+++ b/tests/phpunit/runner/ActionScheduler_QueueCleaner_Test.php
@@ -10,7 +10,7 @@ class ActionScheduler_QueueCleaner_Test extends ActionScheduler_UnitTestCase {
 		$runner = new ActionScheduler_QueueRunner( $store );
 
 		$random = md5(rand());
-		$schedule = new ActionScheduler_SimpleSchedule(new DateTime('1 day ago'));
+		$schedule = new ActionScheduler_SimpleSchedule(new DateTime('1 day ago', new DateTimeZone('UTC')));
 
 		$created_actions = array();
 		for ( $i = 0 ; $i < 5 ; $i++ ) {
@@ -36,7 +36,7 @@ class ActionScheduler_QueueCleaner_Test extends ActionScheduler_UnitTestCase {
 		$runner = new ActionScheduler_QueueRunner( $store );
 
 		$random = md5(rand());
-		$schedule = new ActionScheduler_SimpleSchedule(new DateTime('1 day ago'));
+		$schedule = new ActionScheduler_SimpleSchedule(new DateTime('1 day ago', new DateTimeZone('UTC')));
 
 		$created_actions = array();
 		for ( $i = 0 ; $i < 5 ; $i++ ) {
@@ -59,7 +59,7 @@ class ActionScheduler_QueueCleaner_Test extends ActionScheduler_UnitTestCase {
 		$store = new ActionScheduler_wpPostStore();
 
 		$random = md5(rand());
-		$schedule = new ActionScheduler_SimpleSchedule(new DateTime('1 day ago'));
+		$schedule = new ActionScheduler_SimpleSchedule(new DateTime('1 day ago', new DateTimeZone('UTC')));
 
 		$created_actions = array();
 		for ( $i = 0 ; $i < 5 ; $i++ ) {
@@ -85,7 +85,7 @@ class ActionScheduler_QueueCleaner_Test extends ActionScheduler_UnitTestCase {
 		$store = new ActionScheduler_wpPostStore();
 
 		$random = md5(rand());
-		$schedule = new ActionScheduler_SimpleSchedule(new DateTime('1 day ago'));
+		$schedule = new ActionScheduler_SimpleSchedule(new DateTime('1 day ago', new DateTimeZone('UTC')));
 
 		$created_actions = array();
 		for ( $i = 0 ; $i < 5 ; $i++ ) {

--- a/tests/phpunit/runner/ActionScheduler_QueueRunner_Test.php
+++ b/tests/phpunit/runner/ActionScheduler_QueueRunner_Test.php
@@ -20,7 +20,7 @@ class ActionScheduler_QueueRunner_Test extends ActionScheduler_UnitTestCase {
 		$mock = new MockAction();
 		$random = md5(rand());
 		add_action( $random, array( $mock, 'action' ) );
-		$schedule = new ActionScheduler_SimpleSchedule(new DateTime('1 day ago'));
+		$schedule = new ActionScheduler_SimpleSchedule(new DateTime('1 day ago', new DateTimeZone('UTC')));
 
 		for ( $i = 0 ; $i < 5 ; $i++ ) {
 			$action = new ActionScheduler_Action( $random, array($random), $schedule );
@@ -42,14 +42,14 @@ class ActionScheduler_QueueRunner_Test extends ActionScheduler_UnitTestCase {
 		$mock = new MockAction();
 		$random = md5(rand());
 		add_action( $random, array( $mock, 'action' ) );
-		$schedule = new ActionScheduler_SimpleSchedule(new DateTime('1 day ago'));
+		$schedule = new ActionScheduler_SimpleSchedule(new DateTime('1 day ago', new DateTimeZone('UTC')));
 
 		for ( $i = 0 ; $i < 3 ; $i++ ) {
 			$action = new ActionScheduler_Action( $random, array($random), $schedule );
 			$store->save_action( $action );
 		}
 
-		$schedule = new ActionScheduler_SimpleSchedule(new DateTime('tomorrow'));
+		$schedule = new ActionScheduler_SimpleSchedule(new DateTime('tomorrow', new DateTimeZone('UTC')));
 		for ( $i = 0 ; $i < 3 ; $i++ ) {
 			$action = new ActionScheduler_Action( $random, array($random), $schedule );
 			$store->save_action( $action );
@@ -68,7 +68,7 @@ class ActionScheduler_QueueRunner_Test extends ActionScheduler_UnitTestCase {
 		$runner = new ActionScheduler_QueueRunner( $store );
 
 		$random = md5(rand());
-		$schedule = new ActionScheduler_SimpleSchedule(new DateTime('12 hours ago'));
+		$schedule = new ActionScheduler_SimpleSchedule(new DateTime('12 hours ago', new DateTimeZone('UTC')));
 
 		$action = new ActionScheduler_Action( $random, array(), $schedule );
 		$action_id = $store->save_action( $action );
@@ -85,17 +85,17 @@ class ActionScheduler_QueueRunner_Test extends ActionScheduler_UnitTestCase {
 		$runner = new ActionScheduler_QueueRunner( $store );
 
 		$random = md5(rand());
-		$schedule = new ActionScheduler_IntervalSchedule(new DateTime('12 hours ago'), DAY_IN_SECONDS);
+		$schedule = new ActionScheduler_IntervalSchedule(new DateTime('12 hours ago', new DateTimeZone('UTC')), DAY_IN_SECONDS);
 
 		$action = new ActionScheduler_Action( $random, array(), $schedule );
 		$store->save_action( $action );
 
 		$runner->run();
 
-		$claim = $store->stake_claim(10, new DateTime((DAY_IN_SECONDS - 60).' seconds'));
+		$claim = $store->stake_claim(10, new DateTime((DAY_IN_SECONDS - 60).' seconds', new DateTimeZone('UTC')));
 		$this->assertCount(0, $claim->get_actions());
 
-		$claim = $store->stake_claim(10, new DateTime(DAY_IN_SECONDS.' seconds'));
+		$claim = $store->stake_claim(10, new DateTime(DAY_IN_SECONDS.' seconds', new DateTimeZone('UTC')));
 		$actions = $claim->get_actions();
 		$this->assertCount(1, $actions);
 
@@ -104,7 +104,7 @@ class ActionScheduler_QueueRunner_Test extends ActionScheduler_UnitTestCase {
 
 
 		$this->assertEquals( $random, $new_action->get_hook() );
-		$this->assertEquals( $schedule->next(new DateTime()), $new_action->get_schedule()->next(new DateTime()) );
+		$this->assertEquals( $schedule->next(new DateTime(null, new DateTimeZone('UTC'))), $new_action->get_schedule()->next(new DateTime(null, new DateTimeZone('UTC'))) );
 	}
 
 	public function test_hooked_into_wp_cron() {

--- a/tests/phpunit/runner/ActionScheduler_QueueRunner_Test.php
+++ b/tests/phpunit/runner/ActionScheduler_QueueRunner_Test.php
@@ -20,7 +20,7 @@ class ActionScheduler_QueueRunner_Test extends ActionScheduler_UnitTestCase {
 		$mock = new MockAction();
 		$random = md5(rand());
 		add_action( $random, array( $mock, 'action' ) );
-		$schedule = new ActionScheduler_SimpleSchedule(new DateTime('1 day ago', new DateTimeZone('UTC')));
+		$schedule = new ActionScheduler_SimpleSchedule(ActionScheduler::get_datetime_object('1 day ago'));
 
 		for ( $i = 0 ; $i < 5 ; $i++ ) {
 			$action = new ActionScheduler_Action( $random, array($random), $schedule );
@@ -42,14 +42,14 @@ class ActionScheduler_QueueRunner_Test extends ActionScheduler_UnitTestCase {
 		$mock = new MockAction();
 		$random = md5(rand());
 		add_action( $random, array( $mock, 'action' ) );
-		$schedule = new ActionScheduler_SimpleSchedule(new DateTime('1 day ago', new DateTimeZone('UTC')));
+		$schedule = new ActionScheduler_SimpleSchedule(ActionScheduler::get_datetime_object('1 day ago'));
 
 		for ( $i = 0 ; $i < 3 ; $i++ ) {
 			$action = new ActionScheduler_Action( $random, array($random), $schedule );
 			$store->save_action( $action );
 		}
 
-		$schedule = new ActionScheduler_SimpleSchedule(new DateTime('tomorrow', new DateTimeZone('UTC')));
+		$schedule = new ActionScheduler_SimpleSchedule(ActionScheduler::get_datetime_object('tomorrow'));
 		for ( $i = 0 ; $i < 3 ; $i++ ) {
 			$action = new ActionScheduler_Action( $random, array($random), $schedule );
 			$store->save_action( $action );
@@ -68,7 +68,7 @@ class ActionScheduler_QueueRunner_Test extends ActionScheduler_UnitTestCase {
 		$runner = new ActionScheduler_QueueRunner( $store );
 
 		$random = md5(rand());
-		$schedule = new ActionScheduler_SimpleSchedule(new DateTime('12 hours ago', new DateTimeZone('UTC')));
+		$schedule = new ActionScheduler_SimpleSchedule(ActionScheduler::get_datetime_object('12 hours ago'));
 
 		$action = new ActionScheduler_Action( $random, array(), $schedule );
 		$action_id = $store->save_action( $action );
@@ -85,17 +85,17 @@ class ActionScheduler_QueueRunner_Test extends ActionScheduler_UnitTestCase {
 		$runner = new ActionScheduler_QueueRunner( $store );
 
 		$random = md5(rand());
-		$schedule = new ActionScheduler_IntervalSchedule(new DateTime('12 hours ago', new DateTimeZone('UTC')), DAY_IN_SECONDS);
+		$schedule = new ActionScheduler_IntervalSchedule(ActionScheduler::get_datetime_object('12 hours ago'), DAY_IN_SECONDS);
 
 		$action = new ActionScheduler_Action( $random, array(), $schedule );
 		$store->save_action( $action );
 
 		$runner->run();
 
-		$claim = $store->stake_claim(10, new DateTime((DAY_IN_SECONDS - 60).' seconds', new DateTimeZone('UTC')));
+		$claim = $store->stake_claim(10, ActionScheduler::get_datetime_object((DAY_IN_SECONDS - 60).' seconds'));
 		$this->assertCount(0, $claim->get_actions());
 
-		$claim = $store->stake_claim(10, new DateTime(DAY_IN_SECONDS.' seconds', new DateTimeZone('UTC')));
+		$claim = $store->stake_claim(10, ActionScheduler::get_datetime_object(DAY_IN_SECONDS.' seconds'));
 		$actions = $claim->get_actions();
 		$this->assertCount(1, $actions);
 
@@ -104,7 +104,7 @@ class ActionScheduler_QueueRunner_Test extends ActionScheduler_UnitTestCase {
 
 
 		$this->assertEquals( $random, $new_action->get_hook() );
-		$this->assertEquals( $schedule->next(new DateTime(null, new DateTimeZone('UTC'))), $new_action->get_schedule()->next(new DateTime(null, new DateTimeZone('UTC'))) );
+		$this->assertEquals( $schedule->next(ActionScheduler::get_datetime_object()), $new_action->get_schedule()->next(ActionScheduler::get_datetime_object()) );
 	}
 
 	public function test_hooked_into_wp_cron() {

--- a/tests/phpunit/runner/ActionScheduler_QueueRunner_Test.php
+++ b/tests/phpunit/runner/ActionScheduler_QueueRunner_Test.php
@@ -20,7 +20,7 @@ class ActionScheduler_QueueRunner_Test extends ActionScheduler_UnitTestCase {
 		$mock = new MockAction();
 		$random = md5(rand());
 		add_action( $random, array( $mock, 'action' ) );
-		$schedule = new ActionScheduler_SimpleSchedule(ActionScheduler::get_datetime_object('1 day ago'));
+		$schedule = new ActionScheduler_SimpleSchedule(as_get_datetime_object('1 day ago'));
 
 		for ( $i = 0 ; $i < 5 ; $i++ ) {
 			$action = new ActionScheduler_Action( $random, array($random), $schedule );
@@ -42,14 +42,14 @@ class ActionScheduler_QueueRunner_Test extends ActionScheduler_UnitTestCase {
 		$mock = new MockAction();
 		$random = md5(rand());
 		add_action( $random, array( $mock, 'action' ) );
-		$schedule = new ActionScheduler_SimpleSchedule(ActionScheduler::get_datetime_object('1 day ago'));
+		$schedule = new ActionScheduler_SimpleSchedule(as_get_datetime_object('1 day ago'));
 
 		for ( $i = 0 ; $i < 3 ; $i++ ) {
 			$action = new ActionScheduler_Action( $random, array($random), $schedule );
 			$store->save_action( $action );
 		}
 
-		$schedule = new ActionScheduler_SimpleSchedule(ActionScheduler::get_datetime_object('tomorrow'));
+		$schedule = new ActionScheduler_SimpleSchedule(as_get_datetime_object('tomorrow'));
 		for ( $i = 0 ; $i < 3 ; $i++ ) {
 			$action = new ActionScheduler_Action( $random, array($random), $schedule );
 			$store->save_action( $action );
@@ -68,7 +68,7 @@ class ActionScheduler_QueueRunner_Test extends ActionScheduler_UnitTestCase {
 		$runner = new ActionScheduler_QueueRunner( $store );
 
 		$random = md5(rand());
-		$schedule = new ActionScheduler_SimpleSchedule(ActionScheduler::get_datetime_object('12 hours ago'));
+		$schedule = new ActionScheduler_SimpleSchedule(as_get_datetime_object('12 hours ago'));
 
 		$action = new ActionScheduler_Action( $random, array(), $schedule );
 		$action_id = $store->save_action( $action );
@@ -85,17 +85,17 @@ class ActionScheduler_QueueRunner_Test extends ActionScheduler_UnitTestCase {
 		$runner = new ActionScheduler_QueueRunner( $store );
 
 		$random = md5(rand());
-		$schedule = new ActionScheduler_IntervalSchedule(ActionScheduler::get_datetime_object('12 hours ago'), DAY_IN_SECONDS);
+		$schedule = new ActionScheduler_IntervalSchedule(as_get_datetime_object('12 hours ago'), DAY_IN_SECONDS);
 
 		$action = new ActionScheduler_Action( $random, array(), $schedule );
 		$store->save_action( $action );
 
 		$runner->run();
 
-		$claim = $store->stake_claim(10, ActionScheduler::get_datetime_object((DAY_IN_SECONDS - 60).' seconds'));
+		$claim = $store->stake_claim(10, as_get_datetime_object((DAY_IN_SECONDS - 60).' seconds'));
 		$this->assertCount(0, $claim->get_actions());
 
-		$claim = $store->stake_claim(10, ActionScheduler::get_datetime_object(DAY_IN_SECONDS.' seconds'));
+		$claim = $store->stake_claim(10, as_get_datetime_object(DAY_IN_SECONDS.' seconds'));
 		$actions = $claim->get_actions();
 		$this->assertCount(1, $actions);
 
@@ -104,7 +104,7 @@ class ActionScheduler_QueueRunner_Test extends ActionScheduler_UnitTestCase {
 
 
 		$this->assertEquals( $random, $new_action->get_hook() );
-		$this->assertEquals( $schedule->next(ActionScheduler::get_datetime_object()), $new_action->get_schedule()->next(ActionScheduler::get_datetime_object()) );
+		$this->assertEquals( $schedule->next(as_get_datetime_object()), $new_action->get_schedule()->next(as_get_datetime_object()) );
 	}
 
 	public function test_hooked_into_wp_cron() {

--- a/tests/phpunit/schedules/ActionScheduler_CronSchedule_Test.php
+++ b/tests/phpunit/schedules/ActionScheduler_CronSchedule_Test.php
@@ -6,35 +6,35 @@
  */
 class ActionScheduler_CronSchedule_Test extends ActionScheduler_UnitTestCase {
 	public function test_creation() {
-		$time = new DateTime('tomorrow', new DateTimeZone('UTC'));
+		$time = ActionScheduler::get_datetime_object('tomorrow');
 		$cron = CronExpression::factory('@daily');
 		$schedule = new ActionScheduler_CronSchedule($time, $cron);
 		$this->assertEquals( $time, $schedule->next() );
 	}
 
 	public function test_next() {
-		$time = new DateTime('2013-06-14', new DateTimeZone('UTC'));
+		$time = ActionScheduler::get_datetime_object('2013-06-14');
 		$cron = CronExpression::factory('@daily');
 		$schedule = new ActionScheduler_CronSchedule($time, $cron);
-		$this->assertEquals( new DateTime('tomorrow', new DateTimeZone('UTC')), $schedule->next( new DateTime(null, new DateTimeZone('UTC')) ) );
+		$this->assertEquals( ActionScheduler::get_datetime_object('tomorrow'), $schedule->next( ActionScheduler::get_datetime_object() ) );
 	}
 
 	public function test_cron_format() {
-		$time = new DateTime('2014-01-01', new DateTimeZone('UTC'));
+		$time = ActionScheduler::get_datetime_object('2014-01-01');
 		$cron = CronExpression::factory('0 0 10 10 *');
 		$schedule = new ActionScheduler_CronSchedule($time, $cron);
-		$this->assertEquals( new DateTime('2014-10-10', new DateTimeZone('UTC')), $schedule->next() );
+		$this->assertEquals( ActionScheduler::get_datetime_object('2014-10-10'), $schedule->next() );
 
 		$cron = CronExpression::factory('0 0 L 1/2 *');
 		$schedule = new ActionScheduler_CronSchedule($time, $cron);
-		$this->assertEquals( new DateTime('2014-01-31', new DateTimeZone('UTC')), $schedule->next() );
-		$this->assertEquals( new DateTime('2014-07-31', new DateTimeZone('UTC')), $schedule->next( new DateTime('2014-06-01', new DateTimeZone('UTC')) ) );
-		$this->assertEquals( new DateTime('2028-11-30', new DateTimeZone('UTC')), $schedule->next( new DateTime('2028-11-01', new DateTimeZone('UTC')) ) );
+		$this->assertEquals( ActionScheduler::get_datetime_object('2014-01-31'), $schedule->next() );
+		$this->assertEquals( ActionScheduler::get_datetime_object('2014-07-31'), $schedule->next( ActionScheduler::get_datetime_object('2014-06-01') ) );
+		$this->assertEquals( ActionScheduler::get_datetime_object('2028-11-30'), $schedule->next( ActionScheduler::get_datetime_object('2028-11-01') ) );
 
 		$cron = CronExpression::factory('30 14 * * MON#3 *');
 		$schedule = new ActionScheduler_CronSchedule($time, $cron);
-		$this->assertEquals( new DateTime('2014-01-20 14:30:00', new DateTimeZone('UTC')), $schedule->next() );
-		$this->assertEquals( new DateTime('2014-05-19 14:30:00', new DateTimeZone('UTC')), $schedule->next( new DateTime('2014-05-01', new DateTimeZone('UTC')) ) );
+		$this->assertEquals( ActionScheduler::get_datetime_object('2014-01-20 14:30:00'), $schedule->next() );
+		$this->assertEquals( ActionScheduler::get_datetime_object('2014-05-19 14:30:00'), $schedule->next( ActionScheduler::get_datetime_object('2014-05-01') ) );
 	}
 }
  

--- a/tests/phpunit/schedules/ActionScheduler_CronSchedule_Test.php
+++ b/tests/phpunit/schedules/ActionScheduler_CronSchedule_Test.php
@@ -6,35 +6,35 @@
  */
 class ActionScheduler_CronSchedule_Test extends ActionScheduler_UnitTestCase {
 	public function test_creation() {
-		$time = new DateTime('tomorrow');
+		$time = new DateTime('tomorrow', new DateTimeZone('UTC'));
 		$cron = CronExpression::factory('@daily');
 		$schedule = new ActionScheduler_CronSchedule($time, $cron);
 		$this->assertEquals( $time, $schedule->next() );
 	}
 
 	public function test_next() {
-		$time = new DateTime('2013-06-14');
+		$time = new DateTime('2013-06-14', new DateTimeZone('UTC'));
 		$cron = CronExpression::factory('@daily');
 		$schedule = new ActionScheduler_CronSchedule($time, $cron);
-		$this->assertEquals( new DateTime('tomorrow'), $schedule->next( new DateTime() ) );
+		$this->assertEquals( new DateTime('tomorrow', new DateTimeZone('UTC')), $schedule->next( new DateTime(null, new DateTimeZone('UTC')) ) );
 	}
 
 	public function test_cron_format() {
-		$time = new DateTime('2014-01-01');
+		$time = new DateTime('2014-01-01', new DateTimeZone('UTC'));
 		$cron = CronExpression::factory('0 0 10 10 *');
 		$schedule = new ActionScheduler_CronSchedule($time, $cron);
-		$this->assertEquals( new DateTime('2014-10-10'), $schedule->next() );
+		$this->assertEquals( new DateTime('2014-10-10', new DateTimeZone('UTC')), $schedule->next() );
 
 		$cron = CronExpression::factory('0 0 L 1/2 *');
 		$schedule = new ActionScheduler_CronSchedule($time, $cron);
-		$this->assertEquals( new DateTime('2014-01-31'), $schedule->next() );
-		$this->assertEquals( new DateTime('2014-07-31'), $schedule->next( new DateTime('2014-06-01') ) );
-		$this->assertEquals( new DateTime('2028-11-30'), $schedule->next( new DateTime('2028-11-01') ) );
+		$this->assertEquals( new DateTime('2014-01-31', new DateTimeZone('UTC')), $schedule->next() );
+		$this->assertEquals( new DateTime('2014-07-31', new DateTimeZone('UTC')), $schedule->next( new DateTime('2014-06-01', new DateTimeZone('UTC')) ) );
+		$this->assertEquals( new DateTime('2028-11-30', new DateTimeZone('UTC')), $schedule->next( new DateTime('2028-11-01', new DateTimeZone('UTC')) ) );
 
 		$cron = CronExpression::factory('30 14 * * MON#3 *');
 		$schedule = new ActionScheduler_CronSchedule($time, $cron);
-		$this->assertEquals( new DateTime('2014-01-20 14:30:00'), $schedule->next() );
-		$this->assertEquals( new DateTime('2014-05-19 14:30:00'), $schedule->next( new DateTime('2014-05-01') ) );
+		$this->assertEquals( new DateTime('2014-01-20 14:30:00', new DateTimeZone('UTC')), $schedule->next() );
+		$this->assertEquals( new DateTime('2014-05-19 14:30:00', new DateTimeZone('UTC')), $schedule->next( new DateTime('2014-05-01', new DateTimeZone('UTC')) ) );
 	}
 }
  

--- a/tests/phpunit/schedules/ActionScheduler_CronSchedule_Test.php
+++ b/tests/phpunit/schedules/ActionScheduler_CronSchedule_Test.php
@@ -6,35 +6,35 @@
  */
 class ActionScheduler_CronSchedule_Test extends ActionScheduler_UnitTestCase {
 	public function test_creation() {
-		$time = ActionScheduler::get_datetime_object('tomorrow');
+		$time = as_get_datetime_object('tomorrow');
 		$cron = CronExpression::factory('@daily');
 		$schedule = new ActionScheduler_CronSchedule($time, $cron);
 		$this->assertEquals( $time, $schedule->next() );
 	}
 
 	public function test_next() {
-		$time = ActionScheduler::get_datetime_object('2013-06-14');
+		$time = as_get_datetime_object('2013-06-14');
 		$cron = CronExpression::factory('@daily');
 		$schedule = new ActionScheduler_CronSchedule($time, $cron);
-		$this->assertEquals( ActionScheduler::get_datetime_object('tomorrow'), $schedule->next( ActionScheduler::get_datetime_object() ) );
+		$this->assertEquals( as_get_datetime_object('tomorrow'), $schedule->next( as_get_datetime_object() ) );
 	}
 
 	public function test_cron_format() {
-		$time = ActionScheduler::get_datetime_object('2014-01-01');
+		$time = as_get_datetime_object('2014-01-01');
 		$cron = CronExpression::factory('0 0 10 10 *');
 		$schedule = new ActionScheduler_CronSchedule($time, $cron);
-		$this->assertEquals( ActionScheduler::get_datetime_object('2014-10-10'), $schedule->next() );
+		$this->assertEquals( as_get_datetime_object('2014-10-10'), $schedule->next() );
 
 		$cron = CronExpression::factory('0 0 L 1/2 *');
 		$schedule = new ActionScheduler_CronSchedule($time, $cron);
-		$this->assertEquals( ActionScheduler::get_datetime_object('2014-01-31'), $schedule->next() );
-		$this->assertEquals( ActionScheduler::get_datetime_object('2014-07-31'), $schedule->next( ActionScheduler::get_datetime_object('2014-06-01') ) );
-		$this->assertEquals( ActionScheduler::get_datetime_object('2028-11-30'), $schedule->next( ActionScheduler::get_datetime_object('2028-11-01') ) );
+		$this->assertEquals( as_get_datetime_object('2014-01-31'), $schedule->next() );
+		$this->assertEquals( as_get_datetime_object('2014-07-31'), $schedule->next( as_get_datetime_object('2014-06-01') ) );
+		$this->assertEquals( as_get_datetime_object('2028-11-30'), $schedule->next( as_get_datetime_object('2028-11-01') ) );
 
 		$cron = CronExpression::factory('30 14 * * MON#3 *');
 		$schedule = new ActionScheduler_CronSchedule($time, $cron);
-		$this->assertEquals( ActionScheduler::get_datetime_object('2014-01-20 14:30:00'), $schedule->next() );
-		$this->assertEquals( ActionScheduler::get_datetime_object('2014-05-19 14:30:00'), $schedule->next( ActionScheduler::get_datetime_object('2014-05-01') ) );
+		$this->assertEquals( as_get_datetime_object('2014-01-20 14:30:00'), $schedule->next() );
+		$this->assertEquals( as_get_datetime_object('2014-05-19 14:30:00'), $schedule->next( as_get_datetime_object('2014-05-01') ) );
 	}
 }
  

--- a/tests/phpunit/schedules/ActionScheduler_IntervalSchedule_Test.php
+++ b/tests/phpunit/schedules/ActionScheduler_IntervalSchedule_Test.php
@@ -6,7 +6,7 @@
  */
 class ActionScheduler_IntervalSchedule_Test extends ActionScheduler_UnitTestCase {
 	public function test_creation() {
-		$time = new DateTime(null, new DateTimeZone('UTC'));
+		$time = ActionScheduler::get_datetime_object();
 		$schedule = new ActionScheduler_IntervalSchedule($time, HOUR_IN_SECONDS);
 		$this->assertEquals( $time, $schedule->next() );
 	}
@@ -14,10 +14,10 @@ class ActionScheduler_IntervalSchedule_Test extends ActionScheduler_UnitTestCase
 	public function test_next() {
 		$now = time();
 		$start = $now - 30;
-		$schedule = new ActionScheduler_IntervalSchedule( new DateTime("@$start", new DateTimeZone('UTC')), MINUTE_IN_SECONDS );
+		$schedule = new ActionScheduler_IntervalSchedule( ActionScheduler::get_datetime_object("@$start"), MINUTE_IN_SECONDS );
 		$this->assertEquals( $start, $schedule->next()->format('U') );
-		$this->assertEquals( $now + MINUTE_IN_SECONDS, $schedule->next(new DateTime(null, new DateTimeZone('UTC')))->format('U') );
-		$this->assertEquals( $start, $schedule->next(new DateTime("@$start", new DateTimeZone('UTC')))->format('U') );
+		$this->assertEquals( $now + MINUTE_IN_SECONDS, $schedule->next(ActionScheduler::get_datetime_object())->format('U') );
+		$this->assertEquals( $start, $schedule->next(ActionScheduler::get_datetime_object("@$start"))->format('U') );
 	}
 }
  

--- a/tests/phpunit/schedules/ActionScheduler_IntervalSchedule_Test.php
+++ b/tests/phpunit/schedules/ActionScheduler_IntervalSchedule_Test.php
@@ -6,7 +6,7 @@
  */
 class ActionScheduler_IntervalSchedule_Test extends ActionScheduler_UnitTestCase {
 	public function test_creation() {
-		$time = new DateTime();
+		$time = new DateTime(null, new DateTimeZone('UTC'));
 		$schedule = new ActionScheduler_IntervalSchedule($time, HOUR_IN_SECONDS);
 		$this->assertEquals( $time, $schedule->next() );
 	}
@@ -14,10 +14,10 @@ class ActionScheduler_IntervalSchedule_Test extends ActionScheduler_UnitTestCase
 	public function test_next() {
 		$now = time();
 		$start = $now - 30;
-		$schedule = new ActionScheduler_IntervalSchedule( new DateTime("@$start"), MINUTE_IN_SECONDS );
+		$schedule = new ActionScheduler_IntervalSchedule( new DateTime("@$start", new DateTimeZone('UTC')), MINUTE_IN_SECONDS );
 		$this->assertEquals( $start, $schedule->next()->format('U') );
-		$this->assertEquals( $now + MINUTE_IN_SECONDS, $schedule->next(new DateTime())->format('U') );
-		$this->assertEquals( $start, $schedule->next(new DateTime("@$start"))->format('U') );
+		$this->assertEquals( $now + MINUTE_IN_SECONDS, $schedule->next(new DateTime(null, new DateTimeZone('UTC')))->format('U') );
+		$this->assertEquals( $start, $schedule->next(new DateTime("@$start", new DateTimeZone('UTC')))->format('U') );
 	}
 }
  

--- a/tests/phpunit/schedules/ActionScheduler_IntervalSchedule_Test.php
+++ b/tests/phpunit/schedules/ActionScheduler_IntervalSchedule_Test.php
@@ -6,7 +6,7 @@
  */
 class ActionScheduler_IntervalSchedule_Test extends ActionScheduler_UnitTestCase {
 	public function test_creation() {
-		$time = ActionScheduler::get_datetime_object();
+		$time = as_get_datetime_object();
 		$schedule = new ActionScheduler_IntervalSchedule($time, HOUR_IN_SECONDS);
 		$this->assertEquals( $time, $schedule->next() );
 	}
@@ -14,10 +14,10 @@ class ActionScheduler_IntervalSchedule_Test extends ActionScheduler_UnitTestCase
 	public function test_next() {
 		$now = time();
 		$start = $now - 30;
-		$schedule = new ActionScheduler_IntervalSchedule( ActionScheduler::get_datetime_object("@$start"), MINUTE_IN_SECONDS );
+		$schedule = new ActionScheduler_IntervalSchedule( as_get_datetime_object("@$start"), MINUTE_IN_SECONDS );
 		$this->assertEquals( $start, $schedule->next()->format('U') );
-		$this->assertEquals( $now + MINUTE_IN_SECONDS, $schedule->next(ActionScheduler::get_datetime_object())->format('U') );
-		$this->assertEquals( $start, $schedule->next(ActionScheduler::get_datetime_object("@$start"))->format('U') );
+		$this->assertEquals( $now + MINUTE_IN_SECONDS, $schedule->next(as_get_datetime_object())->format('U') );
+		$this->assertEquals( $start, $schedule->next(as_get_datetime_object("@$start"))->format('U') );
 	}
 }
  

--- a/tests/phpunit/schedules/ActionScheduler_SimpleSchedule_Test.php
+++ b/tests/phpunit/schedules/ActionScheduler_SimpleSchedule_Test.php
@@ -6,25 +6,25 @@
  */
 class ActionScheduler_SimpleSchedule_Test extends ActionScheduler_UnitTestCase {
 	public function test_creation() {
-		$time = ActionScheduler::get_datetime_object();
+		$time = as_get_datetime_object();
 		$schedule = new ActionScheduler_SimpleSchedule($time);
 		$this->assertEquals( $time, $schedule->next() );
 	}
 
 	public function test_past_date() {
-		$time = ActionScheduler::get_datetime_object('-1 day');
+		$time = as_get_datetime_object('-1 day');
 		$schedule = new ActionScheduler_SimpleSchedule($time);
 		$this->assertEquals( $time, $schedule->next() );
 	}
 
 	public function test_future_date() {
-		$time = ActionScheduler::get_datetime_object('+1 day');
+		$time = as_get_datetime_object('+1 day');
 		$schedule = new ActionScheduler_SimpleSchedule($time);
 		$this->assertEquals( $time, $schedule->next() );
 	}
 
 	public function test_grace_period_for_next() {
-		$time = ActionScheduler::get_datetime_object('3 seconds ago');
+		$time = as_get_datetime_object('3 seconds ago');
 		$schedule = new ActionScheduler_SimpleSchedule($time);
 		$this->assertEquals( $time, $schedule->next() );
 	}

--- a/tests/phpunit/schedules/ActionScheduler_SimpleSchedule_Test.php
+++ b/tests/phpunit/schedules/ActionScheduler_SimpleSchedule_Test.php
@@ -6,25 +6,25 @@
  */
 class ActionScheduler_SimpleSchedule_Test extends ActionScheduler_UnitTestCase {
 	public function test_creation() {
-		$time = new DateTime(null, new DateTimeZone('UTC'));
+		$time = ActionScheduler::get_datetime_object();
 		$schedule = new ActionScheduler_SimpleSchedule($time);
 		$this->assertEquals( $time, $schedule->next() );
 	}
 
 	public function test_past_date() {
-		$time = new DateTime('-1 day', new DateTimeZone('UTC'));
+		$time = ActionScheduler::get_datetime_object('-1 day');
 		$schedule = new ActionScheduler_SimpleSchedule($time);
 		$this->assertEquals( $time, $schedule->next() );
 	}
 
 	public function test_future_date() {
-		$time = new DateTime('+1 day', new DateTimeZone('UTC'));
+		$time = ActionScheduler::get_datetime_object('+1 day');
 		$schedule = new ActionScheduler_SimpleSchedule($time);
 		$this->assertEquals( $time, $schedule->next() );
 	}
 
 	public function test_grace_period_for_next() {
-		$time = new DateTime('3 seconds ago', new DateTimeZone('UTC'));
+		$time = ActionScheduler::get_datetime_object('3 seconds ago');
 		$schedule = new ActionScheduler_SimpleSchedule($time);
 		$this->assertEquals( $time, $schedule->next() );
 	}

--- a/tests/phpunit/schedules/ActionScheduler_SimpleSchedule_Test.php
+++ b/tests/phpunit/schedules/ActionScheduler_SimpleSchedule_Test.php
@@ -6,25 +6,25 @@
  */
 class ActionScheduler_SimpleSchedule_Test extends ActionScheduler_UnitTestCase {
 	public function test_creation() {
-		$time = new DateTime();
+		$time = new DateTime(null, new DateTimeZone('UTC'));
 		$schedule = new ActionScheduler_SimpleSchedule($time);
 		$this->assertEquals( $time, $schedule->next() );
 	}
 
 	public function test_past_date() {
-		$time = new DateTime('-1 day');
+		$time = new DateTime('-1 day', new DateTimeZone('UTC'));
 		$schedule = new ActionScheduler_SimpleSchedule($time);
 		$this->assertEquals( $time, $schedule->next() );
 	}
 
 	public function test_future_date() {
-		$time = new DateTime('+1 day');
+		$time = new DateTime('+1 day', new DateTimeZone('UTC'));
 		$schedule = new ActionScheduler_SimpleSchedule($time);
 		$this->assertEquals( $time, $schedule->next() );
 	}
 
 	public function test_grace_period_for_next() {
-		$time = new DateTime('3 seconds ago');
+		$time = new DateTime('3 seconds ago', new DateTimeZone('UTC'));
 		$schedule = new ActionScheduler_SimpleSchedule($time);
 		$this->assertEquals( $time, $schedule->next() );
 	}


### PR DESCRIPTION
This is the first draft of a PR to ensure we use UTC and `post_date_gmt` to avoid issues relating to daylight savings time, changes to the site's timezone and 3rd party code calling `date_default_timezone_set()`.