### PR TITLE
Use as_ prefix not wc_ prefix for public API functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,13 +137,13 @@ The Action Scheduler API functions are designed to mirror the WordPress [WP-Cron
 
 Functions return similar values and accept similar arguments to their WP-Cron counterparts. The notable differences are:
 
-* `wc_schedule_single_action()` & `wc_schedule_recurring_action()` will return the post ID of the scheduled action rather than boolean indicating whether the event was scheduled
-* `wc_schedule_recurring_action()` takes an interval in seconds as the recurring interval rather than an arbitrary string
-* `wc_schedule_single_action()` & `wc_schedule_recurring_action()` can accept a `$group` parameter to group different actions for the one plugin together.
-* the `wp_` prefix is substituted with `wc_` and the term `event` is replaced with `action`
+* `as_schedule_single_action()` & `as_schedule_recurring_action()` will return the post ID of the scheduled action rather than boolean indicating whether the event was scheduled
+* `as_schedule_recurring_action()` takes an interval in seconds as the recurring interval rather than an arbitrary string
+* `as_schedule_single_action()` & `as_schedule_recurring_action()` can accept a `$group` parameter to group different actions for the one plugin together.
+* the `wp_` prefix is substituted with `as_` and the term `event` is replaced with `action`
 
 
-#### Function Reference / `wc_schedule_single_action()`
+#### Function Reference / `as_schedule_single_action()`
 
 ##### Description
 
@@ -152,7 +152,7 @@ Schedule an action to run one time.
 ##### Usage
 
 ```php
-<?php wc_schedule_single_action( $timestamp, $hook, $args, $group ); ?>
+<?php as_schedule_single_action( $timestamp, $hook, $args, $group ); ?>
 ````
 
 ##### Parameters
@@ -167,7 +167,7 @@ Schedule an action to run one time.
 (integer) the action's ID in the [posts](http://codex.wordpress.org/Database_Description#Table_Overview) table.
 
 
-#### Function Reference / `wc_schedule_recurring_action()`
+#### Function Reference / `as_schedule_recurring_action()`
 
 ##### Description
 
@@ -176,7 +176,7 @@ Schedule an action to run repeatedly with a specified interval in seconds.
 ##### Usage
 
 ```php
-<?php wc_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, $args, $group ); ?>
+<?php as_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, $args, $group ); ?>
 ````
 
 ##### Parameters
@@ -192,7 +192,7 @@ Schedule an action to run repeatedly with a specified interval in seconds.
 (integer) the action's ID in the [posts](http://codex.wordpress.org/Database_Description#Table_Overview) table.
 
 
-#### Function Reference / `wc_schedule_cron_action()`
+#### Function Reference / `as_schedule_cron_action()`
 
 ##### Description
 
@@ -201,7 +201,7 @@ Schedule an action that recurs on a cron-like schedule.
 ##### Usage
 
 ```php
-<?php wc_schedule_cron_action( $timestamp, $schedule, $hook, $args, $group ); ?>
+<?php as_schedule_cron_action( $timestamp, $schedule, $hook, $args, $group ); ?>
 ````
 
 ##### Parameters
@@ -217,7 +217,7 @@ Schedule an action that recurs on a cron-like schedule.
 (integer) the action's ID in the [posts](http://codex.wordpress.org/Database_Description#Table_Overview) table.
 
 
-#### Function Reference / `wc_unschedule_action()`
+#### Function Reference / `as_unschedule_action()`
 
 ##### Description
 
@@ -226,7 +226,7 @@ Cancel the next occurrence of a job.
 ##### Usage
 
 ```php
-<?php wc_unschedule_action( $hook, $args, $group ); ?>
+<?php as_unschedule_action( $hook, $args, $group ); ?>
 ````
 
 ##### Parameters
@@ -240,7 +240,7 @@ Cancel the next occurrence of a job.
 (null)
 
 
-#### Function Reference / `wc_next_scheduled_action()`
+#### Function Reference / `as_next_scheduled_action()`
 
 ##### Description
 
@@ -249,7 +249,7 @@ Returns the next timestamp for a scheduled action.
 ##### Usage
 
 ```php
-<?php wc_next_scheduled_action( $hook, $args, $group ); ?>
+<?php as_next_scheduled_action( $hook, $args, $group ); ?>
 ````
 
 ##### Parameters
@@ -263,7 +263,7 @@ Returns the next timestamp for a scheduled action.
 (integer|boolean) The timestamp for the next occurrence, or false if nothing was found.
 
 
-#### Function Reference / `wc_get_scheduled_actions()`
+#### Function Reference / `as_get_scheduled_actions()`
 
 ##### Description
 
@@ -272,7 +272,7 @@ Find scheduled actions.
 ##### Usage
 
 ```php
-<?php wc_get_scheduled_actions( $args, $return_format ); ?>
+<?php as_get_scheduled_actions( $args, $return_format ); ?>
 ````
 
 ##### Parameters

--- a/classes/ActionScheduler.php
+++ b/classes/ActionScheduler.php
@@ -97,6 +97,10 @@ abstract class ActionScheduler {
 
 		require_once( self::plugin_path('functions.php') );
 
+		if ( apply_filters( 'action_scheduler_load_deprecated_functions', true ) ) {
+			require_once( self::plugin_path('deprecated/functions.php') );
+		}
+
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			WP_CLI::add_command( 'action-scheduler', 'ActionScheduler_WPCLI_Scheduler_command' );
 		}

--- a/deprecated/functions.php
+++ b/deprecated/functions.php
@@ -1,0 +1,126 @@
+<?php
+
+/**
+ * Deprecated API functions for scheduling actions
+ *
+ * Functions with the wc prefix were deprecated to avoid confusion with
+ * Action Scheduler being included in WooCommerce core, and it providing
+ * a different set of APIs for working with the action queue.
+ */
+
+/**
+ * Schedule an action to run one time
+ *
+ * @param int $timestamp When the job will run
+ * @param string $hook The hook to trigger
+ * @param array $args Arguments to pass when the hook triggers
+ * @param string $group The group to assign this job to
+ *
+ * @return string The job ID
+ */
+function wc_schedule_single_action( $timestamp, $hook, $args = array(), $group = '' ) {
+	_deprecated_function( __FUNCTION__, '2.1.0', 'as_schedule_single_action()' );
+	return as_schedule_single_action( $timestamp, $hook, $args, $group );
+}
+
+/**
+ * Schedule a recurring action
+ *
+ * @param int $timestamp When the first instance of the job will run
+ * @param int $interval_in_seconds How long to wait between runs
+ * @param string $hook The hook to trigger
+ * @param array $args Arguments to pass when the hook triggers
+ * @param string $group The group to assign this job to
+ *
+ * @deprecated 2.1.0
+ *
+ * @return string The job ID
+ */
+function wc_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, $args = array(), $group = '' ) {
+	_deprecated_function( __FUNCTION__, '2.1.0', 'as_schedule_recurring_action()' );
+	return as_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, $args, $group );
+}
+
+/**
+ * Schedule an action that recurs on a cron-like schedule.
+ *
+ * @param int $timestamp The schedule will start on or after this time
+ * @param string $schedule A cron-link schedule string
+ * @see http://en.wikipedia.org/wiki/Cron
+ *   *    *    *    *    *    *
+ *   ┬    ┬    ┬    ┬    ┬    ┬
+ *   |    |    |    |    |    |
+ *   |    |    |    |    |    + year [optional]
+ *   |    |    |    |    +----- day of week (0 - 7) (Sunday=0 or 7)
+ *   |    |    |    +---------- month (1 - 12)
+ *   |    |    +--------------- day of month (1 - 31)
+ *   |    +-------------------- hour (0 - 23)
+ *   +------------------------- min (0 - 59)
+ * @param string $hook The hook to trigger
+ * @param array $args Arguments to pass when the hook triggers
+ * @param string $group The group to assign this job to
+ *
+ * @deprecated 2.1.0
+ *
+ * @return string The job ID
+ */
+function wc_schedule_cron_action( $timestamp, $schedule, $hook, $args = array(), $group = '' ) {
+	_deprecated_function( __FUNCTION__, '2.1.0', 'as_schedule_cron_action()' );
+	return as_schedule_cron_action( $timestamp, $schedule, $hook, $args, $group );
+}
+
+/**
+ * Cancel the next occurrence of a job.
+ *
+ * @param string $hook The hook that the job will trigger
+ * @param array $args Args that would have been passed to the job
+ * @param string $group
+ *
+ * @deprecated 2.1.0
+ */
+function wc_unschedule_action( $hook, $args = array(), $group = '' ) {
+	_deprecated_function( __FUNCTION__, '2.1.0', 'as_unschedule_action()' );
+	as_unschedule_action( $hook, $args, $group );
+}
+
+/**
+ * @param string $hook
+ * @param array $args
+ * @param string $group
+ *
+ * @deprecated 2.1.0
+ *
+ * @return int|bool The timestamp for the next occurrence, or false if nothing was found
+ */
+function wc_next_scheduled_action( $hook, $args = NULL, $group = '' ) {
+	_deprecated_function( __FUNCTION__, '2.1.0', 'as_next_scheduled_action()' );
+	return as_next_scheduled_action( $hook, $args, $group );
+}
+
+/**
+ * Find scheduled actions
+ *
+ * @param array $args Possible arguments, with their default values:
+ *        'hook' => '' - the name of the action that will be triggered
+ *        'args' => NULL - the args array that will be passed with the action
+ *        'date' => NULL - the scheduled date of the action. Expects a DateTime object, a unix timestamp, or a string that can parsed with strtotime(). Used in UTC timezone.
+ *        'date_compare' => '<=' - operator for testing "date". accepted values are '!=', '>', '>=', '<', '<=', '='
+ *        'modified' => NULL - the date the action was last updated. Expects a DateTime object, a unix timestamp, or a string that can parsed with strtotime(). Used in UTC timezone.
+ *        'modified_compare' => '<=' - operator for testing "modified". accepted values are '!=', '>', '>=', '<', '<=', '='
+ *        'group' => '' - the group the action belongs to
+ *        'status' => '' - ActionScheduler_Store::STATUS_COMPLETE or ActionScheduler_Store::STATUS_PENDING
+ *        'claimed' => NULL - TRUE to find claimed actions, FALSE to find unclaimed actions, a string to find a specific claim ID
+ *        'per_page' => 5 - Number of results to return
+ *        'offset' => 0
+ *        'orderby' => 'date' - accepted values are 'hook', 'group', 'modified', or 'date'
+ *        'order' => 'ASC'
+ * @param string $return_format OBJECT, ARRAY_A, or ids
+ *
+ * @deprecated 2.1.0
+ *
+ * @return array
+ */
+function wc_get_scheduled_actions( $args = array(), $return_format = OBJECT ) {
+	_deprecated_function( __FUNCTION__, '2.1.0', 'as_get_scheduled_actions()' );
+	return as_get_scheduled_actions( $args, $return_format );
+}

--- a/functions.php
+++ b/functions.php
@@ -14,7 +14,7 @@
  *
  * @return string The job ID
  */
-function wc_schedule_single_action( $timestamp, $hook, $args = array(), $group = '' ) {
+function as_schedule_single_action( $timestamp, $hook, $args = array(), $group = '' ) {
 	return ActionScheduler::factory()->single( $hook, $args, $timestamp, $group );
 }
 
@@ -29,7 +29,7 @@ function wc_schedule_single_action( $timestamp, $hook, $args = array(), $group =
  *
  * @return string The job ID
  */
-function wc_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, $args = array(), $group = '' ) {
+function as_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, $args = array(), $group = '' ) {
 	return ActionScheduler::factory()->recurring( $hook, $args, $timestamp, $interval_in_seconds, $group );
 }
 
@@ -54,7 +54,7 @@ function wc_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, 
  *
  * @return string The job ID
  */
-function wc_schedule_cron_action( $timestamp, $schedule, $hook, $args = array(), $group = '' ) {
+function as_schedule_cron_action( $timestamp, $schedule, $hook, $args = array(), $group = '' ) {
 	return ActionScheduler::factory()->cron( $hook, $args, $timestamp, $schedule, $group );
 }
 
@@ -65,7 +65,7 @@ function wc_schedule_cron_action( $timestamp, $schedule, $hook, $args = array(),
  * @param array $args Args that would have been passed to the job
  * @param string $group
  */
-function wc_unschedule_action( $hook, $args = array(), $group = '' ) {
+function as_unschedule_action( $hook, $args = array(), $group = '' ) {
 	$params = array();
 	if ( is_array($args) ) {
 		$params['args'] = $args;
@@ -88,7 +88,7 @@ function wc_unschedule_action( $hook, $args = array(), $group = '' ) {
  *
  * @return int|bool The timestamp for the next occurrence, or false if nothing was found
  */
-function wc_next_scheduled_action( $hook, $args = NULL, $group = '' ) {
+function as_next_scheduled_action( $hook, $args = NULL, $group = '' ) {
 	$params = array();
 	if ( is_array($args) ) {
 		$params['args'] = $args;
@@ -130,7 +130,7 @@ function wc_next_scheduled_action( $hook, $args = NULL, $group = '' ) {
  *
  * @return array
  */
-function wc_get_scheduled_actions( $args = array(), $return_format = OBJECT ) {
+function as_get_scheduled_actions( $args = array(), $return_format = OBJECT ) {
 	$store = ActionScheduler::store();
 	foreach ( array('date', 'modified') as $key ) {
 		if ( isset($args[$key]) ) {

--- a/tests/phpunit/logging/ActionScheduler_wpCommentLogger_Test.php
+++ b/tests/phpunit/logging/ActionScheduler_wpCommentLogger_Test.php
@@ -12,7 +12,7 @@ class ActionScheduler_wpCommentLogger_Test extends ActionScheduler_UnitTestCase 
 	}
 
 	public function test_add_log_entry() {
-		$action_id = wc_schedule_single_action( time(), 'a hook' );
+		$action_id = as_schedule_single_action( time(), 'a hook' );
 		$logger = ActionScheduler::logger();
 		$message = 'Logging that something happened';
 		$log_id = $logger->log( $action_id, $message );
@@ -42,7 +42,7 @@ class ActionScheduler_wpCommentLogger_Test extends ActionScheduler_UnitTestCase 
 	}
 
 	public function test_storage_comments() {
-		$action_id = wc_schedule_single_action( time(), 'a hook' );
+		$action_id = as_schedule_single_action( time(), 'a hook' );
 		$logger = ActionScheduler::logger();
 		$logs = $logger->get_logs( $action_id );
 		$expected = new ActionScheduler_LogEntry( $action_id, 'action created' );
@@ -62,7 +62,7 @@ class ActionScheduler_wpCommentLogger_Test extends ActionScheduler_UnitTestCase 
 	}
 
 	public function test_execution_comments() {
-		$action_id = wc_schedule_single_action( time(), 'a hook' );
+		$action_id = as_schedule_single_action( time(), 'a hook' );
 		$logger = ActionScheduler::logger();
 		$started = new ActionScheduler_LogEntry( $action_id, 'action started' );
 		$finished = new ActionScheduler_LogEntry( $action_id, 'action complete' );
@@ -78,7 +78,7 @@ class ActionScheduler_wpCommentLogger_Test extends ActionScheduler_UnitTestCase 
 	public function test_failed_execution_comments() {
 		$hook = md5(rand());
 		add_action( $hook, array( $this, '_a_hook_callback_that_throws_an_exception' ) );
-		$action_id = wc_schedule_single_action( time(), $hook );
+		$action_id = as_schedule_single_action( time(), $hook );
 		$logger = ActionScheduler::logger();
 		$started = new ActionScheduler_LogEntry( $action_id, 'action started' );
 		$finished = new ActionScheduler_LogEntry( $action_id, 'action complete' );
@@ -95,7 +95,7 @@ class ActionScheduler_wpCommentLogger_Test extends ActionScheduler_UnitTestCase 
 
 	public function test_fatal_error_comments() {
 		$hook = md5(rand());
-		$action_id = wc_schedule_single_action( time(), $hook );
+		$action_id = as_schedule_single_action( time(), $hook );
 		$logger = ActionScheduler::logger();
 		do_action( 'action_scheduler_unexpected_shutdown', $action_id, array(
 			'type' => E_ERROR,
@@ -115,8 +115,8 @@ class ActionScheduler_wpCommentLogger_Test extends ActionScheduler_UnitTestCase 
 	}
 
 	public function test_canceled_action_comments() {
-		$action_id = wc_schedule_single_action( time(), 'a hook' );
-		wc_unschedule_action( 'a hook' );
+		$action_id = as_schedule_single_action( time(), 'a hook' );
+		as_unschedule_action( 'a hook' );
 		$logger = ActionScheduler::logger();
 		$logs = $logger->get_logs( $action_id );
 		$expected = new ActionScheduler_LogEntry( $action_id, 'action canceled' );
@@ -143,7 +143,7 @@ class ActionScheduler_wpCommentLogger_Test extends ActionScheduler_UnitTestCase 
 		$this->assertEquals( $comment_id, $comments[0]->comment_ID );
 
 
-		$action_id = wc_schedule_single_action( time(), 'a hook' );
+		$action_id = as_schedule_single_action( time(), 'a hook' );
 		$logger = ActionScheduler::logger();
 		$message = 'Logging that something happened';
 		$log_id = $logger->log( $action_id, $message );

--- a/tests/phpunit/procedural_api/procedural_api_Test.php
+++ b/tests/phpunit/procedural_api/procedural_api_Test.php
@@ -8,7 +8,7 @@ class procedural_api_Test extends ActionScheduler_UnitTestCase {
 	public function test_schedule_action() {
 		$time = time();
 		$hook = md5(rand());
-		$action_id = wc_schedule_single_action( $time, $hook );
+		$action_id = as_schedule_single_action( $time, $hook );
 
 		$store = ActionScheduler::store();
 		$action = $store->fetch_action($action_id);
@@ -19,7 +19,7 @@ class procedural_api_Test extends ActionScheduler_UnitTestCase {
 	public function test_recurring_action() {
 		$time = time();
 		$hook = md5(rand());
-		$action_id = wc_schedule_recurring_action( $time, HOUR_IN_SECONDS, $hook );
+		$action_id = as_schedule_recurring_action( $time, HOUR_IN_SECONDS, $hook );
 
 		$store = ActionScheduler::store();
 		$action = $store->fetch_action($action_id);
@@ -31,7 +31,7 @@ class procedural_api_Test extends ActionScheduler_UnitTestCase {
 	public function test_cron_schedule() {
 		$time = as_get_datetime_object('2014-01-01');
 		$hook = md5(rand());
-		$action_id = wc_schedule_cron_action( $time->getTimestamp(), '0 0 10 10 *', $hook );
+		$action_id = as_schedule_cron_action( $time->getTimestamp(), '0 0 10 10 *', $hook );
 
 		$store = ActionScheduler::store();
 		$action = $store->fetch_action($action_id);
@@ -43,9 +43,9 @@ class procedural_api_Test extends ActionScheduler_UnitTestCase {
 	public function test_get_next() {
 		$time = as_get_datetime_object('tomorrow');
 		$hook = md5(rand());
-		wc_schedule_recurring_action( $time->getTimestamp(), HOUR_IN_SECONDS, $hook );
+		as_schedule_recurring_action( $time->getTimestamp(), HOUR_IN_SECONDS, $hook );
 
-		$next = wc_next_scheduled_action( $hook );
+		$next = as_next_scheduled_action( $hook );
 
 		$this->assertEquals( $time->getTimestamp(), $next );
 	}
@@ -53,11 +53,11 @@ class procedural_api_Test extends ActionScheduler_UnitTestCase {
 	public function test_unschedule() {
 		$time = time();
 		$hook = md5(rand());
-		$action_id = wc_schedule_single_action( $time, $hook );
+		$action_id = as_schedule_single_action( $time, $hook );
 
-		wc_unschedule_action( $hook );
+		as_unschedule_action( $hook );
 
-		$next = wc_next_scheduled_action( $hook );
+		$next = as_next_scheduled_action( $hook );
 		$this->assertFalse($next);
 
 		$store = ActionScheduler::store();

--- a/tests/phpunit/procedural_api/wc_get_scheduled_actions_Test.php
+++ b/tests/phpunit/procedural_api/wc_get_scheduled_actions_Test.php
@@ -1,9 +1,9 @@
 <?php
 
 /**
- * Class wc_get_scheduled_actions_Test
+ * Class as_get_scheduled_actions_Test
  */
-class wc_get_scheduled_actions_Test extends ActionScheduler_UnitTestCase {
+class as_get_scheduled_actions_Test extends ActionScheduler_UnitTestCase {
 	private $hooks = array();
 	private $args = array();
 	private $groups = array();
@@ -30,13 +30,13 @@ class wc_get_scheduled_actions_Test extends ActionScheduler_UnitTestCase {
 	}
 
 	public function test_date_queries() {
-		$actions = wc_get_scheduled_actions(array(
+		$actions = as_get_scheduled_actions(array(
 			'date' => as_get_datetime_object(gmdate('Y-m-d 00:00:00')),
 			'per_page' => -1,
 		), 'ids');
 		$this->assertCount(30, $actions);
 
-		$actions = wc_get_scheduled_actions(array(
+		$actions = as_get_scheduled_actions(array(
 			'date' => as_get_datetime_object(gmdate('Y-m-d 00:00:00')),
 			'date_compare' => '>=',
 			'per_page' => -1,
@@ -45,13 +45,13 @@ class wc_get_scheduled_actions_Test extends ActionScheduler_UnitTestCase {
 	}
 
 	public function test_hook_queries() {
-		$actions = wc_get_scheduled_actions(array(
+		$actions = as_get_scheduled_actions(array(
 			'hook' => $this->hooks[2],
 			'per_page' => -1,
 		), 'ids');
 		$this->assertCount(10, $actions);
 
-		$actions = wc_get_scheduled_actions(array(
+		$actions = as_get_scheduled_actions(array(
 			'hook' => $this->hooks[2],
 			'date' => as_get_datetime_object(gmdate('Y-m-d 00:00:00')),
 			'per_page' => -1,
@@ -60,20 +60,20 @@ class wc_get_scheduled_actions_Test extends ActionScheduler_UnitTestCase {
 	}
 
 	public function test_args_queries() {
-		$actions = wc_get_scheduled_actions(array(
+		$actions = as_get_scheduled_actions(array(
 			'args' => array($this->args[5]),
 			'per_page' => -1,
 		), 'ids');
 		$this->assertCount(10, $actions);
 
-		$actions = wc_get_scheduled_actions(array(
+		$actions = as_get_scheduled_actions(array(
 			'args' => array($this->args[5]),
 			'hook' => $this->hooks[3],
 			'per_page' => -1,
 		), 'ids');
 		$this->assertCount(1, $actions);
 
-		$actions = wc_get_scheduled_actions(array(
+		$actions = as_get_scheduled_actions(array(
 			'args' => array($this->args[5]),
 			'hook' => $this->hooks[3],
 			'date' => as_get_datetime_object(gmdate('Y-m-d 00:00:00')),
@@ -83,13 +83,13 @@ class wc_get_scheduled_actions_Test extends ActionScheduler_UnitTestCase {
 	}
 
 	public function test_group_queries() {
-		$actions = wc_get_scheduled_actions(array(
+		$actions = as_get_scheduled_actions(array(
 			'group' => $this->groups[1],
 			'per_page' => -1,
 		), 'ids');
 		$this->assertCount(10, $actions);
 
-		$actions = wc_get_scheduled_actions(array(
+		$actions = as_get_scheduled_actions(array(
 			'group' => $this->groups[1],
 			'hook' => $this->hooks[9],
 			'per_page' => -1,


### PR DESCRIPTION
To avoid confusion once Action Scheduler is included in WooCommerce core, and it provides a different set of public APIs for working with the action queue. As raised here: https://github.com/woocommerce/woocommerce/pull/20030#pullrequestreview-139753264 (I also think this is probably how the functions should have been prefixed all along, so it's a worthwhile change).

The existing functions are still loaded by default, and will continue to work normally. A deprecated notice will be thrown however to notify developers of the change (we'll also need to publicly announce this change, ideally well before the release of WC 3.5.0 to give 3rd parties time to prepare).

I've set the version in the deprecated notice to 2.1.0. I think renaming all public API functions justifies bumping to a 2.1.0 instead of just 2.0.1 or 2.0.2.



