### PR TITLE
Implement custom DateTime class

### DIFF
--- a/classes/ActionScheduler_CronSchedule.php
+++ b/classes/ActionScheduler_CronSchedule.php
@@ -36,7 +36,7 @@ class ActionScheduler_CronSchedule implements ActionScheduler_Schedule {
 	 * @return array
 	 */
 	public function __sleep() {
-		$this->start_timestamp = $this->start->format('U');
+		$this->start_timestamp = $this->start->getTimestamp();
 		return array(
 			'start_timestamp',
 			'cron'

--- a/classes/ActionScheduler_DateTime.php
+++ b/classes/ActionScheduler_DateTime.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * ActionScheduler DateTime class.
+ *
+ * This is a custom extension to DateTime that
+ */
+class ActionScheduler_DateTime extends DateTime {
+
+	/**
+	 * Get the unix timestamp of the current object.
+	 *
+	 * Missing in PHP 5.2 so just here so it can be supported consistently.
+	 *
+	 * @return int
+	 */
+	public function getTimestamp() {
+		return method_exists( 'DateTime', 'getTimestamp' ) ? parent::getTimestamp() : $this->format( 'U' );
+	}
+}

--- a/classes/ActionScheduler_IntervalSchedule.php
+++ b/classes/ActionScheduler_IntervalSchedule.php
@@ -49,7 +49,7 @@ class ActionScheduler_IntervalSchedule implements ActionScheduler_Schedule {
 	 * @return array
 	 */
 	public function __sleep() {
-		$this->start_timestamp = $this->start->format('U');
+		$this->start_timestamp = $this->start->getTimestamp();
 		return array(
 			'start_timestamp',
 			'interval_in_seconds'
@@ -60,4 +60,3 @@ class ActionScheduler_IntervalSchedule implements ActionScheduler_Schedule {
 		$this->start = as_get_datetime_object($this->start_timestamp);
 	}
 }
- 

--- a/classes/ActionScheduler_ListTable.php
+++ b/classes/ActionScheduler_ListTable.php
@@ -374,7 +374,7 @@ class ActionScheduler_ListTable extends PP_List_Table {
 			return $schedule_display_string;
 		}
 
-		$next_timestamp = $schedule->next()->format( 'U' );
+		$next_timestamp = $schedule->next()->getTimestamp();
 
 		$schedule_display_string .= $schedule->next()->format( 'Y-m-d H:i:s e' );
 		$schedule_display_string .= '<br/>';

--- a/classes/ActionScheduler_SimpleSchedule.php
+++ b/classes/ActionScheduler_SimpleSchedule.php
@@ -32,7 +32,7 @@ class ActionScheduler_SimpleSchedule implements ActionScheduler_Schedule {
 	 * @return array
 	 */
 	public function __sleep() {
-		$this->timestamp = $this->date->format('U');
+		$this->timestamp = $this->date->getTimestamp();
 		return array(
 			'timestamp',
 		);
@@ -42,4 +42,3 @@ class ActionScheduler_SimpleSchedule implements ActionScheduler_Schedule {
 		$this->date = as_get_datetime_object($this->timestamp);
 	}
 }
- 

--- a/functions.php
+++ b/functions.php
@@ -172,15 +172,15 @@ function wc_get_scheduled_actions( $args = array(), $return_format = OBJECT ) {
  * @param mixed $date_string A date/time string. Valid formats are explained in http://php.net/manual/en/datetime.formats.php
  * @param string $timezone A timezone identifier, like UTC or Europe/Lisbon. The list of valid identifiers is available http://php.net/manual/en/timezones.php
  *
- * @return DateTime
+ * @return ActionScheduler_DateTime
  */
 function as_get_datetime_object( $date_string = null, $timezone = 'UTC' ) {
-	if ( is_object($date_string) && $date_string instanceof DateTime ) {
-		$date = $date_string->setTimezone(new DateTimeZone( $timezone ) );
+	if ( is_object( $date_string ) && $date_string instanceof DateTime ) {
+		$date = new ActionScheduler_DateTime( $date_string->format( 'Y-m-d H:i:s' ), new DateTimeZone( $timezone ) );
 	} elseif ( is_numeric( $date_string ) ) {
-		$date = new DateTime( '@'.$date_string, new DateTimeZone( $timezone ) );
+		$date = new ActionScheduler_DateTime( '@' . $date_string, new DateTimeZone( $timezone ) );
 	} else {
-		$date = new DateTime( $date_string, new DateTimeZone( $timezone ) );
+		$date = new ActionScheduler_DateTime( $date_string, new DateTimeZone( $timezone ) );
 	}
 	return $date;
 }

--- a/lib/cron-expression/CronExpression.php
+++ b/lib/cron-expression/CronExpression.php
@@ -240,10 +240,10 @@ class CronExpression
             $currentTime = new DateTime($currentTime);
             $currentTime->setTime($currentTime->format('H'), $currentTime->format('i'), 0);
             $currentDate = $currentTime->format('Y-m-d H:i');
-            $currentTime = (int)($currentTime->format('U'));
+            $currentTime = (int)($currentTime->getTimestamp());
         }
 
-        return $this->getNextRunDate($currentDate, 0, true)->format('U') == $currentTime;
+        return $this->getNextRunDate($currentDate, 0, true)->getTimestamp() == $currentTime;
     }
 
     /**

--- a/tests/phpunit/jobstore/ActionScheduler_wpPostStore_Test.php
+++ b/tests/phpunit/jobstore/ActionScheduler_wpPostStore_Test.php
@@ -24,7 +24,7 @@ class ActionScheduler_wpPostStore_Test extends ActionScheduler_UnitTestCase {
 		$action_id   = $store->save_action( $action, $time );
 		$action_date = $store->get_date( $action_id );
 
-		$this->assertEquals( $time->format( 'U' ), $action_date->format( 'U' ) );
+		$this->assertEquals( $time->getTimestamp(), $action_date->getTimestamp() );
 	}
 
 	public function test_retrieve_action() {
@@ -37,7 +37,7 @@ class ActionScheduler_wpPostStore_Test extends ActionScheduler_UnitTestCase {
 		$retrieved = $store->fetch_action($action_id);
 		$this->assertEquals($action->get_hook(), $retrieved->get_hook());
 		$this->assertEqualSets($action->get_args(), $retrieved->get_args());
-		$this->assertEquals($action->get_schedule()->next()->format('U'), $retrieved->get_schedule()->next()->format('U'));
+		$this->assertEquals($action->get_schedule()->next()->getTimestamp(), $retrieved->get_schedule()->next()->getTimestamp());
 		$this->assertEquals($action->get_group(), $retrieved->get_group());
 	}
 
@@ -216,19 +216,19 @@ class ActionScheduler_wpPostStore_Test extends ActionScheduler_UnitTestCase {
 		$store = new ActionScheduler_wpPostStore();
 		$action_id = $store->save_action($action);
 
-		$this->assertEquals( $store->get_date($action_id)->format('U'), $time->format('U') );
+		$this->assertEquals( $store->get_date($action_id)->getTimestamp(), $time->getTimestamp() );
 
 		$action = $store->fetch_action($action_id);
 		$action->execute();
 		$now = as_get_datetime_object();
 		$store->mark_complete( $action_id );
 
-		$this->assertEquals( $store->get_date($action_id)->format('U'), $now->format('U') );
+		$this->assertEquals( $store->get_date($action_id)->getTimestamp(), $now->getTimestamp() );
 
 		$next = $action->get_schedule()->next( $now );
 		$new_action_id = $store->save_action( $action, $next );
 
-		$this->assertEquals( (int)($now->format('U')) + HOUR_IN_SECONDS, $store->get_date($new_action_id)->format('U') );
+		$this->assertEquals( (int)($now->getTimestamp()) + HOUR_IN_SECONDS, $store->get_date($new_action_id)->getTimestamp() );
 	}
 
 	public function test_get_status() {

--- a/tests/phpunit/procedural_api/procedural_api_Test.php
+++ b/tests/phpunit/procedural_api/procedural_api_Test.php
@@ -12,7 +12,7 @@ class procedural_api_Test extends ActionScheduler_UnitTestCase {
 
 		$store = ActionScheduler::store();
 		$action = $store->fetch_action($action_id);
-		$this->assertEquals( $time, $action->get_schedule()->next()->format('U') );
+		$this->assertEquals( $time, $action->get_schedule()->next()->getTimestamp() );
 		$this->assertEquals( $hook, $action->get_hook() );
 	}
 
@@ -23,31 +23,31 @@ class procedural_api_Test extends ActionScheduler_UnitTestCase {
 
 		$store = ActionScheduler::store();
 		$action = $store->fetch_action($action_id);
-		$this->assertEquals( $time, $action->get_schedule()->next()->format('U') );
-		$this->assertEquals( $time + HOUR_IN_SECONDS + 2, $action->get_schedule()->next(as_get_datetime_object($time + 2))->format('U'));
+		$this->assertEquals( $time, $action->get_schedule()->next()->getTimestamp() );
+		$this->assertEquals( $time + HOUR_IN_SECONDS + 2, $action->get_schedule()->next(as_get_datetime_object($time + 2))->getTimestamp());
 		$this->assertEquals( $hook, $action->get_hook() );
 	}
 
 	public function test_cron_schedule() {
 		$time = as_get_datetime_object('2014-01-01');
 		$hook = md5(rand());
-		$action_id = wc_schedule_cron_action( $time->format('U'), '0 0 10 10 *', $hook );
+		$action_id = wc_schedule_cron_action( $time->getTimestamp(), '0 0 10 10 *', $hook );
 
 		$store = ActionScheduler::store();
 		$action = $store->fetch_action($action_id);
 		$expected_date = as_get_datetime_object('2014-10-10');
-		$this->assertEquals( $expected_date->format('U'), $action->get_schedule()->next()->format('U') );
+		$this->assertEquals( $expected_date->getTimestamp(), $action->get_schedule()->next()->getTimestamp() );
 		$this->assertEquals( $hook, $action->get_hook() );
 	}
 
 	public function test_get_next() {
 		$time = as_get_datetime_object('tomorrow');
 		$hook = md5(rand());
-		wc_schedule_recurring_action( $time->format('U'), HOUR_IN_SECONDS, $hook );
+		wc_schedule_recurring_action( $time->getTimestamp(), HOUR_IN_SECONDS, $hook );
 
 		$next = wc_next_scheduled_action( $hook );
 
-		$this->assertEquals( $time->format('U'), $next );
+		$this->assertEquals( $time->getTimestamp(), $next );
 	}
 
 	public function test_unschedule() {
@@ -69,7 +69,7 @@ class procedural_api_Test extends ActionScheduler_UnitTestCase {
 
 	public function test_as_get_datetime_object_default() {
 
-		$utc_now = new DateTime(null, new DateTimeZone('UTC'));
+		$utc_now = new ActionScheduler_DateTime(null, new DateTimeZone('UTC'));
 		$as_now  = as_get_datetime_object();
 
 		// Don't want to use 'U' as timestamps will always be in UTC
@@ -78,12 +78,12 @@ class procedural_api_Test extends ActionScheduler_UnitTestCase {
 
 	public function test_as_get_datetime_object_relative() {
 
-		$utc_tomorrow = new DateTime('tomorrow', new DateTimeZone('UTC'));
+		$utc_tomorrow = new ActionScheduler_DateTime('tomorrow', new DateTimeZone('UTC'));
 		$as_tomorrow  = as_get_datetime_object('tomorrow');
 
 		$this->assertEquals($utc_tomorrow->format('Y-m-d H:i:s'),$as_tomorrow->format('Y-m-d H:i:s'));
 
-		$utc_tomorrow = new DateTime('yesterday', new DateTimeZone('UTC'));
+		$utc_tomorrow = new ActionScheduler_DateTime('yesterday', new DateTimeZone('UTC'));
 		$as_tomorrow  = as_get_datetime_object('yesterday');
 
 		$this->assertEquals($utc_tomorrow->format('Y-m-d H:i:s'),$as_tomorrow->format('Y-m-d H:i:s'));
@@ -91,12 +91,12 @@ class procedural_api_Test extends ActionScheduler_UnitTestCase {
 
 	public function test_as_get_datetime_object_fixed() {
 
-		$utc_tomorrow = new DateTime('29 February 2016', new DateTimeZone('UTC'));
+		$utc_tomorrow = new ActionScheduler_DateTime('29 February 2016', new DateTimeZone('UTC'));
 		$as_tomorrow  = as_get_datetime_object('29 February 2016');
 
 		$this->assertEquals($utc_tomorrow->format('Y-m-d H:i:s'),$as_tomorrow->format('Y-m-d H:i:s'));
 
-		$utc_tomorrow = new DateTime('1st January 2024', new DateTimeZone('UTC'));
+		$utc_tomorrow = new ActionScheduler_DateTime('1st January 2024', new DateTimeZone('UTC'));
 		$as_tomorrow  = as_get_datetime_object('1st January 2024');
 
 		$this->assertEquals($utc_tomorrow->format('Y-m-d H:i:s'),$as_tomorrow->format('Y-m-d H:i:s'));
@@ -109,19 +109,19 @@ class procedural_api_Test extends ActionScheduler_UnitTestCase {
 
 		date_default_timezone_set( $timezone_au );
 
-		$au_now = new DateTime(null);
+		$au_now = new ActionScheduler_DateTime(null);
 		$as_now = as_get_datetime_object();
 
 		// Make sure they're for the same time
-		$this->assertEquals($au_now->format('U'),$as_now->format('U'));
+		$this->assertEquals($au_now->getTimestamp(),$as_now->getTimestamp());
 
 		// But not in the same timezone, as $as_now should be using UTC
 		$this->assertNotEquals($au_now->format('Y-m-d H:i:s'),$as_now->format('Y-m-d H:i:s'));
 
-		$au_now    = new DateTime(null);
+		$au_now    = new ActionScheduler_DateTime(null);
 		$as_au_now = as_get_datetime_object();
 
-		$this->assertEquals($au_now->format('U'),$as_now->format('U'));
+		$this->assertEquals($au_now->getTimestamp(),$as_now->getTimestamp());
 
 		// But not in the same timezone, as $as_now should be using UTC
 		$this->assertNotEquals($au_now->format('Y-m-d H:i:s'),$as_now->format('Y-m-d H:i:s'));
@@ -130,4 +130,3 @@ class procedural_api_Test extends ActionScheduler_UnitTestCase {
 		date_default_timezone_set( $timezone_default );
 	}
 }
- 

--- a/tests/phpunit/procedural_api/procedural_api_Test.php
+++ b/tests/phpunit/procedural_api/procedural_api_Test.php
@@ -129,4 +129,14 @@ class procedural_api_Test extends ActionScheduler_UnitTestCase {
 		// Just in cases
 		date_default_timezone_set( $timezone_default );
 	}
+
+	public function test_as_get_datetime_object_type() {
+		$f   = 'Y-m-d H:i:s';
+		$now = as_get_datetime_object();
+		$this->assertInstanceOf( 'ActionScheduler_DateTime', $now );
+
+		$dateTime   = new DateTime( 'now', new DateTimeZone( 'UTC' ) );
+		$asDateTime = as_get_datetime_object( $dateTime );
+		$this->assertEquals( $dateTime->format( $f ), $asDateTime->format( $f ) );
+	}
 }

--- a/tests/phpunit/runner/ActionScheduler_QueueRunner_Test.php
+++ b/tests/phpunit/runner/ActionScheduler_QueueRunner_Test.php
@@ -104,7 +104,7 @@ class ActionScheduler_QueueRunner_Test extends ActionScheduler_UnitTestCase {
 
 
 		$this->assertEquals( $random, $new_action->get_hook() );
-		$this->assertEquals( $schedule->next(as_get_datetime_object())->format( 'U' ), $new_action->get_schedule()->next(as_get_datetime_object())->format( 'U' ) );
+		$this->assertEquals( $schedule->next(as_get_datetime_object())->getTimestamp(), $new_action->get_schedule()->next(as_get_datetime_object())->getTimestamp() );
 	}
 
 	public function test_hooked_into_wp_cron() {
@@ -119,7 +119,7 @@ class ActionScheduler_QueueRunner_Test extends ActionScheduler_UnitTestCase {
 		$mock = new MockAction();
 		$random = md5(rand());
 		add_action( $random, array( $mock, 'action' ) );
-		$schedule = new ActionScheduler_SimpleSchedule(new DateTime('1 day ago'));
+		$schedule = new ActionScheduler_SimpleSchedule(new ActionScheduler_DateTime('1 day ago'));
 
 		for ( $i = 0 ; $i < 30 ; $i++ ) {
 			$action = new ActionScheduler_Action( $random, array($random), $schedule );
@@ -153,7 +153,7 @@ class ActionScheduler_QueueRunner_Test extends ActionScheduler_UnitTestCase {
 		$runner = new ActionScheduler_QueueRunner( $store );
 
 		$random = md5(rand());
-		$schedule = new ActionScheduler_SimpleSchedule(new DateTime('1 day ago'));
+		$schedule = new ActionScheduler_SimpleSchedule(new ActionScheduler_DateTime('1 day ago'));
 
 		for ( $i = 0 ; $i < 30 ; $i++ ) {
 			$action = new ActionScheduler_Action( $random, array($random), $schedule );
@@ -207,4 +207,3 @@ class ActionScheduler_QueueRunner_Test extends ActionScheduler_UnitTestCase {
 		return 6;
 	}
 }
- 

--- a/tests/phpunit/schedules/ActionScheduler_IntervalSchedule_Test.php
+++ b/tests/phpunit/schedules/ActionScheduler_IntervalSchedule_Test.php
@@ -15,9 +15,9 @@ class ActionScheduler_IntervalSchedule_Test extends ActionScheduler_UnitTestCase
 		$now = time();
 		$start = $now - 30;
 		$schedule = new ActionScheduler_IntervalSchedule( as_get_datetime_object("@$start"), MINUTE_IN_SECONDS );
-		$this->assertEquals( $start, $schedule->next()->format('U') );
-		$this->assertEquals( $now + MINUTE_IN_SECONDS, $schedule->next(as_get_datetime_object())->format('U') );
-		$this->assertEquals( $start, $schedule->next(as_get_datetime_object("@$start"))->format('U') );
+		$this->assertEquals( $start, $schedule->next()->getTimestamp() );
+		$this->assertEquals( $now + MINUTE_IN_SECONDS, $schedule->next(as_get_datetime_object())->getTimestamp() );
+		$this->assertEquals( $start, $schedule->next(as_get_datetime_object("@$start"))->getTimestamp() );
 	}
 
 	public function test_is_recurring() {
@@ -26,4 +26,3 @@ class ActionScheduler_IntervalSchedule_Test extends ActionScheduler_UnitTestCase
 		$this->assertTrue( $schedule->is_recurring() );
 	}
 }
- 


### PR DESCRIPTION
Fixes #120.

This does the following:

* Creates a custom class, `ActionScheduler_DateTime`. For now, this class simply implements the `getTimestamp()` method to ensure compatibility with PHP 5.2.
* Uses the new class everywhere in the plugin
* Adds a unit test for the `as_get_datetime_object()` function