### PR TITLE
Exclude Action Scheduler comments from comments RSS feed

### DIFF
--- a/classes/ActionScheduler_wpCommentLogger.php
+++ b/classes/ActionScheduler_wpCommentLogger.php
@@ -114,6 +114,22 @@ class ActionScheduler_wpCommentLogger extends ActionScheduler_Logger {
 	}
 
 	/**
+	 * Make sure Action Scheduler logs are excluded from comment feeds, which use WP_Query, not
+	 * the WP_Comment_Query class handled by @see self::filter_comment_queries().
+	 *
+	 * @param string $where
+	 * @param WP_Query $query
+	 *
+	 * @return string
+	 */
+	public function filter_comment_feed( $where, $query ) {
+		if ( is_comment_feed() ) {
+			$where .= $this->get_where_clause();
+		}
+		return $where;
+	}
+
+	/**
 	 * Return a SQL clause to exclude Action Scheduler comments.
 	 *
 	 * @return string
@@ -212,6 +228,7 @@ class ActionScheduler_wpCommentLogger extends ActionScheduler_Logger {
 		add_action( 'action_scheduler_reset_action', array( $this, 'log_reset_action' ), 10, 1 );
 		add_action( 'pre_get_comments', array( $this, 'filter_comment_queries' ), 10, 1 );
 		add_action( 'wp_count_comments', array( $this, 'filter_comment_count' ), 20, 2 ); // run after WC_Comments::wp_count_comments() to make sure we exclude order notes and action logs
+		add_action( 'comment_feed_where', array( $this, 'filter_comment_feed' ), 10, 2 );
 
 		// Delete comments count cache whenever there is a new comment or a comment status changes
 		add_action( 'wp_insert_comment', array( $this, 'delete_comment_count_cache' ) );

--- a/classes/ActionScheduler_wpCommentLogger.php
+++ b/classes/ActionScheduler_wpCommentLogger.php
@@ -108,10 +108,19 @@ class ActionScheduler_wpCommentLogger extends ActionScheduler_Logger {
 	 */
 	public function filter_comment_query_clauses( $clauses, $query ) {
 		if ( !empty($query->query_vars['action_log_filter']) ) {
-			global $wpdb;
-			$clauses['where'] .= sprintf(" AND {$wpdb->comments}.comment_type != '%s'", self::TYPE);
+			$clauses['where'] .= $this->get_where_clause();
 		}
 		return $clauses;
+	}
+
+	/**
+	 * Return a SQL clause to exclude Action Scheduler comments.
+	 *
+	 * @return string
+	 */
+	protected function get_where_clause() {
+		global $wpdb;
+		return sprintf( " AND {$wpdb->comments}.comment_type != '%s'", self::TYPE );
 	}
 
 	/**


### PR DESCRIPTION
At the moment, Action Scheduler comments appear in the the RSS feed, e.g. `example.com/comments/feed/`

This is because WP uses `WP_Query` to get comments for this feed and that doesn't call the `'pre_get_comments'` or `'comments_clauses'` hooks like `WP_Commnet_Query`, which is used elsewhere to get comments and is already being filtered by Action Scheduler.

This patch uses the `'comment_feed_where'` filter to make sure Action Scheduler comments aren't included in the comments feed.

Reported in https://woothemes.zendesk.com/agent/tickets/499480