### PR TITLE
Add as_unschedule_all_actions() function

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -59,7 +59,14 @@ function as_schedule_cron_action( $timestamp, $schedule, $hook, $args = array(),
 }
 
 /**
- * Cancel the next occurrence of a job.
+ * Cancel the next occurrence of a scheduled action.
+ *
+ * While only the next instance of a recurring or cron action is unscheduled by this method, that will also prevent
+ * all future instances of that recurring or cron action from being run. Recurring and cron actions are scheduled in
+ * a sequence instead of all being scheduled at once. Each successive occurrence of a recurring action is scheduled
+ * only after the former action is run. If the next instance is never run, because it's unscheduled by this function,
+ * then the following instance will never be scheduled (or exist), which is effectively the same as being unscheduled
+ * by this method also.
  *
  * @param string $hook The hook that the job will trigger
  * @param array $args Args that would have been passed to the job

--- a/functions.php
+++ b/functions.php
@@ -71,6 +71,8 @@ function as_schedule_cron_action( $timestamp, $schedule, $hook, $args = array(),
  * @param string $hook The hook that the job will trigger
  * @param array $args Args that would have been passed to the job
  * @param string $group
+ *
+ * @return string The scheduled action ID if a scheduled action was found, or empty string if no matching action found.
  */
 function as_unschedule_action( $hook, $args = array(), $group = '' ) {
 	$params = array();
@@ -81,11 +83,12 @@ function as_unschedule_action( $hook, $args = array(), $group = '' ) {
 		$params['group'] = $group;
 	}
 	$job_id = ActionScheduler::store()->find_action( $hook, $params );
-	if ( empty($job_id) ) {
-		return;
+
+	if ( ! empty( $job_id ) ) {
+		ActionScheduler::store()->cancel_action( $job_id );
 	}
 
-	ActionScheduler::store()->cancel_action( $job_id );
+	return $job_id;
 }
 
 /**

--- a/functions.php
+++ b/functions.php
@@ -92,6 +92,19 @@ function as_unschedule_action( $hook, $args = array(), $group = '' ) {
 }
 
 /**
+ * Cancel all occurrences of a scheduled action.
+ *
+ * @param string $hook The hook that the job will trigger
+ * @param array $args Args that would have been passed to the job
+ * @param string $group
+ */
+function as_unschedule_all_actions( $hook, $args = array(), $group = '' ) {
+	do {
+		$unscheduled_action = as_unschedule_action( $hook, $args, $group );
+	} while ( ! empty( $unscheduled_action ) );
+}
+
+/**
  * @param string $hook
  * @param array $args
  * @param string $group


### PR DESCRIPTION
Add `as_unschedule_all_actions()` method for unscheduling _all_ occurrences of a given hook, args & group combination, not just the _next_ occurrence, which is the behaviour or `as_unschedule_action()`.

Adding this public function also helps avoid ambiguity around the behaviour of `as_unschedule_action()`. But I've updated the docblock on `as_unschedule_action()` to help avoid that ambiguity too, as I had to dive into the code to figure out how it actually worked when asked about it during code review of the PR to add AS into WooCommerce core.

This functionality is also something that's come up in Subscriptions use of Action Scheduler before. We added our own method to [delete all scheduled actions](https://github.com/Prospress/woocommerce-subscriptions/blob/2.3.5/includes/class-wcs-action-scheduler.php#L191-L195). That functionality is useful beyond just Subscriptions, so it belongs in Action Scheduler core.

By adding return values to `as_unschedule_action()`, the `as_unschedule_all_actions()` function is also more performant than the previously required code, which needed to make a separate call to `as_next_scheduled_action()`.
