### PR TITLE
Never reschedule single actions in ActionScheduler_QueueRunner::schedule_next_instance()

### DIFF
--- a/classes/ActionScheduler_QueueRunner.php
+++ b/classes/ActionScheduler_QueueRunner.php
@@ -105,8 +105,11 @@ class ActionScheduler_QueueRunner {
 	}
 
 	protected function schedule_next_instance( ActionScheduler_Action $action ) {
-		$next = $action->get_schedule()->next( as_get_datetime_object() );
-		if ( $next ) {
+
+		$schedule = $action->get_schedule();
+		$next     = $schedule->next( as_get_datetime_object() );
+
+		if ( ! is_a( $schedule, 'ActionScheduler_SimpleSchedule' ) && ! is_null( $next ) ) {
 			$this->store->save_action( $action, $next );
 		}
 	}


### PR DESCRIPTION
See the thread on #68 for background discussion and an explanation of the issue. For details of why this is the proposed patch for #68, see https://github.com/Prospress/action-scheduler/issues/68#issuecomment-265811582 

### Testing

So far to test this, I've:

1. [manually triggered renewals](https://docs.woocommerce.com/document/testing-subscription-renewal-payments/) - no duplicates were scheduled 🎉 
1. scheduled subscription renewal payments to run (I'll check back soon on the status of these)

I still need to test timezone changes. But thanks to the simplicity of the patch, combined with the fact that manually triggering the actions is working correctly (which is near identical behaviour to timezones leading the actions to be triggered early), I'm quite confident this will fix #68 without any unintended consequences. As mentioned on https://github.com/Prospress/action-scheduler/issues/68#issuecomment-265811582 `ActionScheduler_SimpleSchedule` is only used for _Single_ actions, and _Single_ actions shouldn't ever be scheduled or run more than once to honour their purpose, regardless of whether they are being run more than once because of timezone issues, manual intervention or something else.

Fixes #68