### PR TITLE
Only process pending actions

### DIFF
--- a/classes/ActionScheduler_Abstract_QueueRunner.php
+++ b/classes/ActionScheduler_Abstract_QueueRunner.php
@@ -35,6 +35,12 @@ abstract class ActionScheduler_Abstract_QueueRunner {
 	public function process_action( $action_id ) {
 		try {
 			do_action( 'action_scheduler_before_execute', $action_id );
+
+			if ( ActionScheduler_Store::STATUS_PENDING !== $this->store->get_status( $action_id ) ) {
+				do_action( 'action_scheduler_execution_ignored', $action_id );
+				return;
+			}
+
 			$action = $this->store->fetch_action( $action_id );
 			$this->store->log_execution( $action_id );
 			$action->execute();

--- a/classes/ActionScheduler_FatalErrorMonitor.php
+++ b/classes/ActionScheduler_FatalErrorMonitor.php
@@ -19,6 +19,7 @@ class ActionScheduler_FatalErrorMonitor {
 		add_action( 'shutdown', array( $this, 'handle_unexpected_shutdown' ) );
 		add_action( 'action_scheduler_before_execute', array( $this, 'track_current_action' ), 0, 1 );
 		add_action( 'action_scheduler_after_execute',  array( $this, 'untrack_action' ), 0, 0 );
+		add_action( 'action_scheduler_execution_ignored',  array( $this, 'untrack_action' ), 0, 0 );
 		add_action( 'action_scheduler_failed_execution',  array( $this, 'untrack_action' ), 0, 0 );
 	}
 
@@ -28,6 +29,7 @@ class ActionScheduler_FatalErrorMonitor {
 		remove_action( 'shutdown', array( $this, 'handle_unexpected_shutdown' ) );
 		remove_action( 'action_scheduler_before_execute', array( $this, 'track_current_action' ), 0, 1 );
 		remove_action( 'action_scheduler_after_execute',  array( $this, 'untrack_action' ), 0, 0 );
+		remove_action( 'action_scheduler_execution_ignored',  array( $this, 'untrack_action' ), 0 );
 		remove_action( 'action_scheduler_failed_execution',  array( $this, 'untrack_action' ), 0, 0 );
 	}
 

--- a/classes/ActionScheduler_Logger.php
+++ b/classes/ActionScheduler_Logger.php
@@ -54,6 +54,7 @@ abstract class ActionScheduler_Logger {
 		add_action( 'action_scheduler_failed_action', array( $this, 'log_timed_out_action' ), 10, 2 );
 		add_action( 'action_scheduler_unexpected_shutdown', array( $this, 'log_unexpected_shutdown' ), 10, 2 );
 		add_action( 'action_scheduler_reset_action', array( $this, 'log_reset_action' ), 10, 1 );
+		add_action( 'action_scheduler_execution_ignored', array( $this, 'log_ignored_action' ), 10, 1 );
 	}
 
 	public function log_stored_action( $action_id ) {
@@ -88,6 +89,10 @@ abstract class ActionScheduler_Logger {
 
 	public function log_reset_action( $action_id ) {
 		$this->log( $action_id, __( 'action reset', 'action_scheduler' ) );
+	}
+
+	public function log_ignored_action( $action_id ) {
+		$this->log( $action_id, __( 'action ignored', 'action-scheduler' ) );
 	}
 }
  

--- a/classes/ActionScheduler_Logger.php
+++ b/classes/ActionScheduler_Logger.php
@@ -41,7 +41,53 @@ abstract class ActionScheduler_Logger {
 	 */
 	abstract public function get_logs( $action_id );
 
-	abstract public function init();
 
+	/**
+	 * @codeCoverageIgnore
+	 */
+	public function init() {
+		add_action( 'action_scheduler_stored_action', array( $this, 'log_stored_action' ), 10, 1 );
+		add_action( 'action_scheduler_canceled_action', array( $this, 'log_canceled_action' ), 10, 1 );
+		add_action( 'action_scheduler_before_execute', array( $this, 'log_started_action' ), 10, 1 );
+		add_action( 'action_scheduler_after_execute', array( $this, 'log_completed_action' ), 10, 1 );
+		add_action( 'action_scheduler_failed_execution', array( $this, 'log_failed_action' ), 10, 2 );
+		add_action( 'action_scheduler_failed_action', array( $this, 'log_timed_out_action' ), 10, 2 );
+		add_action( 'action_scheduler_unexpected_shutdown', array( $this, 'log_unexpected_shutdown' ), 10, 2 );
+		add_action( 'action_scheduler_reset_action', array( $this, 'log_reset_action' ), 10, 1 );
+	}
+
+	public function log_stored_action( $action_id ) {
+		$this->log( $action_id, __( 'action created', 'action-scheduler' ) );
+	}
+
+	public function log_canceled_action( $action_id ) {
+		$this->log( $action_id, __( 'action canceled', 'action-scheduler' ) );
+	}
+
+	public function log_started_action( $action_id ) {
+		$this->log( $action_id, __( 'action started', 'action-scheduler' ) );
+	}
+
+	public function log_completed_action( $action_id ) {
+		$this->log( $action_id, __( 'action complete', 'action-scheduler' ) );
+	}
+
+	public function log_failed_action( $action_id, \Exception $exception ) {
+		$this->log( $action_id, sprintf( __( 'action failed: %s', 'action-scheduler' ), $exception->getMessage() ) );
+	}
+
+	public function log_timed_out_action( $action_id, $timeout ) {
+		$this->log( $action_id, sprintf( __( 'action timed out after %s seconds', 'action-scheduler' ), $timeout ) );
+	}
+
+	public function log_unexpected_shutdown( $action_id, $error ) {
+		if ( ! empty( $error ) ) {
+			$this->log( $action_id, sprintf( __( 'unexpected shutdown: PHP Fatal error %s in %s on line %s', 'action-scheduler' ), $error['message'], $error['file'], $error['line'] ) );
+		}
+	}
+
+	public function log_reset_action( $action_id ) {
+		$this->log( $action_id, __( 'action reset', 'action_scheduler' ) );
+	}
 }
  

--- a/classes/ActionScheduler_wpCommentLogger.php
+++ b/classes/ActionScheduler_wpCommentLogger.php
@@ -217,14 +217,9 @@ class ActionScheduler_wpCommentLogger extends ActionScheduler_Logger {
 	public function init() {
 		add_action( 'action_scheduler_before_process_queue', array( $this, 'disable_comment_counting' ), 10, 0 );
 		add_action( 'action_scheduler_after_process_queue', array( $this, 'enable_comment_counting' ), 10, 0 );
-		add_action( 'action_scheduler_stored_action', array( $this, 'log_stored_action' ), 10, 1 );
-		add_action( 'action_scheduler_canceled_action', array( $this, 'log_canceled_action' ), 10, 1 );
-		add_action( 'action_scheduler_before_execute', array( $this, 'log_started_action' ), 10, 1 );
-		add_action( 'action_scheduler_after_execute', array( $this, 'log_completed_action' ), 10, 1 );
-		add_action( 'action_scheduler_failed_execution', array( $this, 'log_failed_action' ), 10, 2 );
-		add_action( 'action_scheduler_failed_action', array( $this, 'log_timed_out_action' ), 10, 2 );
-		add_action( 'action_scheduler_unexpected_shutdown', array( $this, 'log_unexpected_shutdown' ), 10, 2 );
-		add_action( 'action_scheduler_reset_action', array( $this, 'log_reset_action' ), 10, 1 );
+
+		parent::init();
+
 		add_action( 'pre_get_comments', array( $this, 'filter_comment_queries' ), 10, 1 );
 		add_action( 'wp_count_comments', array( $this, 'filter_comment_count' ), 20, 2 ); // run after WC_Comments::wp_count_comments() to make sure we exclude order notes and action logs
 		add_action( 'comment_feed_where', array( $this, 'filter_comment_feed' ), 10, 2 );
@@ -239,40 +234,6 @@ class ActionScheduler_wpCommentLogger extends ActionScheduler_Logger {
 	}
 	public function enable_comment_counting() {
 		wp_defer_comment_counting(false);
-	}
-
-	public function log_stored_action( $action_id ) {
-		$this->log( $action_id, __('action created', 'action-scheduler') );
-	}
-
-	public function log_canceled_action( $action_id ) {
-		$this->log( $action_id, __('action canceled', 'action-scheduler') );
-	}
-
-	public function log_started_action( $action_id ) {
-		$this->log( $action_id, __('action started', 'action-scheduler') );
-	}
-
-	public function log_completed_action( $action_id ) {
-		$this->log( $action_id, __('action complete', 'action-scheduler') );
-	}
-
-	public function log_failed_action( $action_id, Exception $exception ) {
-		$this->log( $action_id, sprintf(__('action failed: %s', 'action-scheduler'), $exception->getMessage() ));
-	}
-
-	public function log_timed_out_action( $action_id, $timeout) {
-		$this->log( $action_id, sprintf( __('action timed out after %s seconds', 'action-scheduler'), $timeout ) );
-	}
-
-	public function log_unexpected_shutdown( $action_id, $error ) {
-		if ( !empty($error) ) {
-			$this->log( $action_id, sprintf(__('unexpected shutdown: PHP Fatal error %s in %s on line %s', 'action-scheduler'), $error['message'], $error['file'], $error['line'] ) );
-		}
-	}
-
-	public function log_reset_action( $action_id ) {
-		$this->log( $action_id, __('action reset', 'action_scheduler') );
 	}
 
 }


### PR DESCRIPTION
See #176 for background on the the issue this patch solves.

There's a few ways to address the race condition reported in #176. I've gone with handling the issue in `ActionScheduler_Abstract_QueueRunner::process_action()` because it's the simplest. It also avoids processing a non-pending action regardless of whether the attempt to process it comes from:

* WP Cron runner
* WP CLI runner
* Admin list table action

All of which call `ActionScheduler_Abstract_QueueRunner::process_action()`, and none of which _should_ result in a non-pending action being processed.

Two other notes on this patch:

1. I added logging so that the ignore can be traced if needed. This lead me to a bigger issue with the abstraction (or lack of) in `ActionScheduler_wpCommentLogger`, which I addressed with SHA: bca46a8a3. That makes this changeset bigger, but inline with the comment on the commit, I think it's an important change.
1. I wrapped the check inside the `try/catch` block to catch (and log) any exceptions that may occur with `$this->store->get_status( $action_id )` or in callbacks on `'action_scheduler_execution_ignored'`

Fixes #176