### PR TITLE
Remove the version from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,5 @@
 {
   "name": "prospress/action-scheduler",
-  "version": "2.0.0",
   "description": "Action Scheduler for WordPress and WooCommerce",
   "type": "wordpress-plugin",
   "license": "GPL-3.0",


### PR DESCRIPTION
According to the [composer documentation](https://getcomposer.org/doc/04-schema.md#version), the version parameter shouldn't actually be used in the `composer.json` file.

Here's the exact relevant text, with emphasis added:

> Optional if the package repository can infer the version from somewhere, such as the VCS tag name in the VCS repository. **In that case it is also recommended to omit it.**