### PR TITLE
Remove type declaration for $date parameter on ActionScheduler_LogEntry::__construct()

### DIFF
--- a/classes/ActionScheduler_LogEntry.php
+++ b/classes/ActionScheduler_LogEntry.php
@@ -28,7 +28,20 @@ class ActionScheduler_LogEntry {
 	 * @param Datetime $date    Datetime object with the time when this log entry was created. If this parameter is
 	 *                          not provided a new Datetime object (with current time) will be created.
 	 */
-	public function __construct( $action_id, $message, Datetime $date = null ) {
+	public function __construct( $action_id, $message, $date = null ) {
+
+		/*
+		 * ActionScheduler_wpCommentLogger::get_entry() previously passed a 3rd param of $comment->comment_type
+		 * to ActionScheduler_LogEntry::__construct(), goodness knows why, and the Follow-up Emails plugin
+		 * hard-codes loading its own version of ActionScheduler_wpCommentLogger without that out-dated method,
+		 * goodness knows why, so we need to guard against that here instead of using a DateTime type declaration
+		 * for the constructor's 3rd param of $date and causing a fatal error with older versions of FUE.
+		 */
+		if ( null !== $date && ! is_a( $date, 'DateTime' ) ) {
+			_deprecated_argument( __METHOD__, '2.0.0', 'The third parameter must be a valid DateTime instance, or null.' );
+			$date = null;
+		}
+
 		$this->action_id = $action_id;
 		$this->message   = $message;
 		$this->date      = $date ? $date : new Datetime;


### PR DESCRIPTION
To avoid fatal errors with Follow-up Emails when running Action Scheduler 2.0+ due to a comedy of errors.

Fixes #169.

I went with this approach rather than making `$date` a 4th parameter, and accepting an unused "comment type" string as the 3rd parameter. Technically, `ActionScheduler_LogEntry::__construct()` never had a 3rd parameter, so it shouldn't need to maintain backward compatibility for it. The issue is that FUE is hardcoding the loading of `ActionScheduler_wpCommentLogger.php` so that it can extend it (which is a bug in its own right), which means that it is loading its own out-of-date version of that file, which continues to have the bug in `ActionScheduler_wpCommentLogger::get_entry()` and passing a 3rd parameter to `ActionScheduler_LogEntry::__construct()`.

I'll open an issue on the Follow-up Emails repo to address that too.