### PR TITLE
Use 'pre_wp_unique_post_slug' for unique post name

### DIFF
--- a/classes/ActionScheduler_wpPostStore.php
+++ b/classes/ActionScheduler_wpPostStore.php
@@ -42,8 +42,10 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 
 	protected function save_post_array( $post_array ) {
 		add_filter( 'wp_insert_post_data', array( $this, 'filter_insert_post_data' ), 10, 1 );
+		add_filter( 'pre_wp_unique_post_slug', array( $this, 'set_unique_post_slug' ), 10, 5 );
 		$post_id = wp_insert_post($post_array);
 		remove_filter( 'wp_insert_post_data', array( $this, 'filter_insert_post_data' ), 10 );
+		remove_filter( 'pre_wp_unique_post_slug', array( $this, 'set_unique_post_slug' ), 10 );
 
 		if ( is_wp_error($post_id) || empty($post_id) ) {
 			throw new RuntimeException(__('Unable to save action.', 'action-scheduler'));
@@ -59,6 +61,41 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 			}
 		}
 		return $postdata;
+	}
+
+	/**
+	 * Create a (probably unique) post name for scheduled actions in a more performant manner than wp_unique_post_slug().
+	 *
+	 * When an action's post status is transitioned to something other than 'draft', 'pending' or 'auto-draft, like 'publish'
+	 * or 'failed' or 'trash', WordPress will find a unique slug (stored in post_name column) using the wp_unique_post_slug()
+	 * function. This is done to ensure URL uniqueness. The approach taken by wp_unique_post_slug() is to iterate over existing
+	 * post_name values that match, and append a number 1 greater than the largest. This makes sense when manually creating a
+	 * post from the Edit Post screen. It becomes a bottleneck when automatically processing thousands of actions, with a
+	 * database containing thousands of related post_name values.
+	 *
+	 * WordPress 5.1 introduces the 'pre_wp_unique_post_slug' filter for plugins to address this issue.
+	 *
+	 * We can short-circuit WordPress's wp_unique_post_slug() approach using the 'pre_wp_unique_post_slug' filter. This
+	 * method is available to be used as a callback on that filter. It provides a more scalable approach to generating a
+	 * post_name/slug that is probably unique. Because Action Scheduler never actually uses the post_name field, or an
+	 * action's slug, being probably unique is good enough.
+	 *
+	 * For more backstory on this issue, see:
+	 * - https://github.com/Prospress/action-scheduler/issues/44 and
+	 * - https://core.trac.wordpress.org/ticket/21112
+	 *
+	 * @param string $override_slug Short-circuit return value.
+	 * @param string $slug          The desired slug (post_name).
+	 * @param int    $post_ID       Post ID.
+	 * @param string $post_status   The post status.
+	 * @param string $post_type     Post type.
+	 * @return string
+	 */
+	public function set_unique_post_slug( $override_slug, $slug, $post_ID, $post_status, $post_type ) {
+		if ( self::POST_TYPE == $post_type ) {
+			$override_slug = uniqid( self::POST_TYPE . '-', true ) . '-' . wp_generate_password( 32, false );
+		}
+		return $override_slug;
 	}
 
 	protected function save_post_schedule( $post_id, $schedule ) {
@@ -404,7 +441,9 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 			throw new InvalidArgumentException(sprintf(__('Unidentified action %s', 'action-scheduler'), $action_id));
 		}
 		do_action( 'action_scheduler_canceled_action', $action_id );
+		add_filter( 'pre_wp_unique_post_slug', array( $this, 'set_unique_post_slug' ), 10, 5 );
 		wp_trash_post($action_id);
+		remove_filter( 'pre_wp_unique_post_slug', array( $this, 'set_unique_post_slug' ), 10 );
 	}
 
 	public function delete_action( $action_id ) {
@@ -716,11 +755,13 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 			throw new InvalidArgumentException(sprintf(__('Unidentified action %s', 'action-scheduler'), $action_id));
 		}
 		add_filter( 'wp_insert_post_data', array( $this, 'filter_insert_post_data' ), 10, 1 );
+		add_filter( 'pre_wp_unique_post_slug', array( $this, 'set_unique_post_slug' ), 10, 5 );
 		$result = wp_update_post(array(
 			'ID' => $action_id,
 			'post_status' => 'publish',
 		), TRUE);
 		remove_filter( 'wp_insert_post_data', array( $this, 'filter_insert_post_data' ), 10 );
+		remove_filter( 'pre_wp_unique_post_slug', array( $this, 'set_unique_post_slug' ), 10 );
 		if ( is_wp_error($result) ) {
 			throw new RuntimeException($result->get_error_message());
 		}


### PR DESCRIPTION
**tl;dr** - WordPress 5.1 is [introducing the `'pre_wp_unique_post_slug'` filter](https://core.trac.wordpress.org/ticket/21112#comment:27) for plugins to short-circuit the non-performant approach it takes to determining unique post slugs/`post_name` values.

We can take advantage of this filter to fix #44 as an interim perf improvement until #77 is finished.

---

When an action's post status is transitioned to something other than `'draft'`, `'pending'` or `'auto-draft'`, like `'publish'` or `'failed'` or `'trash'`, WordPress will find a unique slug (stored in the `post_name` column of the `wp_posts` table) using the `wp_unique_post_slug()` function.

This is done to ensure URL uniqueness for posts. It's not needed for scheduled action posts, which have no URL.

The approach taken by `wp_unique_post_slug()` is to iterate over existing `post_name` values that match, and increment a numeric suffix until a unique string is found. This makes sense when manually creating a post from the **Edit Post** screen. It becomes a bottleneck when automatically processing thousands of actions, with a database containing thousands of related `post_name` values.

WordPress 5.1 is introducing the `'pre_wp_unique_post_slug'` filter for plugins to address this issue.

We can short-circuit WordPress's `wp_unique_post_slug()` approach using the `'pre_wp_unique_post_slug'` filter. This patch adds `ActionScheduler_wpPostStore::set_unique_post_slug()` to be used as a callback on that filter. It provides a more scalable approach to generating a `post_name`/slug that is probably unique. Because Action Scheduler never actually uses the `post_name` field, or an action's slug, being probably unique is good enough.

For more backstory on this issue, see:
- https://github.com/Prospress/action-scheduler/issues/44 and
- https://core.trac.wordpress.org/ticket/21112