### PR TITLE
When querying actions ordered by 'group', include joins on term tables

### DIFF
--- a/classes/ActionScheduler_wpPostStore.php
+++ b/classes/ActionScheduler_wpPostStore.php
@@ -243,11 +243,15 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 		$sql  = ( 'count' === $select_or_count ) ? 'SELECT count(p.ID)' : 'SELECT p.ID ';
 		$sql .= "FROM {$wpdb->posts} p";
 		$sql_params = array();
-		if ( !empty($query['group']) ) {
+		if ( ! empty( $query['group'] ) || 'group' === $query['orderby'] ) {
 			$sql .= " INNER JOIN {$wpdb->term_relationships} tr ON tr.object_id=p.ID";
 			$sql .= " INNER JOIN {$wpdb->term_taxonomy} tt ON tr.term_taxonomy_id=tt.term_taxonomy_id";
-			$sql .= " INNER JOIN {$wpdb->terms} t ON tt.term_id=t.term_id AND t.slug=%s";
-			$sql_params[] = $query['group'];
+			$sql .= " INNER JOIN {$wpdb->terms} t ON tt.term_id=t.term_id";
+
+			if ( ! empty( $query['group'] ) ) {
+				$sql .= " AND t.slug=%s";
+				$sql_params[] = $query['group'];
+			}
 		}
 		$sql .= " WHERE post_type=%s";
 		$sql_params[] = self::POST_TYPE;


### PR DESCRIPTION
Part of #151 

To replicate: 
 
1. Go to the scheduled actions table.
1. Order the table by "group". 
1. You should receive the following error: 

```
WordPress database error Unknown column 't.name' in 'order clause' for query SELECT p.ID FROM wp_posts p WHERE post_type='scheduled-action' ORDER BY t.name DESC LIMIT 0, 10
```

The issue is caused by the terms table not being included in the query when ordering by group. 