### PR TITLE
Always display date UTC offset, not timezone identifier

### DIFF
--- a/classes/ActionScheduler_ListTable.php
+++ b/classes/ActionScheduler_ListTable.php
@@ -280,7 +280,7 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 	protected function get_log_entry_html( ActionScheduler_LogEntry $log_entry, DateTimezone $timezone ) {
 		$date = $log_entry->get_date();
 		$date->setTimezone( $timezone );
-		return sprintf( '<li><strong>%s</strong><br/>%s</li>', esc_html( $date->format( 'Y-m-d H:i:s e' ) ), esc_html( $log_entry->get_message() ) );
+		return sprintf( '<li><strong>%s</strong><br/>%s</li>', esc_html( $date->format( 'Y-m-d H:i:s O' ) ), esc_html( $log_entry->get_message() ) );
 	}
 
 	/**
@@ -378,7 +378,7 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 
 		$next_timestamp = $schedule->next()->getTimestamp();
 
-		$schedule_display_string .= $schedule->next()->format( 'Y-m-d H:i:s e' );
+		$schedule_display_string .= $schedule->next()->format( 'Y-m-d H:i:s O' );
 		$schedule_display_string .= '<br/>';
 
 		if ( gmdate( 'U' ) > $next_timestamp ) {


### PR DESCRIPTION
To avoid displaying inconsitent values for the same thing, like `UTC` and `GMT+0000`.

For more background, see https://github.com/Prospress/action-scheduler/issues/208#issuecomment-456619348

Fixes #208