### PR TITLE
Version 2.2.0

### DIFF
--- a/action-scheduler.php
+++ b/action-scheduler.php
@@ -5,7 +5,7 @@
  * Description: A robust scheduling library for use in WordPress plugins.
  * Author: Prospress
  * Author URI: http://prospress.com/
- * Version: 2.1.1
+ * Version: 2.2.0
  * License: GPLv3
  *
  * Copyright 2018 Prospress, Inc.  (email : freedoms@prospress.com)
@@ -25,21 +25,21 @@
  *
  */
 
-if ( ! function_exists( 'action_scheduler_register_2_dot_1_dot_1' ) ) {
+if ( ! function_exists( 'action_scheduler_register_2_dot_2_dot_0' ) ) {
 
 	if ( ! class_exists( 'ActionScheduler_Versions' ) ) {
 		require_once( 'classes/ActionScheduler_Versions.php' );
 		add_action( 'plugins_loaded', array( 'ActionScheduler_Versions', 'initialize_latest_version' ), 1, 0 );
 	}
 
-	add_action( 'plugins_loaded', 'action_scheduler_register_2_dot_1_dot_1', 0, 0 );
+	add_action( 'plugins_loaded', 'action_scheduler_register_2_dot_2_dot_0', 0, 0 );
 
-	function action_scheduler_register_2_dot_1_dot_1() {
+	function action_scheduler_register_2_dot_2_dot_0() {
 		$versions = ActionScheduler_Versions::instance();
-		$versions->register( '2.1.1', 'action_scheduler_initialize_2_dot_1_dot_1' );
+		$versions->register( '2.2.0', 'action_scheduler_initialize_2_dot_2_dot_0' );
 	}
 
-	function action_scheduler_initialize_2_dot_1_dot_1() {
+	function action_scheduler_initialize_2_dot_2_dot_0() {
 		require_once( 'classes/ActionScheduler.php' );
 		ActionScheduler::init( __FILE__ );
 	}


### PR DESCRIPTION
```
* Add: Add 'action_scheduler_pre_init' hook to make it easier to filter core Action Scheduler classes, by providing a reliable, separate action to hook into instead of 3rd party code having to rely on 'plugins_loaded' with a priority between 0 and 1. PR #221
* Fix: Remove inclusion of constant in translatable string for WP CLI output. PR #213 Props @claudiosanches 
* Fix: Fix errors with PHP 5.2 caused by use of namespace prefix (inherited from code in the Custom Tables plugin where PHP 5.6 is required). PR #227
* Perf: Use the new 'pre_wp_unique_post_slug' filter with WordPress 5.1 and newer to create unique post names and improve performance of default, Custom Post Type, data store. PR #231
* Tweak: Make timeout & failure periods a multiple of the allowed time limit to simply increasing allowed time limits. PR #223
* Tweak: Display hook name on WP CLI output when processing queues. PR #230
* Tweak: Always display a date's UTC offset, not timezone identifier, to avoid displaying inconsistent values for the same thing, like UTC and GMT+0000. PR #228
* Tweak: Display cron expression in schedule recurrence column of administration screen for Cron actions. PR #217 Props @alexminza 
```