### PR TITLE
Add unit test for save_action() with 2nd param

### DIFF
--- a/tests/phpunit/jobstore/ActionScheduler_wpPostStore_Test.php
+++ b/tests/phpunit/jobstore/ActionScheduler_wpPostStore_Test.php
@@ -16,6 +16,17 @@ class ActionScheduler_wpPostStore_Test extends ActionScheduler_UnitTestCase {
 		$this->assertNotEmpty($action_id);
 	}
 
+	public function test_create_action_with_scheduled_date() {
+		$time   = as_get_datetime_object( strtotime( '-1 week' ) );
+		$action = new ActionScheduler_Action( 'my_hook', array(), new ActionScheduler_SimpleSchedule( $time ) );
+		$store  = new ActionScheduler_wpPostStore();
+
+		$action_id   = $store->save_action( $action, $time );
+		$action_date = $store->get_date( $action_id );
+
+		$this->assertEquals( $time->format( 'U' ), $action_date->format( 'U' ) );
+	}
+
 	public function test_retrieve_action() {
 		$time = as_get_datetime_object();
 		$schedule = new ActionScheduler_SimpleSchedule($time);


### PR DESCRIPTION
`ActionScheduler_Store::save_action()` accepts a 2nd param - `$date`, but this wasn't being tested.

NB: this will create a merge conflict with https://github.com/Prospress/action-scheduler/pull/144 as both are adding new unit tests, but that will be very straight forward to resolve. https://github.com/Prospress/action-scheduler/pull/144 should also be merged with priority over this PR.