### PR TITLE
Save last attempt date via ActionScheduler_Store::save_action()

### DIFF
--- a/classes/ActionScheduler_Store.php
+++ b/classes/ActionScheduler_Store.php
@@ -19,10 +19,12 @@ abstract class ActionScheduler_Store {
 	 * @param DateTime $date Optional date of the first instance
 	 *        to store. Otherwise uses the first date of the action's
 	 *        schedule.
+	 * @param DateTime $last_attempt_date Optional date of the last time
+	 *        the action was attempted. Otherwise set to 0000-00-00 00:00:00.
 	 *
 	 * @return string The action ID
 	 */
-	abstract public function save_action( ActionScheduler_Action $action, DateTime $date = NULL );
+	abstract public function save_action( ActionScheduler_Action $action, DateTime $date = NULL, DateTime $last_attempt_date = NULL );
 
 	/**
 	 * @param string $action_id

--- a/tests/phpunit/jobstore/ActionScheduler_wpPostStore_Test.php
+++ b/tests/phpunit/jobstore/ActionScheduler_wpPostStore_Test.php
@@ -28,9 +28,10 @@ class ActionScheduler_wpPostStore_Test extends ActionScheduler_UnitTestCase {
 
 		$this->assertEquals( $last_attempt_date->format( 'U' ), $action_date->format( 'U' ) );
 
-		$action_id   = $store->save_action( $action, $scheduled_date, $last_attempt_date );
-		$action_date = $store->get_date( $action_id );
+		$updated_id  = $store->save_action( $action, $scheduled_date, $last_attempt_date );
+		$action_date = $store->get_date( $updated_id );
 
+		$this->assertEquals( $action_id, $updated_id );
 		$this->assertEquals( $last_attempt_date->format( 'U' ), $action_date->format( 'U' ) );
 	}
 

--- a/tests/phpunit/jobstore/ActionScheduler_wpPostStore_Test.php
+++ b/tests/phpunit/jobstore/ActionScheduler_wpPostStore_Test.php
@@ -16,6 +16,24 @@ class ActionScheduler_wpPostStore_Test extends ActionScheduler_UnitTestCase {
 		$this->assertNotEmpty($action_id);
 	}
 
+	public function test_create_action_with_last_attempt_date() {
+		$scheduled_date    = as_get_datetime_object( strtotime( '-24 hours' ) );
+		$last_attempt_date = as_get_datetime_object( strtotime( '-23 hours' ) );
+
+		$action = new ActionScheduler_FinishedAction( 'my_hook', array(), new ActionScheduler_SimpleSchedule( $scheduled_date ) );
+		$store  = new ActionScheduler_wpPostStore();
+
+		$action_id   = $store->save_action( $action, null, $last_attempt_date );
+		$action_date = $store->get_date( $action_id );
+
+		$this->assertEquals( $last_attempt_date->format( 'U' ), $action_date->format( 'U' ) );
+
+		$action_id   = $store->save_action( $action, $scheduled_date, $last_attempt_date );
+		$action_date = $store->get_date( $action_id );
+
+		$this->assertEquals( $last_attempt_date->format( 'U' ), $action_date->format( 'U' ) );
+	}
+
 	public function test_retrieve_action() {
 		$time = as_get_datetime_object();
 		$schedule = new ActionScheduler_SimpleSchedule($time);


### PR DESCRIPTION
This PR is an alternative to #127  for resolving Prospress/action-scheduler-custom-tables#12.

I wanted to see if there was a simpler method to solve Prospress/action-scheduler-custom-tables#12 as I had a sense #127 was blowing out of proportion for what was needed - it has 25 commits, a changeset over 400 lines, and has been open for 2 months.

The approach used in this PR requires only one commit and a changeset of < 50 lines. It's also fully unit tested (i.e. 1 test) and (mostly) backward compatible.

The reason a simpler alternative is needed is because https://github.com/Prospress/action-scheduler-custom-tables/pull/12 is the final piece holding up both Subscriptions 2.3 RC, and Action Scheduler 2.0. 