### PR TITLE
Making sure new scheduled actions won't hog uniqid

### DIFF
--- a/classes/ActionScheduler_wpPostStore.php
+++ b/classes/ActionScheduler_wpPostStore.php
@@ -29,6 +29,7 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 		$post = array(
 			'post_type' => self::POST_TYPE,
 			'post_title' => $action->get_hook(),
+			'post_name' => uniqid( $action->get_hook() . '-', true ) . '-' . wp_generate_password( 34, false, false ),
 			'post_content' => json_encode($action->get_args()),
 			'post_status' => ( $action->is_finished() ? 'publish' : 'pending' ),
 			'post_date_gmt' => $this->get_timestamp($action, $date),
@@ -581,4 +582,4 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 		$taxonomy_registrar->register();
 	}
 }
- 
+


### PR DESCRIPTION
Fixes #44

Partially. Here's what's happening:

* when creating an action, it's set to draft or pending, and those don't need post_name, so they will be empty without this fix (see [here](https://github.com/WordPress/WordPress/blob/master/wp-includes/post.php#L3022-L3036))
* when updating them to publish status, they will need a valid post name, and because it's empty, it will sanitize the post_title, and roll it through the unique function
* because we're using the post_title to distinguish between actions, the first post_name is always going to be the same, so with every new action of the same type, the unique function needs to do n+1 checks
* setting the post name to something sort of random (this fix) eliminates that need to roll for unique

Part 2 of the fix:

Existing sites would need to run a similar query:

```sql
UPDATE wp_posts SET post_name = CONCAT_WS( '_', post_title, REPLACE( RAND(), '.', '-' ), ID ) WHERE post_type = 'scheduled-action' AND post_name = '';
```

When I tried this fix earlier, it didn't work, because AS was trying to update already existing empty post_named actions.