### PR TITLE
Claim actions by oldest ID

### DIFF
--- a/classes/ActionScheduler_wpPostStore.php
+++ b/classes/ActionScheduler_wpPostStore.php
@@ -497,7 +497,7 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 
 		$date = is_null($before_date) ? as_get_datetime_object() : clone $before_date;
 		// can't use $wpdb->update() because of the <= condition, using post_modified to take advantage of indexes
-		$sql = "UPDATE {$wpdb->posts} SET post_password = %s, post_modified_gmt = %s, post_modified = %s WHERE post_type = %s AND post_status = %s AND post_password = '' AND post_date_gmt <= %s ORDER BY menu_order ASC, post_date_gmt ASC LIMIT %d";
+		$sql = "UPDATE {$wpdb->posts} SET post_password = %s, post_modified_gmt = %s, post_modified = %s WHERE post_type = %s AND post_status = %s AND post_password = '' AND post_date_gmt <= %s ORDER BY menu_order ASC, post_date_gmt ASC, ID ASC LIMIT %d";
 		$sql = $wpdb->prepare( $sql, array( $claim_id, current_time('mysql', true), current_time('mysql'), self::POST_TYPE, 'pending', $date->format('Y-m-d H:i:s'), $limit ) );
 		$rows_affected = $wpdb->query($sql);
 		if ( $rows_affected === false ) {


### PR DESCRIPTION
Order actions by ID when staking a claim so that if multiple actions are scheduled for the same exact time (to the second), they will be run in the order in which they were created/scheduled.

However, be sure to apply the order only after ordering actions being claimed by number of previous attempts (`menu_order`) and scheduled date (`post_date_gmt`), to preserve backward compatibility.

Instigated by this [Slack conversation](https://woocommercecommunity.slack.com/archives/C4TNYTR28/p1525960776000345).