### PR TITLE
Fix claim by group or hooks for 2...n queue run via WP CLI command

### DIFF
--- a/classes/ActionScheduler_WPCLI_Scheduler_command.php
+++ b/classes/ActionScheduler_WPCLI_Scheduler_command.php
@@ -63,7 +63,7 @@ class ActionScheduler_WPCLI_Scheduler_command extends WP_CLI_Command {
 				$batches_completed++;
 
 				// Maybe set up tasks for the next batch.
-				$total = ( $unlimited || $batches_completed < $batches ) ? $runner->setup( $batch, $force ) : 0;
+				$total = ( $unlimited || $batches_completed < $batches ) ? $runner->setup( $batch, $hooks, $group, $force ) : 0;
 			}
 		} catch ( Exception $e ) {
 			$this->print_error( $e );


### PR DESCRIPTION
By making sure we pass the correct parameters to the 2nd `$runner->setup()` call.

This is a good example of why it's not ideal having duplicate calls to `$runner->setup()`, as mentioned here https://github.com/Prospress/action-scheduler/pull/115#issuecomment-373201118

We may wish to refactor that look to avoid the duplicate and these potential issues. But for now, this patch fixes the bug.