### PR TITLE
Fix errors with PHP 5.2

### DIFF
--- a/classes/ActionScheduler_Logger.php
+++ b/classes/ActionScheduler_Logger.php
@@ -73,7 +73,7 @@ abstract class ActionScheduler_Logger {
 		$this->log( $action_id, __( 'action complete', 'action-scheduler' ) );
 	}
 
-	public function log_failed_action( $action_id, \Exception $exception ) {
+	public function log_failed_action( $action_id, Exception $exception ) {
 		$this->log( $action_id, sprintf( __( 'action failed: %s', 'action-scheduler' ), $exception->getMessage() ) );
 	}
 

--- a/classes/ActionScheduler_wpPostStore.php
+++ b/classes/ActionScheduler_wpPostStore.php
@@ -685,7 +685,7 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 		$status = $this->get_post_column( $action_id, 'post_status' );
 
 		if ( $status === null ) {
-			throw new \InvalidArgumentException( __( 'Invalid action ID. No status found.', 'action-scheduler' ) );
+			throw new InvalidArgumentException( __( 'Invalid action ID. No status found.', 'action-scheduler' ) );
 		}
 
 		return $this->get_action_status_by_post_status( $status );


### PR DESCRIPTION
Introduced after porting code from the Custom Tables plugin which does not rely on PHP 5.2

Fixes #226. Originally reported in woocommerce/woocommerce#22160