### PR TITLE
Support hooks filter when staking a claim and add a WP CLI --hooks option to take advantage of it

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ These are the commands available to use with Action Scheduler:
     Options:
     * `--batch-size` - This is the number of actions to run in a single batch. The default is `100`.
     * `--batches` - This is the number of batches to run. Using 0 means that batches will continue running until there are no more actions to run.
-    * `--hooks` - Process only actions with specific hook or hooks, like `'woocommerce_scheduled_subscription_payment'`. By default, actions with any hook will be processed.
+    * `--hooks` - Process only actions with specific hook or hooks, like `'woocommerce_scheduled_subscription_payment'`. By default, actions with any hook will be processed. Define multiple hooks as a comma separated string (without spaces), e.g. `--hooks=woocommerce_scheduled_subscription_trial_end,woocommerce_scheduled_subscription_payment,woocommerce_scheduled_subscription_expiration`
     * `--group` - Process only actions in a specific group, like `'woocommerce-memberships'`. By default, actions in any group (or no group) will be processed.
     * `--force` - By default, Action Scheduler limits the number of concurrent batches that can be run at once to ensure the server does not get overwhelmed. Using the `--force` flag overrides this behavior to force the WP CLI queue to run.
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ These are the commands available to use with Action Scheduler:
     Options:
     * `--batch-size` - This is the number of actions to run in a single batch. The default is `100`.
     * `--batches` - This is the number of batches to run. Using 0 means that batches will continue running until there are no more actions to run.
+    * `--hooks` - Process only actions with specific hook or hooks, like `'woocommerce_scheduled_subscription_payment'`. By default, actions with any hook will be processed.
     * `--group` - Process only actions in a specific group, like `'woocommerce-memberships'`. By default, actions in any group (or no group) will be processed.
     * `--force` - By default, Action Scheduler limits the number of concurrent batches that can be run at once to ensure the server does not get overwhelmed. Using the `--force` flag overrides this behavior to force the WP CLI queue to run.
 

--- a/classes/ActionScheduler_Store.php
+++ b/classes/ActionScheduler_Store.php
@@ -72,11 +72,12 @@ abstract class ActionScheduler_Store {
 	/**
 	 * @param int      $max_actions
 	 * @param DateTime $before_date Claim only actions schedule before the given date. Defaults to now.
+	 * @param array    $hooks       Claim only actions with a hook or hooks.
 	 * @param string   $group       Claim only actions in the given group.
 	 *
 	 * @return ActionScheduler_ActionClaim
 	 */
-	abstract public function stake_claim( $max_actions = 10, DateTime $before_date = null, $group = '' );
+	abstract public function stake_claim( $max_actions = 10, DateTime $before_date = null, $hooks = array(), $group = '' );
 
 	/**
 	 * @return int

--- a/classes/ActionScheduler_WPCLI_QueueRunner.php
+++ b/classes/ActionScheduler_WPCLI_QueueRunner.php
@@ -39,13 +39,14 @@ class ActionScheduler_WPCLI_QueueRunner extends ActionScheduler_Abstract_QueueRu
 	 * @author Jeremy Pry
 	 *
 	 * @param int    $batch_size The batch size to process.
+	 * @param array  $hooks      The hooks being used to filter the actions claimed in this batch.
 	 * @param string $group      The group of actions to claim with this batch.
 	 * @param bool   $force      Whether to force running even with too many concurrent processes.
 	 *
 	 * @return int The number of actions that will be run.
 	 * @throws \WP_CLI\ExitException When there are too many concurrent batches.
 	 */
-	public function setup( $batch_size, $group = '', $force = false ) {
+	public function setup( $batch_size, $hooks = array(), $group = '', $force = false ) {
 		$this->run_cleanup();
 		$this->add_hooks();
 
@@ -61,7 +62,7 @@ class ActionScheduler_WPCLI_QueueRunner extends ActionScheduler_Abstract_QueueRu
 		}
 
 		// Stake a claim and store it.
-		$this->claim = $this->store->stake_claim( $batch_size, null, $group );
+		$this->claim = $this->store->stake_claim( $batch_size, null, $hooks, $group );
 		$this->monitor->attach( $this->claim );
 		$this->actions = $this->claim->get_actions();
 

--- a/classes/ActionScheduler_WPCLI_Scheduler_command.php
+++ b/classes/ActionScheduler_WPCLI_Scheduler_command.php
@@ -37,7 +37,8 @@ class ActionScheduler_WPCLI_Scheduler_command extends WP_CLI_Command {
 		$batch   = absint( \WP_CLI\Utils\get_flag_value( $assoc_args, 'batch-size', 100 ) );
 		$batches = absint( \WP_CLI\Utils\get_flag_value( $assoc_args, 'batches', 0 ) );
 		$clean   = absint( \WP_CLI\Utils\get_flag_value( $assoc_args, 'cleanup-batch-size', $batch ) );
-		$hooks   = explode( ',', trim( \WP_CLI\Utils\get_flag_value( $assoc_args, 'hooks', array() ) ) );
+		$hooks   = explode( ',', WP_CLI\Utils\get_flag_value( $assoc_args, 'hooks', '' ) );
+		$hooks   = array_filter( array_map( 'trim', $hooks ) );
 		$group   = \WP_CLI\Utils\get_flag_value( $assoc_args, 'group', '' );
 		$force   = \WP_CLI\Utils\get_flag_value( $assoc_args, 'force', false );
 

--- a/classes/ActionScheduler_WPCLI_Scheduler_command.php
+++ b/classes/ActionScheduler_WPCLI_Scheduler_command.php
@@ -19,6 +19,9 @@ class ActionScheduler_WPCLI_Scheduler_command extends WP_CLI_Command {
 	 * [--cleanup-batch-size=<size>]
 	 * : The maximum number of actions to clean up. Defaults to the value of --batch-size.
 	 *
+	 * [--hooks=<hooks>]
+	 * : Only run actions with the specified hook. Omitting this option runs actions with any hook.
+	 *
 	 * [--group=<group>]
 	 * : Only run actions from the specified group. Omitting this option runs actions from all groups.
 	 *
@@ -34,6 +37,7 @@ class ActionScheduler_WPCLI_Scheduler_command extends WP_CLI_Command {
 		$batch   = absint( \WP_CLI\Utils\get_flag_value( $assoc_args, 'batch-size', 100 ) );
 		$batches = absint( \WP_CLI\Utils\get_flag_value( $assoc_args, 'batches', 0 ) );
 		$clean   = absint( \WP_CLI\Utils\get_flag_value( $assoc_args, 'cleanup-batch-size', $batch ) );
+		$hooks   = \WP_CLI\Utils\get_flag_value( $assoc_args, 'hooks', array() );
 		$group   = \WP_CLI\Utils\get_flag_value( $assoc_args, 'group', '' );
 		$force   = \WP_CLI\Utils\get_flag_value( $assoc_args, 'force', false );
 
@@ -49,7 +53,7 @@ class ActionScheduler_WPCLI_Scheduler_command extends WP_CLI_Command {
 			$runner = new ActionScheduler_WPCLI_QueueRunner( null, null, $cleaner );
 
 			// Determine how many tasks will be run in the first batch.
-			$total = $runner->setup( $batch, $group, $force );
+			$total = $runner->setup( $batch, $hooks, $group, $force );
 
 			// Run actions for as long as possible.
 			while ( $total > 0 ) {

--- a/classes/ActionScheduler_WPCLI_Scheduler_command.php
+++ b/classes/ActionScheduler_WPCLI_Scheduler_command.php
@@ -20,7 +20,7 @@ class ActionScheduler_WPCLI_Scheduler_command extends WP_CLI_Command {
 	 * : The maximum number of actions to clean up. Defaults to the value of --batch-size.
 	 *
 	 * [--hooks=<hooks>]
-	 * : Only run actions with the specified hook. Omitting this option runs actions with any hook.
+	 * : Only run actions with the specified hook. Omitting this option runs actions with any hook. Define multiple hooks as a comma separated string (without spaces), e.g. `--hooks=hook_one,hook_two,hook_three`
 	 *
 	 * [--group=<group>]
 	 * : Only run actions from the specified group. Omitting this option runs actions from all groups.
@@ -37,7 +37,7 @@ class ActionScheduler_WPCLI_Scheduler_command extends WP_CLI_Command {
 		$batch   = absint( \WP_CLI\Utils\get_flag_value( $assoc_args, 'batch-size', 100 ) );
 		$batches = absint( \WP_CLI\Utils\get_flag_value( $assoc_args, 'batches', 0 ) );
 		$clean   = absint( \WP_CLI\Utils\get_flag_value( $assoc_args, 'cleanup-batch-size', $batch ) );
-		$hooks   = \WP_CLI\Utils\get_flag_value( $assoc_args, 'hooks', array() );
+		$hooks   = explode( ',', trim( \WP_CLI\Utils\get_flag_value( $assoc_args, 'hooks', array() ) ) );
 		$group   = \WP_CLI\Utils\get_flag_value( $assoc_args, 'group', '' );
 		$force   = \WP_CLI\Utils\get_flag_value( $assoc_args, 'force', false );
 

--- a/classes/ActionScheduler_wpPostStore.php
+++ b/classes/ActionScheduler_wpPostStore.php
@@ -438,15 +438,16 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 	/**
 	 * @param int      $max_actions
 	 * @param DateTime $before_date Jobs must be schedule before this date. Defaults to now.
+	 * @param array    $hooks       Claim only actions with a hook or hooks.
 	 * @param string   $group       Claim only actions in the given group.
 	 *
 	 * @return ActionScheduler_ActionClaim
 	 * @throws RuntimeException When there is an error staking a claim.
 	 * @throws InvalidArgumentException When the given group is not valid.
 	 */
-	public function stake_claim( $max_actions = 10, DateTime $before_date = null, $group = '' ) {
+	public function stake_claim( $max_actions = 10, DateTime $before_date = null, $hooks = array(), $group = '' ) {
 		$claim_id = $this->generate_claim_id();
-		$this->claim_actions( $claim_id, $max_actions, $before_date, $group );
+		$this->claim_actions( $claim_id, $max_actions, $before_date, $hooks, $group );
 		$action_ids = $this->find_actions_by_claim_id( $claim_id );
 
 		return new ActionScheduler_ActionClaim( $claim_id, $action_ids );
@@ -473,13 +474,14 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 	 * @param string   $claim_id
 	 * @param int      $limit
 	 * @param DateTime $before_date Should use UTC timezone.
+	 * @param array    $hooks       Claim only actions with a hook or hooks.
 	 * @param string   $group       Claim only actions in the given group.
 	 *
 	 * @return int The number of actions that were claimed
 	 * @throws RuntimeException When there is a database error.
 	 * @throws InvalidArgumentException When the group is invalid.
 	 */
-	protected function claim_actions( $claim_id, $limit, DateTime $before_date = null, $group = '' ) {
+	protected function claim_actions( $claim_id, $limit, DateTime $before_date = null, $hooks = array(), $group = '' ) {
 		// Set up initial variables.
 		$date      = null === $before_date ? as_get_datetime_object() : clone $before_date;
 		$limit_ids = ! empty( $group );
@@ -510,6 +512,12 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 		$where    = "WHERE post_type = %s AND post_status = %s AND post_password = ''";
 		$params[] = self::POST_TYPE;
 		$params[] = ActionScheduler_Store::STATUS_PENDING;
+
+		if ( ! empty( $hooks ) ) {
+			$placeholders = array_fill( 0, count( $hooks ), '%s' );
+			$where       .= ' AND post_title IN (' . join( ', ', $placeholders ) . ')';
+			$params       = array_merge( $params, array_values( $hooks ) );
+		}
 
 		/*
 		 * Add the IDs to the WHERE clause. IDs not escaped because they came directly from a prior DB query.

--- a/classes/ActionScheduler_wpPostStore.php
+++ b/classes/ActionScheduler_wpPostStore.php
@@ -550,7 +550,7 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 	protected function get_actions_by_group( $group, $limit, DateTime $date ) {
 		// Ensure the group exists before continuing.
 		if ( ! term_exists( $group, self::GROUP_TAXONOMY )) {
-			throw new InvalidArgumentException( __( 'The group "%s" does not exist.', 'action-scheduler' ), $group );
+			throw new InvalidArgumentException( sprintf( __( 'The group "%s" does not exist.', 'action-scheduler' ), $group ) );
 		}
 
 		// Set up a query for post IDs to use later.


### PR DESCRIPTION
This is a quick prototype to see what it would take to implement #160. Still a WIP - I need to test passing arrays with the `--hooks` option for WP CLI to ensure it works. It appears the syntax is just comma separated strings, e.g.

```
action-scheduler run --hooks=woocommerce_scheduled_subscription_trial_end,woocommerce_scheduled_subscription_expiration
```

Also need to add docs to the README once I confirm the syntax for that.