### PR TITLE
Display cron expression in Admin schedule recurrence table field

### DIFF
--- a/classes/ActionScheduler_CronSchedule.php
+++ b/classes/ActionScheduler_CronSchedule.php
@@ -32,6 +32,13 @@ class ActionScheduler_CronSchedule implements ActionScheduler_Schedule {
 	}
 
 	/**
+	 * @return string
+	 */
+	public function get_recurrence() {
+		return strval($this->cron);
+	}
+
+	/**
 	 * For PHP 5.2 compat, since DateTime objects can't be serialized
 	 * @return array
 	 */

--- a/classes/ActionScheduler_IntervalSchedule.php
+++ b/classes/ActionScheduler_IntervalSchedule.php
@@ -36,9 +36,7 @@ class ActionScheduler_IntervalSchedule implements ActionScheduler_Schedule {
 	}
 
 	/**
-	 * @param DateTime $after
-	 *
-	 * @return DateTime|null
+	 * @return int
 	 */
 	public function interval_in_seconds() {
 		return $this->interval_in_seconds;

--- a/classes/ActionScheduler_ListTable.php
+++ b/classes/ActionScheduler_ListTable.php
@@ -222,9 +222,16 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 	 */
 	protected function get_recurrence( $action ) {
 		$recurrence = $action->get_schedule();
-		if ( method_exists( $recurrence, 'interval_in_seconds' ) ) {
-			return sprintf( __( 'Every %s', 'action-scheduler' ), self::human_interval( $recurrence->interval_in_seconds() ) );
+		if ( $recurrence->is_recurring() ) {
+			if ( method_exists( $recurrence, 'interval_in_seconds' ) ) {
+				return sprintf( __( 'Every %s', 'action-scheduler' ), self::human_interval( $recurrence->interval_in_seconds() ) );
+			}
+
+			if ( method_exists( $recurrence, 'get_recurrence' ) ) {
+				return sprintf( __( 'Cron %s', 'action-scheduler' ), $recurrence->get_recurrence() );
+			}
 		}
+
 		return __( 'Non-repeating', 'action-scheduler' );
 	}
 


### PR DESCRIPTION
Currently, `Non-repeating` is displayed for `ActionScheduler_CronSchedule` actions scheduled via `as_schedule_cron_action`.