### PR TITLE
Restore batch processing loop

### DIFF
--- a/classes/ActionScheduler_Abstract_QueueRunner.php
+++ b/classes/ActionScheduler_Abstract_QueueRunner.php
@@ -15,6 +15,16 @@ abstract class ActionScheduler_Abstract_QueueRunner {
 	protected $store;
 
 	/**
+	 * The created time.
+	 *
+	 * Represents when the queue runner was constructed and used when calculating how long a PHP request has been running.
+	 * For this reason it should be as close as possible to the PHP request start time.
+	 *
+	 * @var int
+	 */
+	private $created_time;
+
+	/**
 	 * ActionScheduler_Abstract_QueueRunner constructor.
 	 *
 	 * @param ActionScheduler_Store             $store
@@ -22,6 +32,9 @@ abstract class ActionScheduler_Abstract_QueueRunner {
 	 * @param ActionScheduler_QueueCleaner      $cleaner
 	 */
 	public function __construct( ActionScheduler_Store $store = null, ActionScheduler_FatalErrorMonitor $monitor = null, ActionScheduler_QueueCleaner $cleaner = null ) {
+
+		$this->created_time = microtime( true );
+
 		$this->store   = $store ? $store : ActionScheduler_Store::instance();
 		$this->monitor = $monitor ? $monitor : new ActionScheduler_FatalErrorMonitor( $this->store );
 		$this->cleaner = $cleaner ? $cleaner : new ActionScheduler_QueueCleaner( $this->store );
@@ -77,6 +90,45 @@ abstract class ActionScheduler_Abstract_QueueRunner {
 	 */
 	public function get_allowed_concurrent_batches() {
 		return apply_filters( 'action_scheduler_queue_runner_concurrent_batches', 5 );
+	}
+
+	/**
+	 * Get the maximum number of seconds a batch can run for.
+	 *
+	 * @return int The number of seconds.
+	 */
+	protected function get_maximum_execution_time() {
+
+		// There are known hosts with a strict 60 second execution time.
+		if ( defined( 'WPENGINE_ACCOUNT' ) || defined( 'PANTHEON_ENVIRONMENT' ) ) {
+			$maximum_execution_time = 60;
+		} elseif ( false !== strpos( getenv( 'HOSTNAME' ), '.siteground.' ) ) {
+			$maximum_execution_time = 120;
+		} else {
+			$maximum_execution_time = ini_get( 'max_execution_time' );
+		}
+
+		return absint( apply_filters( 'action_scheduler_maximum_execution_time', $maximum_execution_time ) );
+	}
+
+	/**
+	 * Get the number of seconds a batch has run for.
+	 *
+	 * @return int The number of seconds.
+	 */
+	protected function get_execution_time() {
+		$execution_time = microtime( true ) - $this->created_time;
+
+		// Get the CPU time if the hosting environment uses it rather than wall-clock time to calculate a process's execution time.
+		if ( function_exists( 'getrusage' ) && apply_filters( 'action_scheduler_use_cpu_execution_time', defined( 'PANTHEON_ENVIRONMENT' ) ) ) {
+			$resource_usages = getrusage();
+
+			if ( isset( $resource_usages['ru_stime.tv_usec'], $resource_usages['ru_stime.tv_usec'] ) ) {
+				$execution_time = $resource_usages['ru_stime.tv_sec'] + ( $resource_usages['ru_stime.tv_usec'] / 1000000 );
+			}
+		}
+
+		return $execution_time;
 	}
 
 	/**

--- a/classes/ActionScheduler_Compatibility.php
+++ b/classes/ActionScheduler_Compatibility.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * Class ActionScheduler_Compatibility
+ */
+class ActionScheduler_Compatibility {
+
+	/**
+	 * Converts a shorthand byte value to an integer byte value.
+	 *
+	 * Wrapper for wp_convert_hr_to_bytes(), moved to load.php in WordPress 4.6 from media.php
+	 *
+	 * @link https://secure.php.net/manual/en/function.ini-get.php
+	 * @link https://secure.php.net/manual/en/faq.using.php#faq.using.shorthandbytes
+	 *
+	 * @param string $value A (PHP ini) byte value, either shorthand or ordinary.
+	 * @return int An integer byte value.
+	 */
+	public static function convert_hr_to_bytes( $value ) {
+		if ( function_exists( 'wp_convert_hr_to_bytes' ) ) {
+			return wp_convert_hr_to_bytes( $value );
+		}
+
+		$value = strtolower( trim( $value ) );
+		$bytes = (int) $value;
+
+		if ( false !== strpos( $value, 'g' ) ) {
+			$bytes *= GB_IN_BYTES;
+		} elseif ( false !== strpos( $value, 'm' ) ) {
+			$bytes *= MB_IN_BYTES;
+		} elseif ( false !== strpos( $value, 'k' ) ) {
+			$bytes *= KB_IN_BYTES;
+		}
+
+		// Deal with large (float) values which run into the maximum integer size.
+		return min( $bytes, PHP_INT_MAX );
+	}
+}

--- a/classes/ActionScheduler_Compatibility.php
+++ b/classes/ActionScheduler_Compatibility.php
@@ -35,4 +35,46 @@ class ActionScheduler_Compatibility {
 		// Deal with large (float) values which run into the maximum integer size.
 		return min( $bytes, PHP_INT_MAX );
 	}
+
+	/**
+	 * Attempts to raise the PHP memory limit for memory intensive processes.
+	 *
+	 * Only allows raising the existing limit and prevents lowering it.
+	 *
+	 * Wrapper for wp_raise_memory_limit(), added in WordPress v4.6.0
+	 *
+	 * @return bool|int|string The limit that was set or false on failure.
+	 */
+	public static function raise_memory_limit() {
+		if ( function_exists( 'wp_raise_memory_limit' ) ) {
+			return wp_raise_memory_limit( 'admin' );
+		}
+
+		$current_limit     = @ini_get( 'memory_limit' );
+		$current_limit_int = self::convert_hr_to_bytes( $current_limit );
+
+		if ( -1 === $current_limit_int ) {
+			return false;
+		}
+
+		$wp_max_limit       = WP_MAX_MEMORY_LIMIT;
+		$wp_max_limit_int   = self::convert_hr_to_bytes( $wp_max_limit );
+		$filtered_limit     = apply_filters( 'admin_memory_limit', $wp_max_limit );
+		$filtered_limit_int = self::convert_hr_to_bytes( $filtered_limit );
+
+		if ( -1 === $filtered_limit_int || ( $filtered_limit_int > $wp_max_limit_int && $filtered_limit_int > $current_limit_int ) ) {
+			if ( false !== @ini_set( 'memory_limit', $filtered_limit ) ) {
+				return $filtered_limit;
+			} else {
+				return false;
+			}
+		} elseif ( -1 === $wp_max_limit_int || $wp_max_limit_int > $current_limit_int ) {
+			if ( false !== @ini_set( 'memory_limit', $wp_max_limit ) ) {
+				return $wp_max_limit;
+			} else {
+				return false;
+			}
+		}
+		return false;
+	}
 }

--- a/classes/ActionScheduler_QueueRunner.php
+++ b/classes/ActionScheduler_QueueRunner.php
@@ -12,16 +12,6 @@ class ActionScheduler_QueueRunner extends ActionScheduler_Abstract_QueueRunner {
 	private static $runner = null;
 
 	/**
-	 * The created time.
-	 *
-	 * Represents when the queue runner was constructed and used when calculating how long a PHP request has been running.
-	 * For this reason it should be as close as possible to the PHP request start time.
-	 *
-	 * @var int
-	 */
-	private $created_time;
-
-	/**
 	 * @return ActionScheduler_QueueRunner
 	 * @codeCoverageIgnore
 	 */
@@ -42,7 +32,6 @@ class ActionScheduler_QueueRunner extends ActionScheduler_Abstract_QueueRunner {
 	 */
 	public function __construct( ActionScheduler_Store $store = null, ActionScheduler_FatalErrorMonitor $monitor = null, ActionScheduler_QueueCleaner $cleaner = null ) {
 		parent::__construct( $store, $monitor, $cleaner );
-		$this->created_time = microtime( true );
 	}
 
 	/**
@@ -126,44 +115,5 @@ class ActionScheduler_QueueRunner extends ActionScheduler_Abstract_QueueRunner {
 		);
 
 		return $schedules;
-	}
-
-	/**
-	 * Get the maximum number of seconds a batch can run for.
-	 *
-	 * @return int The number of seconds.
-	 */
-	protected function get_maximum_execution_time() {
-
-		// There are known hosts with a strict 60 second execution time.
-		if ( defined( 'WPENGINE_ACCOUNT' ) || defined( 'PANTHEON_ENVIRONMENT' ) ) {
-			$maximum_execution_time = 60;
-		} elseif ( false !== strpos( getenv( 'HOSTNAME' ), '.siteground.' ) ) {
-			$maximum_execution_time = 120;
-		} else {
-			$maximum_execution_time = ini_get( 'max_execution_time' );
-		}
-
-		return absint( apply_filters( 'action_scheduler_maximum_execution_time', $maximum_execution_time ) );
-	}
-
-	/**
-	 * Get the number of seconds a batch has run for.
-	 *
-	 * @return int The number of seconds.
-	 */
-	protected function get_execution_time() {
-		$execution_time = microtime( true ) - $this->created_time;
-
-		// Get the CPU time if the hosting environment uses it rather than wall-clock time to calculate a process's execution time.
-		if ( function_exists( 'getrusage' ) && apply_filters( 'action_scheduler_use_cpu_execution_time', defined( 'PANTHEON_ENVIRONMENT' ) ) ) {
-			$resource_usages = getrusage();
-
-			if ( isset( $resource_usages['ru_stime.tv_usec'], $resource_usages['ru_stime.tv_usec'] ) ) {
-				$execution_time = $resource_usages['ru_stime.tv_sec'] + ( $resource_usages['ru_stime.tv_usec'] / 1000000 );
-			}
-		}
-
-		return $execution_time;
 	}
 }

--- a/classes/ActionScheduler_QueueRunner.php
+++ b/classes/ActionScheduler_QueueRunner.php
@@ -50,7 +50,7 @@ class ActionScheduler_QueueRunner extends ActionScheduler_Abstract_QueueRunner {
 	}
 
 	public function run() {
-		@ini_set( 'memory_limit', apply_filters( 'admin_memory_limit', WP_MAX_MEMORY_LIMIT ) );
+		ActionScheduler_Compatibility::raise_memory_limit();
 		@set_time_limit( apply_filters( 'action_scheduler_queue_runner_time_limit', 600 ) );
 		do_action( 'action_scheduler_before_process_queue' );
 		$this->run_cleanup();


### PR DESCRIPTION
This PR reintroduces a loop in `ActionScheduler_QueueRunner::run()`  to increase the rate of action processing. Instead of processing just one batch of actions, with this patch, AS will process as many batches as it can before reaching 90% of the available memory, or it becomes likely processing another action will exceed the available script timeout limit.

Fixes #184

I recommend reviewing individual commit messages for a more in-depth explanation on each change.

---

I also snuck in https://github.com/Prospress/action-scheduler/commit/1a698d04795bac737dfa54769804b5db15c33fd8 to this PR, as it's a relatively small patch, which fixes #188, and it depends on the new `ActionScheduler_Compatibility` class being added here for #184, so I figured it was worth including in the same PR.

I'll move it to a separate PR if it slows down the review/merge of the patches required for #184, as that is a higher priority issue.