### PR TITLE
Loosen timezone string check.

### DIFF
--- a/classes/ActionScheduler_DateTime.php
+++ b/classes/ActionScheduler_DateTime.php
@@ -8,6 +8,16 @@
 class ActionScheduler_DateTime extends DateTime {
 
 	/**
+	 * UTC offset.
+	 *
+	 * Only used when a timezone is not set. When a timezone string is
+	 * used, this will be set to 0.
+	 *
+	 * @var int
+	 */
+	protected $utcOffset = 0;
+
+	/**
 	 * Get the unix timestamp of the current object.
 	 *
 	 * Missing in PHP 5.2 so just here so it can be supported consistently.
@@ -16,5 +26,51 @@ class ActionScheduler_DateTime extends DateTime {
 	 */
 	public function getTimestamp() {
 		return method_exists( 'DateTime', 'getTimestamp' ) ? parent::getTimestamp() : $this->format( 'U' );
+	}
+
+	/**
+	 * Set the UTC offset.
+	 *
+	 * This represents a fixed offset instead of a timezone setting.
+	 *
+	 * @param $offset
+	 */
+	public function setUtcOffset( $offset ) {
+		$this->utcOffset = intval( $offset );
+	}
+
+	/**
+	 * Returns the timezone offset.
+	 *
+	 * @return int
+	 * @link http://php.net/manual/en/datetime.getoffset.php
+	 */
+	public function getOffset() {
+		return $this->utcOffset ? $this->utcOffset : parent::getOffset();
+	}
+
+	/**
+	 * Set the TimeZone associated with the DateTime
+	 *
+	 * @param DateTimeZone $timezone
+	 *
+	 * @return static
+	 * @link http://php.net/manual/en/datetime.settimezone.php
+	 */
+	public function setTimezone( $timezone ) {
+		$this->utcOffset = 0;
+		parent::setTimezone( $timezone );
+
+		return $this;
+	}
+
+	/**
+	 * Get the timestamp with the WordPress timezone offset added or subtracted.
+	 *
+	 * @since  3.0.0
+	 * @return int
+	 */
+	public function getOffsetTimestamp() {
+		return $this->getTimestamp() + $this->getOffset();
 	}
 }

--- a/classes/ActionScheduler_TimezoneHelper.php
+++ b/classes/ActionScheduler_TimezoneHelper.php
@@ -25,6 +25,24 @@ abstract class ActionScheduler_TimezoneHelper {
 						$tzstring = timezone_name_from_abbr( '', $gmt_offset, 0 );
 					}
 
+					// Try mapping to the first abbreviation we can find.
+					if ( false === $tzstring ) {
+						$is_dst = date( 'I' );
+						foreach ( timezone_abbreviations_list() as $abbr ) {
+							foreach ( $abbr as $city ) {
+								if ( $city['dst'] == $is_dst && $city['offset'] == $gmt_offset ) {
+									// If there's no valid timezone ID, keep looking.
+									if ( null === $city['timezone_id'] ) {
+										continue;
+									}
+
+									$tzstring = $city['timezone_id'];
+									break 2;
+								}
+							}
+						}
+					}
+
 					// If we still have no valid string, then fall back to UTC.
 					if ( false === $tzstring ) {
 						$tzstring = 'UTC';

--- a/classes/ActionScheduler_TimezoneHelper.php
+++ b/classes/ActionScheduler_TimezoneHelper.php
@@ -18,18 +18,14 @@ abstract class ActionScheduler_TimezoneHelper {
 					$tzstring = 'UTC';
 				} else {
 					$gmt_offset *= HOUR_IN_SECONDS;
-					$tzstring = timezone_name_from_abbr('', $gmt_offset);
+					$tzstring   = timezone_name_from_abbr( '', $gmt_offset, 1 );
+
+					// If there's no timezone string, try again with no DST.
 					if ( false === $tzstring ) {
-						$is_dst = date( 'I' );
-						foreach ( timezone_abbreviations_list() as $abbr ) {
-							foreach ( $abbr as $city ) {
-								if ( $city['dst'] == $is_dst && $city['offset'] == $gmt_offset ) {
-									$tzstring = $city['timezone_id'];
-									break 2;
-								}
-							}
-						}
+						$tzstring = timezone_name_from_abbr( '', $gmt_offset, 0 );
 					}
+
+					// If we still have no valid string, then fall back to UTC.
 					if ( false === $tzstring ) {
 						$tzstring = 'UTC';
 					}
@@ -41,4 +37,3 @@ abstract class ActionScheduler_TimezoneHelper {
 		return self::$local_timezone;
 	}
 }
- 

--- a/tests/phpunit/helpers/ActionScheduler_TimezoneHelper_Test.php
+++ b/tests/phpunit/helpers/ActionScheduler_TimezoneHelper_Test.php
@@ -1,0 +1,187 @@
+<?php
+
+/**
+ * @group timezone
+ */
+class ActionScheduler_TimezoneHelper_Test extends ActionScheduler_UnitTestCase {
+
+	/**
+	 * Ensure that the timezone string we expect works properly.
+	 *
+	 * @dataProvider local_timezone_provider
+	 *
+	 * @param $timezone_string
+	 */
+	public function test_local_timezone_strings( $timezone_string ) {
+		$timezone_filter = function ( $tz ) use ( $timezone_string ) {
+			return $timezone_string;
+		};
+
+		add_filter( 'option_timezone_string', $timezone_filter );
+		$timezone = ActionScheduler_TimezoneHelper::get_local_timezone( true );
+		$this->assertInstanceOf( 'DateTimeZone', $timezone );
+		$this->assertEquals( $timezone_string, $timezone->getName() );
+		remove_filter( 'option_timezone_string', $timezone_filter );
+	}
+
+	public function local_timezone_provider() {
+		return array(
+			array( 'America/New_York' ),
+			array( 'Australia/Melbourne' ),
+			array( 'UTC' ),
+		);
+	}
+
+	/**
+	 * Ensure that most GMT offsets don't return UTC as the timezone.
+	 *
+	 * @dataProvider local_timezone_offsets_provider
+	 *
+	 * @param $gmt_offset
+	 */
+	public function test_local_timezone_offsets( $gmt_offset ) {
+		$gmt_filter = function ( $gmt ) use ( $gmt_offset ) {
+			return $gmt_offset;
+		};
+
+		add_filter( 'option_gmt_offset', $gmt_filter );
+		try {
+			$timezone = ActionScheduler_TimezoneHelper::get_local_timezone( true );
+		} catch ( Exception $_e ) {
+			$e = $_e;
+			// Handle outside this block...
+		}
+		remove_filter( 'option_gmt_offset', $gmt_filter );
+
+		if ( isset( $e ) ) {
+			if ( false !== stripos( $e->getMessage(), 'unknown or bad timezone' ) ) {
+				$this->fail( sprintf( 'GMT offset [%s] caused fatal error.', $gmt_offset ) );
+			} else {
+				throw $e;
+			}
+		}
+
+		$this->assertInstanceOf( 'DateTimeZone', $timezone );
+		$this->assertNotEquals(
+			'UTC',
+			$timezone->getName(),
+			sprintf( 'GMT offset [%s] transformed into UTC', $gmt_offset )
+		);
+	}
+
+	public function local_timezone_offsets_provider() {
+		return array(
+			array( '-11' ),
+			array( '-10.5' ),
+			array( '-10' ),
+			array( '-9' ),
+			array( '-8' ),
+			array( '-7' ),
+			array( '-6' ),
+			array( '-5' ),
+			array( '-4.5' ),
+			array( '-4' ),
+			array( '-3.5' ),
+			array( '-3' ),
+			array( '-2' ),
+			array( '-1' ),
+			array( '1' ),
+			array( '1.5' ),
+			array( '2' ),
+			array( '3' ),
+			array( '4' ),
+			array( '5' ),
+			array( '5.5' ),
+			array( '5.75' ),
+			array( '6' ),
+			array( '7' ),
+			array( '8' ),
+			array( '8.5' ),
+			array( '9' ),
+			array( '9.5' ),
+			array( '10' ),
+			array( '10.5' ),
+			array( '11' ),
+			array( '11.5' ),
+			array( '12' ),
+			array( '13' ),
+		);
+	}
+
+	/**
+	 * There are certain GMT offsets that we expect to return UTC as the timezone.
+	 *
+	 * @dataProvider local_timezone_offsets_utc_provider
+	 *
+	 * @param string $gmt_offset
+	 * @param string $possible_string
+	 */
+	public function test_local_timezone_offsets_utc( $gmt_offset, $possible_string ) {
+		$gmt_filter = function ( $gmt ) use ( $gmt_offset ) {
+			return $gmt_offset;
+		};
+
+		add_filter( 'option_gmt_offset', $gmt_filter );
+		try {
+			$timezone = ActionScheduler_TimezoneHelper::get_local_timezone( true );
+		} catch ( Exception $_e ) {
+			$e = $_e;
+			// Handle outside this block...
+		}
+		remove_filter( 'option_gmt_offset', $gmt_filter );
+
+		if ( isset( $e ) ) {
+			if ( false !== stripos( $e->getMessage(), 'unknown or bad timezone' ) ) {
+				$this->fail( sprintf( 'GMT offset [%s] caused fatal error.', $gmt_offset ) );
+			} else {
+				throw $e;
+			}
+		}
+
+		$this->assertInstanceOf( 'DateTimeZone', $timezone );
+
+		/*
+		 * PHP versions less that 7 should have a recognized value for some of these offsets.
+		 * This means that we expect a different result for older versions of PHP than we do
+		 * for PHP 7+
+		 */
+		if ( ! empty( $possible_string) && version_compare( phpversion(), '7.0.0', '<' ) ) {
+			$this->assertEquals(
+				$possible_string,
+				$timezone->getName(),
+				sprintf( 'GMT offset [%s] should be transformed to %s string.', $gmt_offset, $possible_string )
+			);
+		} else {
+			$this->assertEquals(
+				'UTC',
+				$timezone->getName(),
+				sprintf( 'GMT offset [%s] transformed into UTC', $gmt_offset )
+			);
+		}
+	}
+
+	public function local_timezone_offsets_utc_provider() {
+		return array(
+			array( '-12', 'Pacific/Kwajalein' ),
+			array( '-11.5', 'Pacific/Niue' ),
+			array( '-9.5', 'Pacific/Marquesas' ),
+			array( '-8.5', 'Pacific/Pitcairn' ),
+			array( '-7.5', '' ),
+			array( '-6.5', '' ),
+			array( '-5.5', '' ),
+			array( '-2.5', '' ),
+			array( '-1.5', '' ),
+			array( '-0.5', '' ),
+			array( '0.5', '' ),
+			array( '2.5', 'Africa/Mogadishu' ),
+			array( '3.5', 'Asia/Tehran' ),
+			array( '4.5', 'Asia/Kabul' ),
+			array( '6.5', 'Asia/Kolkata' ),
+			array( '7.5', 'Asia/Brunei' ),
+			array( '8.75', 'Australia/Eucla' ),
+			array( '12.75', 'Pacific/Chatham' ),
+			array( '13.75', '' ),
+			array( '14', 'Pacific/Kiritimati' ),
+		);
+	}
+}


### PR DESCRIPTION
Fixes #179.

For certain timezone strings, the `$city['timezone_id']` is set to `null`. While normally it's desirable to use the `===` operator, in this case the timezone string wasn't set to UTC.