### PR TITLE
Pass both args to WPCLI_QueueRunner::action_failed()

### DIFF
--- a/classes/ActionScheduler_WPCLI_QueueRunner.php
+++ b/classes/ActionScheduler_WPCLI_QueueRunner.php
@@ -75,7 +75,7 @@ class ActionScheduler_WPCLI_QueueRunner extends ActionScheduler_Abstract_QueueRu
 	protected function add_hooks() {
 		add_action( 'action_scheduler_before_execute', array( $this, 'before_execute' ) );
 		add_action( 'action_scheduler_after_execute', array( $this, 'after_execute' ) );
-		add_action( 'action_scheduler_failed_execution', array( $this, 'action_failed' ) );
+		add_action( 'action_scheduler_failed_execution', array( $this, 'action_failed' ), 10, 2 );
 	}
 
 	/**


### PR DESCRIPTION
To avoid errors like the following when an exception occurs when processing an action:

```
Fatal error: Uncaught Error: Call to a member function getMessage() on null in /sites/wp-content/plugins/action-scheduler/classes/ActionScheduler_WPCLI_QueueRunner.php:163
Stack trace:
#0 /sites/wp-includes/class-wp-hook.php(288): ActionScheduler_WPCLI_QueueRunner->action_failed(787213)
#1 /sites/wp-includes/class-wp-hook.php(310): WP_Hook->apply_filters(NULL, Array)
#2 /sites/wp-includes/plugin.php(453): WP_Hook->do_action(Array)
#3 /sites/wp-content/plugins/action-scheduler/classes/ActionScheduler_Abstract_QueueRunner.php(45): do_action('action_schedule...', 787213, Object(Exception))
#4 /sites/wp-content/plugins/action-scheduler/classes/ActionScheduler_WPCLI_QueueRunner.php(110): ActionScheduler_Abstract_QueueRunner->process_action(787213)
#5 /sites/wp-content/plugins/action-scheduler/classes/ActionScheduler_WPCLI_Scheduler_command.php(53): ActionScheduler_WPCLI_QueueRunner->run()
#6 [internal  in /sites/wp-content/plugins/action-scheduler/classes/ActionScheduler_WPCLI_QueueRunner.php on line 163
```

As well as the notice:

```
PHP Warning:  Missing argument 2 for ActionScheduler_WPCLI_QueueRunner::action_failed(), called in /sites/wp-includes/class-wp-hook.php on line 288 and defined in /sites/wp-content/plugins/action-scheduler/classes/ActionScheduler_WPCLI_QueueRunner.php on line 160
```