### PR TITLE
Catch exception when deleting old actions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ env:
     - WP_VERSION=4.5 WP_MULTISITE=1
     - WP_VERSION=4.4 WP_MULTISITE=1
 
+dist: precise
+
 # Grab the setup script and execute
 before_script:
     - source tests/travis/setup.sh $TRAVIS_PHP_VERSION

--- a/classes/ActionScheduler_QueueCleaner.php
+++ b/classes/ActionScheduler_QueueCleaner.php
@@ -26,7 +26,25 @@ class ActionScheduler_QueueCleaner {
 		) );
 
 		foreach ( $actions_to_delete as $action_id ) {
-			$this->store->delete_action( $action_id );
+			try {
+				$this->store->delete_action( $action_id );
+			} catch ( Exception $e ) {
+
+				/**
+				 * Notify 3rd party code of exceptions when deleting a completed action older than the retention period
+				 *
+				 * This hook provides a way for 3rd party code to log or otherwise handle exceptions relating to their
+				 * actions.
+				 *
+				 * @since 1.6.0
+				 *
+				 * @param int $action_id The scheduled actions ID in the data store
+				 * @param Exception $e The exception thrown when attempting to delete the action from the data store
+				 * @param int $lifespan The retention period, in seconds, for old actions
+				 * @param int $count_of_actions_to_delete The number of old actions being deleted in this batch
+				 */
+				do_action( 'action_scheduler_failed_old_action_deletion', $action_id, $e, $lifespan, count( $actions_to_delete ) );
+			}
 		}
 	}
 


### PR DESCRIPTION
And add 'action_scheduler_failed_old_action_deletion' hook to add logging outside of Action Scheduler, or to Action Scheduler itself at a later stage once we have logging not linked to the ID directly (which won't work if it's been deleted).

Fixes #103

---

This doesn't address all the issues mentioned in #103, specifically:

> This will guarantee this race condition is ignored, but it may catch other exceptions for new conditions, so it will need special handling.

If we see issues with that, we may want to add a custom exception class for this case, and only catch that, and throw a different exception type for other cases.
