### PR TITLE
Add better handling of hosts with hard timeouts

### DIFF
--- a/classes/ActionScheduler_QueueRunner.php
+++ b/classes/ActionScheduler_QueueRunner.php
@@ -112,4 +112,25 @@ class ActionScheduler_QueueRunner extends ActionScheduler_Abstract_QueueRunner {
 
 		return absint( apply_filters( 'action_scheduler_maximum_execution_time', $maximum_execution_time ) );
 	}
+
+	/**
+	 * Get the number of seconds a batch has run for.
+	 *
+	 * @param int $start_time The timestamp the batch started.
+	 * @return int The number of seconds.
+	 */
+	protected function get_execution_time( $start_time ) {
+		$execution_time = microtime( true ) - $start_time;
+
+		// Get the CPU time if the hosting environment uses it rather than wall-clock time to calculate a process's execution time.
+		if ( function_exists( 'getrusage' ) && apply_filters( 'action_scheduler_use_cpu_execution_time', defined( 'PANTHEON_ENVIRONMENT' ) ) ) {
+			$resource_usages = getrusage();
+
+			if ( isset( $resource_usages['ru_stime.tv_usec'], $resource_usages['ru_stime.tv_usec'] ) ) {
+				$execution_time = $resource_usages['ru_stime.tv_sec'] + ( $resource_usages['ru_stime.tv_usec'] / 1000000 );
+			}
+		}
+
+		return $execution_time;
+	}
 }

--- a/classes/ActionScheduler_QueueRunner.php
+++ b/classes/ActionScheduler_QueueRunner.php
@@ -95,4 +95,21 @@ class ActionScheduler_QueueRunner extends ActionScheduler_Abstract_QueueRunner {
 
 		return $schedules;
 	}
+
+	/**
+	 * Get the maximum number of seconds a batch can run for.
+	 *
+	 * @return int The number of seconds.
+	 */
+	protected function get_maximum_execution_time() {
+
+		// There are known hosts with a strict 60 second execution time.
+		if ( defined( 'WPENGINE_ACCOUNT' ) || defined( 'PANTHEON_ENVIRONMENT' ) ) {
+			$maximum_execution_time = 60;
+		} else {
+			$maximum_execution_time = ini_get( 'max_execution_time' );
+		}
+
+		return absint( apply_filters( 'action_scheduler_maximum_execution_time', $maximum_execution_time ) );
+	}
 }


### PR DESCRIPTION
This PR implements the proposed solution on #108. 

At the start of running a batch of actions, record the start time using `microtime( true );` and as each action is processed, track how long it takes and abort running the batch if the total run time of the batch is approaching the maximum execution time - less than 2 times the average action processing time remaining.  

The maximum execution time is returned by `ActionScheduler_QueueRunner::get_maximum_execution_time()` and can be 60 seconds if there's a known host constant defined (`WPENGINE_ACCOUNT` or `PANTHEON_ENVIRONMENT`) or falls back to `ini_get( 'max_execution_time' )`.

The elapsed time is returned by `ActionScheduler_QueueRunner::get_execution_time()` and will be the wall-clock time (the continuous time elapsed in the real world from start to finish) by default or the total CPU processing time if the server enforces execution time restrictions on system processing time.

I've done some testing of both modes of getting the execution time. The time it takes to process renewal actions in CPU time, however, is really low (if I've calculated it correctly from `getrusage()`) so it's slightly harder to test.

fixes #108 