### PR TITLE
Refactor stored actions APIs

### DIFF
--- a/classes/ActionScheduler_AbstractAction.php
+++ b/classes/ActionScheduler_AbstractAction.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Class ActionScheduler_AbstractAction
+ *
+ * Define shared methods and data for all action types.
+ *
+ * @since 1.6.0
+ */
+abstract class ActionScheduler_AbstractAction implements ActionScheduler_Interface_Action, ActionScheduler_Interface_Scheduled {
+
+	/** @var string */
+	protected $hook = '';
+
+	/** @var array */
+	protected $args = array();
+
+	/** @var ActionScheduler_Schedule */
+	protected $schedule = NULL;
+
+	/** @var string */
+	protected $group = '';
+
+	/** @var bool */
+	protected $is_finished = false;
+
+	public function execute() {
+		return do_action_ref_array( $this->get_hook(), $this->get_args() );
+	}
+
+	/**
+	 * @param string $hook
+	 * @return void
+	 */
+	protected function set_hook( $hook ) {
+		$this->hook = $hook;
+	}
+
+	public function get_hook() {
+		return $this->hook;
+	}
+
+	protected function set_schedule( ActionScheduler_Schedule $schedule ) {
+		$this->schedule = $schedule;
+	}
+
+	/**
+	 * @return ActionScheduler_Schedule
+	 */
+	public function get_schedule() {
+		return $this->schedule;
+	}
+
+	protected function set_args( array $args ) {
+		$this->args = $args;
+	}
+
+	public function get_args() {
+		return $this->args;
+	}
+
+	/**
+	 * @param string $group
+	 */
+	protected function set_group( $group ) {
+		$this->group = $group;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function get_group() {
+		return $this->group;
+	}
+
+	/**
+	 * @return bool If the action has been finished
+	 */
+	public function is_finished() {
+		return $this->is_finished;
+	}
+}

--- a/classes/ActionScheduler_AbstractAction.php
+++ b/classes/ActionScheduler_AbstractAction.php
@@ -24,7 +24,7 @@ abstract class ActionScheduler_AbstractAction implements ActionScheduler_Interfa
 	protected $is_finished = false;
 
 	public function execute() {
-		return do_action_ref_array( $this->get_hook(), $this->get_args() );
+		do_action_ref_array( $this->get_hook(), $this->get_args() );
 	}
 
 	/**

--- a/classes/ActionScheduler_Action.php
+++ b/classes/ActionScheduler_Action.php
@@ -3,12 +3,7 @@
 /**
  * Class ActionScheduler_Action
  */
-class ActionScheduler_Action {
-	protected $hook = '';
-	protected $args = array();
-	/** @var ActionScheduler_Schedule */
-	protected $schedule = NULL;
-	protected $group = '';
+class ActionScheduler_Action extends ActionScheduler_AbstractAction {
 
 	public function __construct( $hook, array $args = array(), ActionScheduler_Schedule $schedule = NULL, $group = '' ) {
 		$schedule = empty( $schedule ) ? new ActionScheduler_NullSchedule() : $schedule;
@@ -17,61 +12,4 @@ class ActionScheduler_Action {
 		$this->set_args($args);
 		$this->set_group($group);
 	}
-
-	public function execute() {
-		return do_action_ref_array($this->get_hook(), $this->get_args());
-	}
-
-	/**
-	 * @param string $hook
-	 * @return void
-	 */
-	protected function set_hook( $hook ) {
-		$this->hook = $hook;
-	}
-
-	public function get_hook() {
-		return $this->hook;
-	}
-
-	protected function set_schedule( ActionScheduler_Schedule $schedule ) {
-		$this->schedule = $schedule;
-	}
-
-	/**
-	 * @return ActionScheduler_Schedule
-	 */
-	public function get_schedule() {
-		return $this->schedule;
-	}
-
-	protected function set_args( array $args ) {
-		$this->args = $args;
-	}
-
-	public function get_args() {
-		return $this->args;
-	}
-
-	/**
-	 * @param string $group
-	 */
-	protected function set_group( $group ) {
-		$this->group = $group;
-	}
-
-	/**
-	 * @return string
-	 */
-	public function get_group() {
-		return $this->group;
-	}
-
-	/**
-	 * @return bool If the action has been finished
-	 */
-	public function is_finished() {
-		return FALSE;
-	}
 }
- 

--- a/classes/ActionScheduler_ActionFactory.php
+++ b/classes/ActionScheduler_ActionFactory.php
@@ -4,6 +4,39 @@
  * Class ActionScheduler_ActionFactory
  */
 class ActionScheduler_ActionFactory {
+
+	/**
+	 * @param int $action_id The action's ID in the data store
+	 * @param string $hook The hook to trigger when this action runs
+	 * @param string $status The action's status in the data store
+	 * @param string $claim_id The identifier for the claim this action belongs to, if any, derived from ActionScheduler_ActionClaim::get_id()
+	 * @param array $args Args to pass to callbacks when the hook is triggered
+	 * @param ActionScheduler_Schedule $schedule The action's schedule
+	 * @param string $group A group to put the action in
+	 *
+	 * @return ActionScheduler_StoredAction An instance of the stored action
+	 */
+	public function get_stored_action_instance( $action_id, $hook, $status, $claim_id = '', array $args = array(), ActionScheduler_Schedule $schedule = NULL, $group = '' ) {
+
+		switch ( $status ) {
+			case ActionScheduler_Store::STATUS_PENDING :
+				$action_class = 'ActionScheduler_StoredAction';
+				break;
+			case ActionScheduler_Store::STATUS_CANCELED :
+				$action_class = 'ActionScheduler_CanceledAction';
+				break;
+			default :
+				$action_class = 'ActionScheduler_NonexecutableAction';
+				break;
+		}
+
+		$action_class = apply_filters( 'action_scheduler_stored_action_class', $action_class, $action_id, $hook, $status, $claim_id, $args, $schedule, $group );
+
+		$action = new $action_class( $action_id, $hook, $status, $claim_id, $args, $schedule, $group );
+
+		return apply_filters( 'action_scheduler_stored_action_instance', $action, $action_id, $hook, $status, $claim_id, $args, $schedule, $group )
+	}
+
 	/**
 	 * @param string $hook The hook to trigger when this action runs
 	 * @param array $args Args to pass when the hook is triggered

--- a/classes/ActionScheduler_CanceledAction.php
+++ b/classes/ActionScheduler_CanceledAction.php
@@ -6,10 +6,10 @@
  * Stored action which was canceled and therefore acts like a finished action but should always return a null schedule,
  * regardless of schedule passed to its constructor.
  */
-class ActionScheduler_CanceledAction extends ActionScheduler_FinishedAction {
+class ActionScheduler_CanceledAction extends ActionScheduler_NonexecutableAction {
 
-	public function __construct( $hook, array $args = array(), ActionScheduler_Schedule $schedule = NULL, $group = '', $id = NULL, $status = '', $claim_id = '' ) {
-		parent::__construct( $hook, $args, $schedule, $group );
-		$this->set_schedule( new ActionScheduler_NullSchedule() );
+	public function __construct( $id, $hook, $status, $claim_id = '', array $args = array(), ActionScheduler_Schedule $schedule = NULL, $group = '' ) {
+		$null_schedule = new ActionScheduler_NullSchedule();
+		parent::__construct( $id, $hook, $status, $claim_id, $args, $null_schedule, $group );
 	}
 }

--- a/classes/ActionScheduler_FinishedAction.php
+++ b/classes/ActionScheduler_FinishedAction.php
@@ -3,16 +3,19 @@
 /**
  * Class ActionScheduler_FinishedAction
  *
- * Stored action which has finished, which could be because it was cancelled, completed or failed.
+ * Deprecated to avoid ambiguity with stored actions and objects instantiated purely to call the hook.
+ *
+ * @deprecated 1.6.0
  */
-class ActionScheduler_FinishedAction extends ActionScheduler_StoredAction {
+class ActionScheduler_FinishedAction extends ActionScheduler_Action {
+
+	public function __construct( $hook, array $args = array(), ActionScheduler_Schedule $schedule = NULL, $group = '' ) {
+		trigger_error( sprintf( __('%1$s is <strong>deprecated</strong> since version 1.6.0! Use an instance of ActionScheduler_NonexecutableAction instead.'), __CLASS__ ) );
+		parent::__construct( $hook, $args, $schedule, $group );
+		$this->is_finished = true;
+	}
 
 	public function execute() {
 		// don't execute
 	}
-
-	public function is_finished() {
-		return TRUE;
-	}
 }
- 

--- a/classes/ActionScheduler_Interface_Action.php
+++ b/classes/ActionScheduler_Interface_Action.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Interface ActionScheduler_Interface_Action
+ *
+ * Define public methods for all action types to provide
+ *
+ * @since 1.6.0
+ */
+interface ActionScheduler_Interface_Action {
+
+	/**
+	 * Get the hook for the Action.
+	 *
+	 * @author Jeremy Pry
+	 * @return string
+	 */
+	public function get_hook();
+
+	/**
+	 * Get the arguments used for the Action.
+	 *
+	 * @author Jeremy Pry
+	 * @return array
+	 */
+	public function get_args();
+
+	/**
+	 * Get the arguments used for the Action.
+	 *
+	 * @author Jeremy Pry
+	 * @return array
+	 */
+	public function get_group();
+}

--- a/classes/ActionScheduler_Interface_Claimable.php
+++ b/classes/ActionScheduler_Interface_Claimable.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Interface ActionScheduler_Interface_Claimable
+ *
+ * Define the public methods provided by claimable objects, like an action
+ *
+ * @since 1.6.0
+ */
+interface ActionScheduler_Interface_Claimable {
+
+	/**
+	 * Get the claim ID of the action.
+	 *
+	 * @author Jeremy Pry
+	 * @return mixed
+	 */
+	public function get_claim_id();
+}

--- a/classes/ActionScheduler_Interface_Scheduled.php
+++ b/classes/ActionScheduler_Interface_Scheduled.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Interface ActionScheduler_Interface_Scheduled
+ *
+ * Define the public methods provided by scheduled objects, like an action with a schedule
+ *
+ * @since 1.6.0
+ */
+interface ActionScheduler_Interface_Scheduled {
+
+	/**
+	 * Get the schedule for the action.
+	 *
+	 * @author Jeremy Pry
+	 * @return ActionScheduler_Schedule
+	 */
+	public function get_schedule();
+}

--- a/classes/ActionScheduler_Interface_Storable.php
+++ b/classes/ActionScheduler_Interface_Storable.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Interface ActionScheduler_Interface_Storable
+ *
+ * Define public methods for all action types to provide
+ *
+ * @since 1.6.0
+ */
+interface ActionScheduler_Interface_Storable {
+
+	/**
+	 * Get the ID of the action.
+	 *
+	 * @author Jeremy Pry
+	 * @return int
+	 */
+	public function get_id();
+
+	/**
+	 * Get the status of the action.
+	 *
+	 * @author Jeremy Pry
+	 * @return string
+	 */
+	public function get_status();
+}

--- a/classes/ActionScheduler_NonexecutableAction.php
+++ b/classes/ActionScheduler_NonexecutableAction.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * Class ActionScheduler_NonexecutableAction
+ *
+ * Stored action which should not be executed because it has already been executed, and has the
+ * failed or completed status, or becuase it has been cancelled, and has the cancelled status.
+ */
+class ActionScheduler_NonexecutableAction extends ActionScheduler_StoredAction {
+
+	public function __construct( $id, $hook, $status, $claim_id = '', array $args = array(), ActionScheduler_Schedule $schedule = NULL, $group = '' ) {
+		parent::__construct( $id, $hook, $status, $claim_id, $args, $schedule, $group );
+		$this->is_finished = true;
+	}
+
+	public function execute() {
+		// don't execute
+	}
+}

--- a/classes/ActionScheduler_NullAction.php
+++ b/classes/ActionScheduler_NullAction.php
@@ -3,14 +3,14 @@
 /**
  * Class ActionScheduler_NullAction
  */
-class ActionScheduler_NullAction extends ActionScheduler_Action {
+class ActionScheduler_NullAction extends ActionScheduler_AbstractAction {
 
 	public function __construct( $hook = '', array $args = array(), ActionScheduler_Schedule $schedule = NULL ) {
 		$this->set_schedule( new ActionScheduler_NullSchedule() );
+		$this->is_finished = true;
 	}
 
 	public function execute() {
 		// don't execute
 	}
 }
- 

--- a/classes/ActionScheduler_Store.php
+++ b/classes/ActionScheduler_Store.php
@@ -22,7 +22,7 @@ abstract class ActionScheduler_Store {
 	 *
 	 * @return string The action ID
 	 */
-	abstract public function save_action( ActionScheduler_Action $action, DateTime $date = NULL );
+	abstract public function save_action( ActionScheduler_AbstractAction $action, DateTime $date = NULL );
 
 	/**
 	 * @param string $action_id

--- a/classes/ActionScheduler_StoredAction.php
+++ b/classes/ActionScheduler_StoredAction.php
@@ -5,22 +5,26 @@
  *
  * An action which has been saved in the data store and is pending execution (i.e. not finished).
  */
-class ActionScheduler_StoredAction extends ActionScheduler_Action {
+class ActionScheduler_StoredAction extends ActionScheduler_AbstractAction implements ActionScheduler_Interface_Storable, ActionScheduler_Interface_Claimable {
 
 	/** @var mixed */
-	protected $id = NULL;
+	protected $id;
 
 	/** @var string */
-	protected $status = '';
+	protected $status;
 
 	/** @var string */
 	protected $claim_id = '';
 
-	public function __construct( $hook, array $args = array(), ActionScheduler_Schedule $schedule = NULL, $group = '', $id = NULL, $status = '', $claim_id = '' ) {
-		parent::__construct( $hook, $args, $schedule, $group );
+	public function __construct( $id, $hook, $status, $claim_id = '', array $args = array(), ActionScheduler_Schedule $schedule = NULL, $group = '' ) {
+		$schedule = empty( $schedule ) ? new ActionScheduler_NullSchedule() : $schedule;
 		$this->set_id($id);
+		$this->set_hook($hook);
 		$this->set_status($status);
 		$this->set_claim_id($claim_id);
+		$this->set_args($args);
+		$this->set_schedule($schedule);
+		$this->set_group($group);
 	}
 
 	/**
@@ -37,7 +41,7 @@ class ActionScheduler_StoredAction extends ActionScheduler_Action {
 	/**
 	 * Returns the ID of this current action or throws a RuntimeException otherwise
 	 *
-	 * @return mixed
+	 * @return int
 	 */
 	public function get_id() {
 		return $this->id;
@@ -57,7 +61,7 @@ class ActionScheduler_StoredAction extends ActionScheduler_Action {
 	/**
 	 * Returns the ID of this current action or throws a RuntimeException otherwise
 	 *
-	 * @return mixed
+	 * @return string
 	 */
 	public function get_status() {
 		return $this->status;
@@ -70,7 +74,7 @@ class ActionScheduler_StoredAction extends ActionScheduler_Action {
 	/**
 	 * Returns the claim ID. If this value is not set previous it will be read from the default store.
 	 *
-	 * @return mixed
+	 * @return string
 	 */
 	public function get_claim_id() {
 		return $this->claim_id;

--- a/classes/ActionScheduler_wpPostStore.php
+++ b/classes/ActionScheduler_wpPostStore.php
@@ -11,7 +11,7 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 	/** @var DateTimeZone */
 	protected $local_timezone = NULL;
 
-	public function save_action( ActionScheduler_Action $action, DateTime $date = NULL ){
+	public function save_action( ActionScheduler_AbstractAction $action, DateTime $date = NULL ){
 		try {
 			$post_array = $this->create_post_array( $action, $date );
 			$post_id = $this->save_post_array( $post_array );

--- a/classes/ActionScheduler_wpPostStore.php
+++ b/classes/ActionScheduler_wpPostStore.php
@@ -113,6 +113,9 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 	protected function make_action_from_post( $post ) {
 		$hook = $post->post_title;
 		$args = json_decode( $post->post_content, true );
+
+		$status   = $this->get_action_status_by_post_status( $post->post_status );
+		$claim_id = $post->post_password;
 		$schedule = get_post_meta( $post->ID, self::SCHEDULE_META_KEY, true );
 		if ( empty($schedule) ) {
 			$schedule = new ActionScheduler_NullSchedule();
@@ -120,17 +123,7 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 		$group = wp_get_object_terms( $post->ID, self::GROUP_TAXONOMY, array('fields' => 'names') );
 		$group = empty( $group ) ? '' : reset($group);
 
-		$status = $this->get_action_status_by_post_status( $post->post_status );
-
-		if ( self::STATUS_PENDING === $status ) {
-			$action_class = 'ActionScheduler_StoredAction';
-		} elseif ( self::STATUS_CANCELED === $status ) {
-			$action_class = 'ActionScheduler_CanceledAction';
-		} else {
-			$action_class = 'ActionScheduler_FinishedAction';
-		}
-
-		return new $action_class( $hook, $args, $schedule, $group, $post->ID, $status, $post->post_password );
+		return ActionScheduler::factory()->get_stored_action_instance( $post->ID, $hook, $status, $claim_id, $args, $schedule, $group );
 	}
 
 	/**


### PR DESCRIPTION
This is a proposal to refactor the stored actions handling approach introduced in #88 (the PR is using `issue_85` as a base, which is the branch used for #88). I'm introducing it as a separate PR outside of #88 to keep a separate place for discussion and review of it (#88 is already unwieldy enough).

The approach taken here builds on the one proposed by @JPry in this comment https://github.com/Prospress/action-scheduler/pull/88#issuecomment-363942542 to use interfaces to define the shared, public methods available between stored and unstored actions.

It also introduces a new `ActionScheduler_AbstractAction` class to use as a base for both stored and unstored actions. I think this was the missing piece when tackling it previously. Using this shared abstract class allows for different constructors, which means stored actions can require an ID and status to be passed in, while also allow them to be used interchangeably when that data isn't required.

**This makes it possible to maintain full backward compatibility, while still introducing new classes well suited for instantiating stored actions.**

The best demonstration of this is with `ActionScheduler_AbstractAction::save_action()`. Previously, it required an instance of `ActionScheduler_Action` as the first parameter. Therefore, any stored action would need to extend `ActionScheduler_Action`, meaning stored actions needed to honour that class's constructor. However, by changing it to now require an instance of `ActionScheduler_AbstractAction`, it will now gladly accept an instance of `ActionScheduler_Action` or any child class of it, which maintains backward compatibility. It will also now accept an instance of `ActionScheduler_StoredAction`, or any of its child classes.

I also snuck in another related commit to this PR to introduce `ActionFactory::get_stored_action_instance()` in response to feedback on #88.