### PR TITLE
Don't stop WP CLI execution when claim lost on one batch

### DIFF
--- a/classes/ActionScheduler_WPCLI_QueueRunner.php
+++ b/classes/ActionScheduler_WPCLI_QueueRunner.php
@@ -92,15 +92,6 @@ class ActionScheduler_WPCLI_QueueRunner extends ActionScheduler_Abstract_QueueRu
 	}
 
 	/**
-	 * Ensure the progress bar has finished properly.
-	 *
-	 * @author Jeremy Pry
-	 */
-	protected function finish_progress_bar() {
-		$this->progress_bar->finish();
-	}
-
-	/**
 	 * Process actions in the queue.
 	 *
 	 * @author Jeremy Pry
@@ -126,7 +117,7 @@ class ActionScheduler_WPCLI_QueueRunner extends ActionScheduler_Abstract_QueueRu
 		}
 
 		$completed = $this->progress_bar->current();
-		$this->finish_progress_bar();
+		$this->progress_bar->finish();
 		$this->store->release_claim( $this->claim );
 		do_action( 'action_scheduler_after_process_queue' );
 

--- a/classes/ActionScheduler_WPCLI_QueueRunner.php
+++ b/classes/ActionScheduler_WPCLI_QueueRunner.php
@@ -105,7 +105,6 @@ class ActionScheduler_WPCLI_QueueRunner extends ActionScheduler_Abstract_QueueRu
 	 *
 	 * @author Jeremy Pry
 	 * @return int The number of actions processed.
-	 * @throws \WP_CLI\ExitException When the claim is lost.
 	 */
 	public function run() {
 		do_action( 'action_scheduler_before_process_queue' );
@@ -113,8 +112,8 @@ class ActionScheduler_WPCLI_QueueRunner extends ActionScheduler_Abstract_QueueRu
 		foreach ( $this->actions as $action_id ) {
 			// Error if we lost the claim.
 			if ( ! in_array( $action_id, $this->store->find_actions_by_claim_id( $this->claim->get_id() ) ) ) {
-				$this->finish_progress_bar();
-				WP_CLI::error( __( 'The claim has been lost. Aborting.', 'action-scheduler' ) );
+				WP_CLI::warning( __( 'The claim has been lost. Aborting current batch.', 'action-scheduler' ) );
+				break;
 			}
 
 			$this->process_action( $action_id );


### PR DESCRIPTION
Fixes #130.

This converts the WP CLI error into a warning, which will allow the processing to continue.

In looking at this, I wonder whether it would be a good idea to add a filter to the batch timeout for WP CLI operations, so that "old" claims are never actually removed. That might also help here, since the underlying problem of batches being unclaimed still remains.