### PR TITLE
Use `get_allowed_concurrent_batches()` method for WP CLI

### DIFF
--- a/classes/ActionScheduler_WPCLI_QueueRunner.php
+++ b/classes/ActionScheduler_WPCLI_QueueRunner.php
@@ -51,7 +51,7 @@ class ActionScheduler_WPCLI_QueueRunner extends ActionScheduler_Abstract_QueueRu
 
 		// Check to make sure there aren't too many concurrent processes running.
 		$claim_count = $this->store->get_claim_count();
-		$too_many    = $claim_count >= apply_filters( 'action_scheduler_queue_runner_concurrent_batches', 5 );
+		$too_many    = $claim_count >= $this->get_allowed_concurrent_batches();
 		if ( $too_many ) {
 			if ( $force ) {
 				WP_CLI::warning( __( 'There are too many concurrent batches, but the run is forced to continue.', 'action-scheduler' ) );


### PR DESCRIPTION
Fixes #141.