### PR TITLE
Fixed translatable string

### DIFF
--- a/classes/ActionScheduler_WPCLI_QueueRunner.php
+++ b/classes/ActionScheduler_WPCLI_QueueRunner.php
@@ -27,7 +27,8 @@ class ActionScheduler_WPCLI_QueueRunner extends ActionScheduler_Abstract_QueueRu
 	 */
 	public function __construct( ActionScheduler_Store $store = null, ActionScheduler_FatalErrorMonitor $monitor = null, ActionScheduler_QueueCleaner $cleaner = null ) {
 		if ( ! ( defined( 'WP_CLI' ) && WP_CLI ) ) {
-			throw new Exception( __( 'The ' . __CLASS__ . ' class can only be run within WP CLI.', 'action-scheduler' ) );
+			/* translators: %s php class name */
+			throw new Exception( sprintf( __( 'The %s class can only be run within WP CLI.', 'action-scheduler' ), __CLASS__ ) );
 		}
 
 		parent::__construct( $store, $monitor, $cleaner );


### PR DESCRIPTION
Translatable strings can't have variables or constants inside, this causes problems like:

![screenshot from 2018-11-30 16-13-00](https://user-images.githubusercontent.com/1264099/49306942-d5a11c00-f4ba-11e8-8529-a5a86febb48d.png)

