### PR TITLE
Tweak admin view logic to always include Scheduled Actions admin page

### DIFF
--- a/action-scheduler.php
+++ b/action-scheduler.php
@@ -5,24 +5,24 @@ Plugin URI: https://github.com/prospress/action-scheduler
 Description: A robust action scheduler for WordPress
 Author: Prospress
 Author URI: http://prospress.com/
-Version: 1.5.2
+Version: 1.5.3
 */
 
-if ( ! function_exists( 'action_scheduler_register_1_dot_5_dot_2' ) ) {
+if ( ! function_exists( 'action_scheduler_register_1_dot_5_dot_3' ) ) {
 
 	if ( ! class_exists( 'ActionScheduler_Versions' ) ) {
 		require_once( 'classes/ActionScheduler_Versions.php' );
 		add_action( 'plugins_loaded', array( 'ActionScheduler_Versions', 'initialize_latest_version' ), 1, 0 );
 	}
 
-	add_action( 'plugins_loaded', 'action_scheduler_register_1_dot_5_dot_2', 0, 0 );
+	add_action( 'plugins_loaded', 'action_scheduler_register_1_dot_5_dot_3', 0, 0 );
 
-	function action_scheduler_register_1_dot_5_dot_2() {
+	function action_scheduler_register_1_dot_5_dot_3() {
 		$versions = ActionScheduler_Versions::instance();
-		$versions->register( '1.5.2', 'action_scheduler_initialize_1_dot_5_dot_2' );
+		$versions->register( '1.5.3', 'action_scheduler_initialize_1_dot_5_dot_3' );
 	}
 
-	function action_scheduler_initialize_1_dot_5_dot_2() {
+	function action_scheduler_initialize_1_dot_5_dot_3() {
 		require_once( 'classes/ActionScheduler.php' );
 		ActionScheduler::init( __FILE__ );
 	}

--- a/classes/ActionScheduler_AdminView.php
+++ b/classes/ActionScheduler_AdminView.php
@@ -29,7 +29,7 @@ class ActionScheduler_AdminView {
 	 */
 	public function init() {
 
-		if ( defined( 'WP_DEBUG' ) && true == WP_DEBUG && is_admin() && ( ! defined( 'DOING_AJAX' ) || false == DOING_AJAX ) ) {
+		if ( is_admin() && ( ! defined( 'DOING_AJAX' ) || false == DOING_AJAX ) ) {
 			add_filter( 'action_scheduler_post_type_args', array( self::instance(), 'action_scheduler_post_type_args' ) );
 		}
 
@@ -60,10 +60,10 @@ class ActionScheduler_AdminView {
 
 	public function action_scheduler_post_type_args( $args ) {
 		return array_merge( $args, array(
-			'show_ui' => true,
-			'show_in_menu' => 'tools.php',
+			'show_ui'           => true,
+			'show_in_menu'      => 'tools.php',
 			'show_in_admin_bar' => false,
-		));
+		) );
 	}
 
 	/**

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "prospress/action-scheduler",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "Action Scheduler for WordPress and WooCommerce",
   "type": "wordpress-plugin",
   "license": "GPL-3.0",


### PR DESCRIPTION
So that we don't need to get FTP details to edit `wp-config.php` or other files to set `WP_DEBUG` or `WCS_DEBUG`.

Also bump version to 1.5.3.