### PR TITLE
Fix cron schedule's next date fetch method

### DIFF
--- a/classes/ActionScheduler_CronSchedule.php
+++ b/classes/ActionScheduler_CronSchedule.php
@@ -21,7 +21,7 @@ class ActionScheduler_CronSchedule implements ActionScheduler_Schedule {
 	 */
 	public function next( DateTime $after = NULL ) {
 		$after = empty($after) ? clone $this->start : clone $after;
-		return $this->cron->getNextRunDate($after, 0, TRUE);
+		return $this->cron->getNextRunDate($after, 0, false);
 	}
 
 
@@ -41,4 +41,4 @@ class ActionScheduler_CronSchedule implements ActionScheduler_Schedule {
 		$this->start = as_get_datetime_object($this->start_timestamp);
 	}
 }
- 
+


### PR DESCRIPTION
No issue. The problem is that the third argument permits the cron schedule to return the same date as the "next" date, which results in duplicate scheduled actions. Take the following cron expression:

```
20-26/2 13 * * * *
```

Without this fix, the schedules will be the following:

```
3rd Oct 13:20
3rd Oct 13:20
3rd Oct 13:22
3rd Oct 13:22
3rd Oct 13:24
3rd Oct 13:24
3rd Oct 13:26
3rd Oct 13:26
4th Oct 13:20
```

With this fix, these are the schedules:

```
3rd Oct 13:20
3rd Oct 13:22
3rd Oct 13:24
3rd Oct 13:26
4th Oct 13:20
```

Current implementation would lead to bugs and race conditions and parallel execution.

Related to https://github.com/Prospress/woocommerce-subscriptions/pull/1690