### PR TITLE
Rename $date param on save_action()

### DIFF
--- a/classes/ActionScheduler_Store.php
+++ b/classes/ActionScheduler_Store.php
@@ -16,13 +16,13 @@ abstract class ActionScheduler_Store {
 
 	/**
 	 * @param ActionScheduler_Action $action
-	 * @param DateTime $date Optional date of the first instance
+	 * @param DateTime $scheduled_date Optional Date of the first instance
 	 *        to store. Otherwise uses the first date of the action's
 	 *        schedule.
 	 *
 	 * @return string The action ID
 	 */
-	abstract public function save_action( ActionScheduler_Action $action, DateTime $date = NULL );
+	abstract public function save_action( ActionScheduler_Action $action, DateTime $scheduled_date = NULL );
 
 	/**
 	 * @param string $action_id

--- a/classes/ActionScheduler_wpPostStore.php
+++ b/classes/ActionScheduler_wpPostStore.php
@@ -11,9 +11,9 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 	/** @var DateTimeZone */
 	protected $local_timezone = NULL;
 
-	public function save_action( ActionScheduler_Action $action, DateTime $date = NULL ){
+	public function save_action( ActionScheduler_Action $action, DateTime $scheduled_date = NULL ){
 		try {
-			$post_array = $this->create_post_array( $action, $date );
+			$post_array = $this->create_post_array( $action, $scheduled_date );
 			$post_id = $this->save_post_array( $post_array );
 			$this->save_post_schedule( $post_id, $action->get_schedule() );
 			$this->save_action_group( $post_id, $action->get_group() );
@@ -24,14 +24,14 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 		}
 	}
 
-	protected function create_post_array( ActionScheduler_Action $action, DateTime $date = NULL ) {
+	protected function create_post_array( ActionScheduler_Action $action, DateTime $scheduled_date = NULL ) {
 		$post = array(
 			'post_type' => self::POST_TYPE,
 			'post_title' => $action->get_hook(),
 			'post_content' => json_encode($action->get_args()),
 			'post_status' => ( $action->is_finished() ? 'publish' : 'pending' ),
-			'post_date_gmt' => $this->get_timestamp($action, $date),
-			'post_date' => $this->get_local_timestamp($action, $date),
+			'post_date_gmt' => $this->get_timestamp($action, $scheduled_date),
+			'post_date' => $this->get_local_timestamp($action, $scheduled_date),
 		);
 		return $post;
 	}


### PR DESCRIPTION
To make it more clear what type of date it refers to, which is particularly important now that `save_action()` will also accept a `$last_attempt_date` param once #144 is merged.

NB: this will create a merge conflict with #144, but that will be straight forward to resolve. #144 should be merged with priority over this PR. I've kept this patch separate to #144 to avoid it slowing down its merge for any reason.