### PR TITLE
Never reschedule single actions (alternative to #69)

### DIFF
--- a/classes/ActionScheduler_CronSchedule.php
+++ b/classes/ActionScheduler_CronSchedule.php
@@ -24,6 +24,12 @@ class ActionScheduler_CronSchedule implements ActionScheduler_Schedule {
 		return $this->cron->getNextRunDate($after, 0, false);
 	}
 
+	/**
+	 * @return bool
+	 */
+	public function is_recurring() {
+		return true;
+	}
 
 	/**
 	 * For PHP 5.2 compat, since DateTime objects can't be serialized

--- a/classes/ActionScheduler_IntervalSchedule.php
+++ b/classes/ActionScheduler_IntervalSchedule.php
@@ -29,6 +29,13 @@ class ActionScheduler_IntervalSchedule implements ActionScheduler_Schedule {
 	}
 
 	/**
+	 * @return bool
+	 */
+	public function is_recurring() {
+		return true;
+	}
+
+	/**
 	 * @param DateTime $after
 	 *
 	 * @return DateTime|null

--- a/classes/ActionScheduler_NullSchedule.php
+++ b/classes/ActionScheduler_NullSchedule.php
@@ -8,5 +8,12 @@ class ActionScheduler_NullSchedule implements ActionScheduler_Schedule {
 	public function next( DateTime $after = NULL ) {
 		return NULL;
 	}
+
+	/**
+	 * @return bool
+	 */
+	public function is_recurring() {
+		return false;
+	}
 }
  

--- a/classes/ActionScheduler_QueueRunner.php
+++ b/classes/ActionScheduler_QueueRunner.php
@@ -109,7 +109,7 @@ class ActionScheduler_QueueRunner {
 		$schedule = $action->get_schedule();
 		$next     = $schedule->next( as_get_datetime_object() );
 
-		if ( ! is_a( $schedule, 'ActionScheduler_SimpleSchedule' ) && ! is_null( $next ) ) {
+		if ( ! is_null( $next ) && $schedule->is_recurring() ) {
 			$this->store->save_action( $action, $next );
 		}
 	}

--- a/classes/ActionScheduler_QueueRunner.php
+++ b/classes/ActionScheduler_QueueRunner.php
@@ -105,8 +105,11 @@ class ActionScheduler_QueueRunner {
 	}
 
 	protected function schedule_next_instance( ActionScheduler_Action $action ) {
-		$next = $action->get_schedule()->next( as_get_datetime_object() );
-		if ( $next ) {
+
+		$schedule = $action->get_schedule();
+		$next     = $schedule->next( as_get_datetime_object() );
+
+		if ( ! is_a( $schedule, 'ActionScheduler_SimpleSchedule' ) && ! is_null( $next ) ) {
 			$this->store->save_action( $action, $next );
 		}
 	}

--- a/classes/ActionScheduler_Schedule.php
+++ b/classes/ActionScheduler_Schedule.php
@@ -9,5 +9,10 @@ interface ActionScheduler_Schedule {
 	 * @return DateTime|null
 	 */
 	public function next( DateTime $after = NULL );
+
+	/**
+	 * @return bool
+	 */
+	public function is_recurring();
 }
  

--- a/classes/ActionScheduler_SimpleSchedule.php
+++ b/classes/ActionScheduler_SimpleSchedule.php
@@ -21,6 +21,13 @@ class ActionScheduler_SimpleSchedule implements ActionScheduler_Schedule {
 	}
 
 	/**
+	 * @return bool
+	 */
+	public function is_recurring() {
+		return false;
+	}
+
+	/**
 	 * For PHP 5.2 compat, since DateTime objects can't be serialized
 	 * @return array
 	 */

--- a/tests/phpunit/schedules/ActionScheduler_CronSchedule_Test.php
+++ b/tests/phpunit/schedules/ActionScheduler_CronSchedule_Test.php
@@ -19,6 +19,11 @@ class ActionScheduler_CronSchedule_Test extends ActionScheduler_UnitTestCase {
 		$this->assertEquals( as_get_datetime_object('tomorrow'), $schedule->next( as_get_datetime_object() ) );
 	}
 
+	public function test_is_recurring() {
+		$schedule = new ActionScheduler_CronSchedule(as_get_datetime_object('2013-06-14'), CronExpression::factory('@daily'));
+		$this->assertTrue( $schedule->is_recurring() );
+	}
+
 	public function test_cron_format() {
 		$time = as_get_datetime_object('2014-01-01');
 		$cron = CronExpression::factory('0 0 10 10 *');

--- a/tests/phpunit/schedules/ActionScheduler_IntervalSchedule_Test.php
+++ b/tests/phpunit/schedules/ActionScheduler_IntervalSchedule_Test.php
@@ -19,5 +19,11 @@ class ActionScheduler_IntervalSchedule_Test extends ActionScheduler_UnitTestCase
 		$this->assertEquals( $now + MINUTE_IN_SECONDS, $schedule->next(as_get_datetime_object())->format('U') );
 		$this->assertEquals( $start, $schedule->next(as_get_datetime_object("@$start"))->format('U') );
 	}
+
+	public function test_is_recurring() {
+		$start = time() - 30;
+		$schedule = new ActionScheduler_IntervalSchedule( as_get_datetime_object("@$start"), MINUTE_IN_SECONDS );
+		$this->assertTrue( $schedule->is_recurring() );
+	}
 }
  

--- a/tests/phpunit/schedules/ActionScheduler_NullSchedule_Test.php
+++ b/tests/phpunit/schedules/ActionScheduler_NullSchedule_Test.php
@@ -9,5 +9,10 @@ class ActionScheduler_NullSchedule_Test extends ActionScheduler_UnitTestCase {
 		$schedule = new ActionScheduler_NullSchedule();
 		$this->assertNull( $schedule->next() );
 	}
+
+	public function test_is_recurring() {
+		$schedule = new ActionScheduler_NullSchedule();
+		$this->assertFalse( $schedule->is_recurring() );
+	}
 }
  

--- a/tests/phpunit/schedules/ActionScheduler_SimpleSchedule_Test.php
+++ b/tests/phpunit/schedules/ActionScheduler_SimpleSchedule_Test.php
@@ -28,5 +28,10 @@ class ActionScheduler_SimpleSchedule_Test extends ActionScheduler_UnitTestCase {
 		$schedule = new ActionScheduler_SimpleSchedule($time);
 		$this->assertEquals( $time, $schedule->next() );
 	}
+
+	public function test_is_recurring() {
+		$schedule = new ActionScheduler_SimpleSchedule(as_get_datetime_object('+1 day'));
+		$this->assertFalse( $schedule->is_recurring() );
+	}
 }
  


### PR DESCRIPTION
This PR implements equivalent logic to the patches in #69 in order to fix #68; however, it addresses the following issue with #69 that were mentioned in https://github.com/Prospress/action-scheduler/issues/68#issuecomment-265811582, specifically:

> It breaks some of the nice architecture of AS, because it's explicitly checking an object type in a class which previously has no knowledge of that object type

Instead of making `schedule_next_instance()` aware of the schedule classes, this PR instead makes it possible to check any instance of a Schedule class to see if it should be rescheduled (which is the case only when it is a recurring schedule type).

Although equivalent, this is a better approach to the one taken in #69. For example, with this patch, new one-off schedule types could be added in future without any changes required to `schedule_next_instance()`.