### PR TITLE
Add action_scheduler_pre_init hook

### DIFF
--- a/classes/ActionScheduler.php
+++ b/classes/ActionScheduler.php
@@ -85,6 +85,11 @@ abstract class ActionScheduler {
 		self::$plugin_file = $plugin_file;
 		spl_autoload_register( array( __CLASS__, 'autoload' ) );
 
+		/**
+		 * Fires in the early stages of Action Scheduler init hook.
+		 */
+		do_action( 'action_scheduler_pre_init' );
+
 		$store = self::store();
 		add_action( 'init', array( $store, 'init' ), 1, 0 );
 


### PR DESCRIPTION
This hook will help with the ability to filter core Action Scheduler classes, by ensuring that there is a reliable action to hook into. This ensures that trying to use a hook priority of `0.5` isn't necessary.

Helps with Prospress/action-scheduler-custom-tables#49.