### PR TITLE
[WIP] Added setters/getters to Action objects.

### DIFF
--- a/classes/ActionScheduler_Action.php
+++ b/classes/ActionScheduler_Action.php
@@ -10,12 +10,100 @@ class ActionScheduler_Action {
 	protected $schedule = NULL;
 	protected $group = '';
 
+	/** @var mixed */
+	protected $id;
+
+	/** @var int */
+	protected $status;
+
+	/** @var mixed */
+	protected $claim_id;
+
+	/**
+	 * This array keeps track of all the properties that were set through the setters.
+	 *
+	 * Why is it needed?
+	 *
+	 *  1. If a variable was not assigned it may be populated on demand.
+	 *  2. FALSE, NULL or 0 could be valid properties value, thus making it impossible to tell
+	 *     without an external aid if our properties were assigned or not.
+	 *
+	 * To make things efficent the value of this array is always TRUE and the key is the property
+	 * name.
+	 *
+	 * @type array
+	 */
+	protected $has = array();
+
 	public function __construct( $hook, array $args = array(), ActionScheduler_Schedule $schedule = NULL, $group = '' ) {
 		$schedule = empty( $schedule ) ? new ActionScheduler_NullSchedule() : $schedule;
 		$this->set_hook($hook);
 		$this->set_schedule($schedule);
 		$this->set_args($args);
 		$this->set_group($group);
+	}
+
+	/**
+	 * Sets the ID for this current action.
+	 *
+	 * @param mixed $id Action ID
+	 *
+	 * @return self
+	 */
+	public function set_id( $id ) {
+		$this->has['id'] = true;
+		$this->id = $id;
+		return $this;
+	}
+
+	/**
+	 * Returns the ID of this current action or throws a RuntimeException otherwise
+	 *
+	 * @return mixed
+	 */
+	public function get_id() {
+		if ( empty( $this->has['id'] ) ) {
+			throw new RuntimeException( 'Cannot get ID from Action object ' );
+		}
+		return $this->id;
+	}
+
+	public function set_claim_id( $claim_id ) {
+		$this->has['claim_id'] = true;
+		$this->claim_id = $claim_id;
+		return $this;
+	}
+
+	/**
+	 * Returns the claim ID. If this value is not set previous it will be read from the default store.
+	 *
+	 * @return mixed
+	 */
+	public function get_claim_id() {
+		if ( empty( $this->has['claim_id'] ) ) {
+			$this->set_claim_id( ActionScheduler::store()->get_claim_id_for_action( $this->get_id() ) );
+		}
+		return $this->claim_id;
+	}
+
+	public function set_status( $status ) {
+		$this->has['status'] = true;
+		$this->status = $status;
+		return $this;
+	}
+
+
+	/**
+	 * Returns the Action status. If this value is not set previous it will be read from the default store.
+	 *
+	 * @return mixed
+	 */
+	public function get_status() {
+		if ( empty( $this->has['status'] ) ) {
+			$this->set_status( ActionScheduler::store()->get_status( $this->get_id() ) );
+		}
+
+		return $this->status;
 	}
 
 	public function execute() {

--- a/classes/ActionScheduler_Store.php
+++ b/classes/ActionScheduler_Store.php
@@ -86,6 +86,15 @@ abstract class ActionScheduler_Store {
 	abstract public function get_claim_count();
 
 	/**
+	 * Returns the claim ID of an $action_id
+	 *
+	 * @param mixed $action_id
+	 *
+	 * @return string|null
+	 */
+	abstract public function get_claim_id_for_action( $action_id );
+
+	/**
 	 * @param ActionScheduler_ActionClaim $claim
 	 *
 	 * @return void


### PR DESCRIPTION
The idea behind this PR is to add setters/getters to Action objects. All
the properties that belongs to the actions should be accesible directly
from the object, without any external calls to the store.

This PR adds a fallback mechanism reading most unset properties from the
store, but ideally the store should create the action object property.

To be able to read the claim ID off an action id, this PR introduces a
new abstract method to the Store abstract class
(`get_claim_id_for_action`).

This PR wants to fix #94, #95 and #96 and it will be merged against #88  (and not master).

Beware to also implement `get_claim_id_for_action` in https://github.com/Prospress/action-scheduler-custom-tables