### PR TITLE
Fix build & update test versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,16 @@ php:
     - "5.4"
     - "5.5"
     - "5.6"
+    - "7.0"
 
 # Specify versions of WordPress to test against
 # WP_VERSION = WordPress version number (use "master" for SVN trunk)
 # WP_MULTISITE = whether to test multisite (use either "0" or "1")
 env:
+    - WP_VERSION=4.6 WP_MULTISITE=0
     - WP_VERSION=4.5 WP_MULTISITE=0
     - WP_VERSION=4.4 WP_MULTISITE=0
+    - WP_VERSION=4.6 WP_MULTISITE=1
     - WP_VERSION=4.5 WP_MULTISITE=1
     - WP_VERSION=4.4 WP_MULTISITE=1
 

--- a/tests/phpunit/schedules/ActionScheduler_CronSchedule_Test.php
+++ b/tests/phpunit/schedules/ActionScheduler_CronSchedule_Test.php
@@ -8,7 +8,7 @@ class ActionScheduler_CronSchedule_Test extends ActionScheduler_UnitTestCase {
 	public function test_creation() {
 		$time = as_get_datetime_object('tomorrow');
 		$cron = CronExpression::factory('@daily');
-		$schedule = new ActionScheduler_CronSchedule($time, $cron);
+		$schedule = new ActionScheduler_CronSchedule(as_get_datetime_object(), $cron);
 		$this->assertEquals( $time, $schedule->next() );
 	}
 

--- a/tests/travis/setup.sh
+++ b/tests/travis/setup.sh
@@ -20,7 +20,7 @@ mkdir -p $WP_CORE_DIR
 tar --strip-components=1 -zxmf /tmp/wordpress.tar.gz -C $WP_CORE_DIR
 
 # Grab testing framework
-git clone git://develop.git.wordpress.org/ /tmp/wordpress-tests
+svn co --quiet https://develop.svn.wordpress.org/tags/$WP_VERSION/ /tmp/wordpress-tests
 
 # Put various components in proper folders
 cp tests/travis/wp-tests-config.php $WP_TESTS_DIR/wp-tests-config.php


### PR DESCRIPTION
Fix travis builds by making sure we use the WP tests version relates to the WP version we're testing against. This is particularly important at the moment to avoid a fatal error caused by changes in trunk to the `WP_UnitTestCase::_backup_hooks()` method.

See an example of a failing build in: https://travis-ci.org/Prospress/action-scheduler/builds/165926598

I switched to pull down WP via SVN as I found it was faster than using `git clone --branch $WP_VERSION`.

This PR also adds a fix to the unit tests which were broken when #60 was merged (which wasn't obvious because the above issue with `WP_UnitTestCase::_backup_hooks()` was causing the build to break).