### PR TITLE
Display hook on WP CLI output

### DIFF
--- a/classes/ActionScheduler_Abstract_QueueRunner.php
+++ b/classes/ActionScheduler_Abstract_QueueRunner.php
@@ -57,7 +57,7 @@ abstract class ActionScheduler_Abstract_QueueRunner extends ActionScheduler_Abst
 			$action = $this->store->fetch_action( $action_id );
 			$this->store->log_execution( $action_id );
 			$action->execute();
-			do_action( 'action_scheduler_after_execute', $action_id );
+			do_action( 'action_scheduler_after_execute', $action_id, $action );
 			$this->store->mark_complete( $action_id );
 		} catch ( Exception $e ) {
 			$this->store->mark_failure( $action_id );

--- a/classes/ActionScheduler_WPCLI_QueueRunner.php
+++ b/classes/ActionScheduler_WPCLI_QueueRunner.php
@@ -77,7 +77,7 @@ class ActionScheduler_WPCLI_QueueRunner extends ActionScheduler_Abstract_QueueRu
 	 */
 	protected function add_hooks() {
 		add_action( 'action_scheduler_before_execute', array( $this, 'before_execute' ) );
-		add_action( 'action_scheduler_after_execute', array( $this, 'after_execute' ) );
+		add_action( 'action_scheduler_after_execute', array( $this, 'after_execute' ), 10, 2 );
 		add_action( 'action_scheduler_failed_execution', array( $this, 'action_failed' ), 10, 2 );
 	}
 
@@ -144,11 +144,16 @@ class ActionScheduler_WPCLI_QueueRunner extends ActionScheduler_Abstract_QueueRu
 	 *
 	 * @author Jeremy Pry
 	 *
-	 * @param $action_id
+	 * @param int $action_id
+	 * @param null|ActionScheduler_Action $action The instance of the action. Default to null for backward compatibility.
 	 */
-	public function after_execute( $action_id ) {
+	public function after_execute( $action_id, $action = null ) {
+		// backward compatibility
+		if ( null === $action ) {
+			$action = $this->store->fetch_action( $action_id );
+		}
 		/* translators: %s refers to the action ID */
-		WP_CLI::log( sprintf( __( 'Completed processing action %s', 'action-scheduler' ), $action_id ) );
+		WP_CLI::log( sprintf( __( 'Completed processing action %s with hook: %s', 'action-scheduler' ), $action_id, $action->get_hook() ) );
 	}
 
 	/**


### PR DESCRIPTION
Because the action has been instantiated by the time the `'action_scheduler_after_execute'` hook is triggered, it's possible to pass this instance of the action to callbacks.

This makes it possible to display the hook name (or other action properties) on that callback.

It's not possible to pass the action instance on other hooks used for WP CLI output, like `'action_scheduler_before_execute' `or `'action_scheduler_failed_execution'`, because there is no guarantee at that stage that the action will have been successfully instantiated in the case of the later, and moving the instantiation to happen prior to the former would be a breaking change. Because of this, its only be passed to the `'action_scheduler_after_execute'` hook.

Fixes #225 