### PR TITLE
Display scheduled action args for trashed actions

### DIFF
--- a/classes/ActionScheduler_AdminView.php
+++ b/classes/ActionScheduler_AdminView.php
@@ -186,6 +186,8 @@ class ActionScheduler_AdminView {
 					foreach( $action_args as $key => $value ) {
 						printf( "<code>%s => %s</code><br/>", $key, $value );
 					}
+				} else {
+					printf( "<code>%s</code><br/>", $action_args );
 				}
 				break;
 			case 'recurrence':


### PR DESCRIPTION
While viewing trashed scheduled actions it can be helpful to view the action args, similar to other scheduled action statuses. 

Before: https://cloudup.com/cwLsWX5N92B
After: https://cloudup.com/cRrMM6djzSS