### PR TITLE
Addded checks for past due actions

### DIFF
--- a/classes/ActionScheduler_AdminView.php
+++ b/classes/ActionScheduler_AdminView.php
@@ -35,12 +35,12 @@ class ActionScheduler_AdminView {
 			} else {
 				add_action( 'admin_menu', array( $self, 'register_menu' ) );
 			}
-			add_action( 'admin_notices', array( $self, 'check_past_due_actions' ) );
+			add_action( 'admin_notices', array( $self, 'past_due_actions' ) );
 		}
 	}
 
 	/**
-	 * Check if there are any past due actions.
+	 * Trigger API for 3rd parties to handle past due actions.
 	 *
 	 * This method will check if there are past due actions. Because Action Scheduler is action agnostic,
 	 * it will trigger an action with a list of hooks that callbacks can use to handle past due actions
@@ -55,7 +55,7 @@ class ActionScheduler_AdminView {
 	 *
 	 * This method is executed on the `admin_notices`, so it is safe to render the admin notification.
 	 */
-	public function check_past_due_actions() {
+	public function past_due_actions() {
 		$instance = ActionScheduler_Store::instance();
 
 		$actions = apply_filters( 'action_scheduler_past_due_hooks', array() );

--- a/classes/ActionScheduler_AdminView.php
+++ b/classes/ActionScheduler_AdminView.php
@@ -40,13 +40,14 @@ class ActionScheduler_AdminView {
 	}
 
 	/**
-	 * Check if there are any past due action
+	 * Check if there are any past due actions.
 	 *
-	 * This method will check if there are past due. Because Action Scheduler is action agnostic,
-	 * it will execute an action with a list of the actions.
+	 * This method will check if there are past due actions. Because Action Scheduler is action agnostic,
+	 * it will trigger an action with a list of hooks that callbacks can use to handle past due actions
+	 * as needed.
 	 *
-	 * To make narrow down possible results, and improve query looking for past due actions, any
-	 * interested plugin must add their hook to an array through the `action_scheduler_past_due_hooks`
+	 * To narrow down possible results, and improve query looking for past due actions, any plugin
+	 * must add their hook name to an array through the `action_scheduler_past_due_hooks`
 	 * filter.
 	 *
 	 * The action owner should be listening to the `action_schedule_past_due_action` action, 

--- a/classes/ActionScheduler_AdminView.php
+++ b/classes/ActionScheduler_AdminView.php
@@ -57,16 +57,16 @@ class ActionScheduler_AdminView {
 	 */
 	public function past_due_actions() {
 
-		$actions = apply_filters( 'action_scheduler_past_due_hooks', array() );
-		
-		if ( ! empty( $actions ) ) {
+		$action_hooks = apply_filters( 'action_scheduler_past_due_hooks', array() );
+
+		if ( ! empty( $action_hooks ) ) {
 			return;
 		}
 
 		$action_ids = ActionScheduler::store()->query_actions( array(
 			'date'   => new Datetime( apply_filters( 'action_scheduler_past_due_time', '-5 days' ) ),
 			'status' => ActionScheduler_Store::STATUS_PENDING,
-			'hook'   => $actions,
+			'hook'   => $action_hooks,
 		) );
 
 		if ( ! empty( $action_ids ) ) {

--- a/classes/ActionScheduler_AdminView.php
+++ b/classes/ActionScheduler_AdminView.php
@@ -56,7 +56,6 @@ class ActionScheduler_AdminView {
 	 * This method is executed on the `admin_notices`, so it is safe to render the admin notification.
 	 */
 	public function past_due_actions() {
-		$instance = ActionScheduler_Store::instance();
 
 		$actions = apply_filters( 'action_scheduler_past_due_hooks', array() );
 		
@@ -64,7 +63,7 @@ class ActionScheduler_AdminView {
 			return;
 		}
 
-		$action_ids = $instance->query_actions( array(
+		$action_ids = ActionScheduler::store()->query_actions( array(
 			'date'   => new Datetime( apply_filters( 'action_scheduler_past_due_time', '-5 days' ) ),
 			'status' => ActionScheduler_Store::STATUS_PENDING,
 			'hook'   => $actions,
@@ -76,7 +75,7 @@ class ActionScheduler_AdminView {
 
 		$actions = array();
 		foreach ( $action_ids as $id ) {
-			$action = $instance->fetch_action( $id );
+			$action = ActionScheduler::store()->fetch_action( $id );
 			$actions[ $action->get_hook() ][] = $action;
 		}
 

--- a/classes/ActionScheduler_AdminView.php
+++ b/classes/ActionScheduler_AdminView.php
@@ -57,7 +57,7 @@ class ActionScheduler_AdminView {
 	 */
 	public function past_due_actions() {
 
-		$action_hooks = apply_filters( 'action_scheduler_past_due_hooks', array() );
+		$action_hooks = apply_filters( 'action_scheduler_past_due_hooks_to_check', array() );
 
 		if ( ! empty( $action_hooks ) ) {
 			return;

--- a/classes/ActionScheduler_AdminView.php
+++ b/classes/ActionScheduler_AdminView.php
@@ -35,9 +35,42 @@ class ActionScheduler_AdminView {
 			} else {
 				add_action( 'admin_menu', array( $self, 'register_menu' ) );
 			}
+			add_action( 'admin_notices', array( $self, 'check_past_due_actions' ) );
 		}
 	}
 
+	/**
+	 * Check if there are any past due action
+	 *
+	 * This method will check if there are past due. Because Action Scheduler is action agnostic,
+	 * it will execute an action with a list of the actions.
+	 *
+	 * The action owners should be listening to this action, and do something to warn the users
+	 * about how to fix their WP-Cron or to run their actions manually.
+	 *
+	 * This method is executed by the `admin_notices`, so it is safe to render the admin notification
+	 * from the `action_scheduler_past_due_action` action.
+	 *
+	 */
+	public function check_past_due_actions() {
+		$instance = ActionScheduler_Store::instance();
+		if ( $cache = get_transient( __METHOD__ ) ) {
+			$action_ids = $cache['action_ids'];
+		} else {
+			$action_ids = $instance->query_actions( array(
+				'date' => new Datetime( apply_filters( 'action_scheduler_past_due_time', '-5 days' ) ),
+				'status' => ActionScheduler_Store::STATUS_PENDING,
+			) );
+			set_transient( __METHOD__, compact( 'action_ids' ) );
+		}
+
+		$action_ids = array( 2151 );
+		$actions = array();
+		foreach ( $action_ids as $id ) {
+			$actions[ $id ] = $instance->fetch_action( $id );
+		}
+		do_action( 'action_scheduler_past_due_action', $actions );
+	}
 
 	/**
 	 * Registers action-scheduler into WooCommerce > System status.

--- a/classes/ActionScheduler_AdminView.php
+++ b/classes/ActionScheduler_AdminView.php
@@ -64,7 +64,6 @@ class ActionScheduler_AdminView {
 			set_transient( __METHOD__, compact( 'action_ids' ) );
 		}
 
-		$action_ids = array( 2151 );
 		$actions = array();
 		foreach ( $action_ids as $id ) {
 			$actions[ $id ] = $instance->fetch_action( $id );

--- a/classes/ActionScheduler_wpPostStore.php
+++ b/classes/ActionScheduler_wpPostStore.php
@@ -231,7 +231,7 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 		if ( $query['hook'] && is_scalar( $query['hook'] ) ) {
 			$sql .= " AND p.post_title=%s";
 			$sql_params[] = $query['hook'];
-		} else if ( $query['hook'] ) {
+		} else if ( is_array( $query['hook'] ) ) {
 			$sql .= ' AND p.post_title IN (' . implode( ',', array_fill( '%s', 0, count( $query['hook'] ) ) ) . ')';
 			$sql_params = array_merge( $sql_params, $query['hook'] );
 		}
@@ -324,7 +324,7 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 		if ( $query['hook'] && is_scalar( $query['hook'] ) ) {
 			$sql .= " AND p.post_title=%s";
 			$sql_params[] = $query['hook'];
-		} else if ( $query['hook'] ) {
+		} else if ( is_array( $query['hook'] ) ) {
 			$sql .= ' AND p.post_title IN (' . implode( ',', array_fill( 0, count( $query['hook'] ), '%s' ) ) . ')';
 			$sql_params = array_merge( $sql_params, $query['hook'] );
 		}

--- a/classes/ActionScheduler_wpPostStore.php
+++ b/classes/ActionScheduler_wpPostStore.php
@@ -228,10 +228,14 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 		}
 		$sql .= " WHERE post_type=%s";
 		$sql_params[] = self::POST_TYPE;
-		if ( $query['hook'] ) {
+		if ( $query['hook'] && is_scalar( $query['hook'] ) ) {
 			$sql .= " AND p.post_title=%s";
 			$sql_params[] = $query['hook'];
+		} else if ( $query['hook'] ) {
+			$sql .= ' AND p.post_title IN (' . implode( ',', array_fill( '%s', 0, count( $query['hook'] ) ) ) . ')';
+			$sql_params = array_merge( $sql_params, $query['hook'] );
 		}
+
 		if ( !is_null($query['args']) ) {
 			$sql .= " AND p.post_content=%s";
 			$sql_params[] = json_encode($query['args']);
@@ -317,9 +321,12 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 		}
 		$sql .= " WHERE post_type=%s";
 		$sql_params[] = self::POST_TYPE;
-		if ( $query['hook'] ) {
+		if ( $query['hook'] && is_scalar( $query['hook'] ) ) {
 			$sql .= " AND p.post_title=%s";
 			$sql_params[] = $query['hook'];
+		} else if ( $query['hook'] ) {
+			$sql .= ' AND p.post_title IN (' . implode( ',', array_fill( 0, count( $query['hook'] ), '%s' ) ) . ')';
+			$sql_params = array_merge( $sql_params, $query['hook'] );
 		}
 		if ( !is_null($query['args']) ) {
 			$sql .= " AND p.post_content=%s";


### PR DESCRIPTION
This commit adds checks for past due actions. Because Action Scheduler is action agnostic it will trigger an action with all the past due actions. It is the responsability of the action owner (library which created it) to warn their users how to fix their WP-Cron or how to run those actions manually.

This PR would help to improve the [user experience in Subscriptions](https://github.com/Prospress/woocommerce-subscriptions/issues/2380).