### PR TITLE
Refactor scheduled date string APIs

### DIFF
--- a/classes/ActionScheduler_Store.php
+++ b/classes/ActionScheduler_Store.php
@@ -185,6 +185,15 @@ abstract class ActionScheduler_Store {
 	}
 
 	/**
+	 * Get the site's local time. Wrapper for ActionScheduler_TimezoneHelper::get_local_timezone().
+	 *
+	 * @return DateTimeZone
+	 */
+	protected function get_local_timezone() {
+		return ActionScheduler_TimezoneHelper::get_local_timezone();
+	}
+
+	/**
 	 * @return array
 	 */
 	public function get_status_labels() {

--- a/classes/ActionScheduler_Store.php
+++ b/classes/ActionScheduler_Store.php
@@ -151,6 +151,40 @@ abstract class ActionScheduler_Store {
 	}
 
 	/**
+	 * Get the time MySQL formated date/time string for an action's (next) scheduled date.
+	 *
+	 * @param ActionScheduler_Action $action
+	 * @param DateTime $scheduled_date (optional)
+	 * @return string
+	 */
+	protected function get_scheduled_date_string( ActionScheduler_Action $action, DateTime $scheduled_date = NULL ) {
+		$next = null === $scheduled_date ? $action->get_schedule()->next() : $scheduled_date;
+		if ( ! $next ) {
+			throw new InvalidArgumentException( __( 'Invalid schedule. Cannot save action.', 'action-scheduler' ) );
+		}
+		$next->setTimezone( new DateTimeZone( 'UTC' ) );
+
+		return $next->format( 'Y-m-d H:i:s' );
+	}
+
+	/**
+	 * Get the time MySQL formated date/time string for an action's (next) scheduled date.
+	 *
+	 * @param ActionScheduler_Action $action
+	 * @param DateTime $scheduled_date (optional)
+	 * @return string
+	 */
+	protected function get_scheduled_date_string_local( ActionScheduler_Action $action, DateTime $scheduled_date = NULL ) {
+		$next = null === $scheduled_date ? $action->get_schedule()->next() : $scheduled_date;
+		if ( ! $next ) {
+			throw new InvalidArgumentException( __( 'Invalid schedule. Cannot save action.', 'action-scheduler' ) );
+		}
+		$next->setTimezone( $this->get_local_timezone() );
+
+		return $next->format( 'Y-m-d H:i:s' );
+	}
+
+	/**
 	 * @return array
 	 */
 	public function get_status_labels() {
@@ -176,4 +210,3 @@ abstract class ActionScheduler_Store {
 		return self::$store;
 	}
 }
- 

--- a/classes/ActionScheduler_wpPostStore.php
+++ b/classes/ActionScheduler_wpPostStore.php
@@ -30,28 +30,10 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 			'post_title' => $action->get_hook(),
 			'post_content' => json_encode($action->get_args()),
 			'post_status' => ( $action->is_finished() ? 'publish' : 'pending' ),
-			'post_date_gmt' => $this->get_timestamp($action, $scheduled_date),
-			'post_date' => $this->get_local_timestamp($action, $scheduled_date),
+			'post_date_gmt' => $this->get_scheduled_date_string( $action, $scheduled_date ),
+			'post_date'     => $this->get_scheduled_date_string_local( $action, $scheduled_date ),
 		);
 		return $post;
-	}
-
-	protected function get_timestamp( ActionScheduler_Action $action, DateTime $date = NULL ) {
-		$next = is_null($date) ? $action->get_schedule()->next() : $date;
-		if ( !$next ) {
-			throw new InvalidArgumentException(__('Invalid schedule. Cannot save action.', 'action-scheduler'));
-		}
-		$next->setTimezone(new DateTimeZone('UTC'));
-		return $next->format('Y-m-d H:i:s');
-	}
-
-	protected function get_local_timestamp( ActionScheduler_Action $action, DateTime $date = NULL ) {
-		$next = is_null($date) ? $action->get_schedule()->next() : $date;
-		if ( !$next ) {
-			throw new InvalidArgumentException(__('Invalid schedule. Cannot save action.', 'action-scheduler'));
-		}
-		$next->setTimezone($this->get_local_timezone());
-		return $next->format('Y-m-d H:i:s');
 	}
 
 	protected function get_local_timezone() {

--- a/classes/ActionScheduler_wpPostStore.php
+++ b/classes/ActionScheduler_wpPostStore.php
@@ -36,10 +36,6 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 		return $post;
 	}
 
-	protected function get_local_timezone() {
-		return ActionScheduler_TimezoneHelper::get_local_timezone();
-	}
-
 	protected function save_post_array( $post_array ) {
 		add_filter( 'wp_insert_post_data', array( $this, 'filter_insert_post_data' ), 10, 1 );
 		$post_id = wp_insert_post($post_array);


### PR DESCRIPTION
The custom tables `DB_Store` class currently duplicates:

* `ActionScheduler_wpPostStore::get_timestamp()`
* `ActionScheduler_wpPostStore::get_local_timestamp()` and
* `ActionScheduler_wpPostStore::get_local_timezone()`

To avoid that, these methods can be moved into the shared `ActionScheduler_Store` base class. Which is part of what this PR proposes doing.

This also provides an opportunity to more accurately rename the first two of those methods, as the current method names indicate the methods return a Unix timestamp, when the actual return value is a MySQL formatted date/time string.

Because this patch is being proposed as part of v2.0, I've removed the previous `ActionScheduler_wpPostStore::get_timestamp()` methods instead of deprecating them, as it is a major release, so breaking backward compatibility is acceptable.
