### PR TITLE
Adding ability to execute actions by group

### DIFF
--- a/classes/ActionScheduler_Store.php
+++ b/classes/ActionScheduler_Store.php
@@ -70,12 +70,13 @@ abstract class ActionScheduler_Store {
 
 
 	/**
-	 * @param int $max_actions
+	 * @param int      $max_actions
 	 * @param DateTime $before_date Claim only actions schedule before the given date. Defaults to now.
+	 * @param string   $group       Claim only actions in the given group.
 	 *
 	 * @return ActionScheduler_ActionClaim
 	 */
-	abstract public function stake_claim( $max_actions = 10, DateTime $before_date = NULL );
+	abstract public function stake_claim( $max_actions = 10, DateTime $before_date = null, $group = '' );
 
 	/**
 	 * @return int

--- a/classes/ActionScheduler_WPCLI_QueueRunner.php
+++ b/classes/ActionScheduler_WPCLI_QueueRunner.php
@@ -38,13 +38,14 @@ class ActionScheduler_WPCLI_QueueRunner extends ActionScheduler_Abstract_QueueRu
 	 *
 	 * @author Jeremy Pry
 	 *
-	 * @param int  $batch_size The batch size to process.
-	 * @param bool $force      Whether to force running even with too many concurrent processes.
+	 * @param int    $batch_size The batch size to process.
+	 * @param string $group      The group of actions to claim with this batch.
+	 * @param bool   $force      Whether to force running even with too many concurrent processes.
 	 *
 	 * @return int The number of actions that will be run.
 	 * @throws \WP_CLI\ExitException When there are too many concurrent batches.
 	 */
-	public function setup( $batch_size, $force = false ) {
+	public function setup( $batch_size, $group = '', $force = false ) {
 		$this->run_cleanup();
 		$this->add_hooks();
 
@@ -60,7 +61,7 @@ class ActionScheduler_WPCLI_QueueRunner extends ActionScheduler_Abstract_QueueRu
 		}
 
 		// Stake a claim and store it.
-		$this->claim = $this->store->stake_claim( $batch_size );
+		$this->claim = $this->store->stake_claim( $batch_size, null, $group );
 		$this->monitor->attach( $this->claim );
 		$this->actions = $this->claim->get_actions();
 

--- a/classes/ActionScheduler_WPCLI_Scheduler_command.php
+++ b/classes/ActionScheduler_WPCLI_Scheduler_command.php
@@ -19,6 +19,9 @@ class ActionScheduler_WPCLI_Scheduler_command extends WP_CLI_Command {
 	 * [--cleanup-batch-size=<size>]
 	 * : The maximum number of actions to clean up. Defaults to the value of --batch-size.
 	 *
+	 * [--group=<group>]
+	 * : Only run actions from the specified group. Omitting this option runs actions from all groups.
+	 *
 	 * [--force]
 	 * : Whether to force execution despite the maximum number of concurrent processes being exceeded.
 	 *
@@ -31,6 +34,7 @@ class ActionScheduler_WPCLI_Scheduler_command extends WP_CLI_Command {
 		$batch   = absint( \WP_CLI\Utils\get_flag_value( $assoc_args, 'batch-size', 100 ) );
 		$batches = absint( \WP_CLI\Utils\get_flag_value( $assoc_args, 'batches', 0 ) );
 		$clean   = absint( \WP_CLI\Utils\get_flag_value( $assoc_args, 'cleanup-batch-size', $batch ) );
+		$group   = \WP_CLI\Utils\get_flag_value( $assoc_args, 'group', '' );
 		$force   = \WP_CLI\Utils\get_flag_value( $assoc_args, 'force', false );
 
 		$batches_completed = 0;
@@ -45,7 +49,7 @@ class ActionScheduler_WPCLI_Scheduler_command extends WP_CLI_Command {
 			$runner = new ActionScheduler_WPCLI_QueueRunner( null, null, $cleaner );
 
 			// Determine how many tasks will be run in the first batch.
-			$total = $runner->setup( $batch, $force );
+			$total = $runner->setup( $batch, $group, $force );
 
 			// Run actions for as long as possible.
 			while ( $total > 0 ) {


### PR DESCRIPTION
This adds the ability for Action Scheduler to claim actions based on a given group.

* `ActionScheduler_Store::stake_claim()` (as well as child classes) now include a `$group` parameter. When a group is passed, only actions in that group will be returned. When omitted, all matching actions regardless of a group (or no group) will be returned.
* `ActionScheduler_WPCLI_QueueRunner::setup()` also includes a `$group` parameter. 
* `ActionScheduler_WPCLI_Scheduler_Command` now allows passing `--group=<group>` using WP CLI.

Fixes #121 