### PR TITLE
Ensure we have a valid schedule in `make_action_from_post`

### DIFF
--- a/classes/ActionScheduler_wpPostStore.php
+++ b/classes/ActionScheduler_wpPostStore.php
@@ -139,7 +139,7 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 		}
 
 		$schedule = get_post_meta( $post->ID, self::SCHEDULE_META_KEY, true );
-		if ( empty($schedule) ) {
+		if ( empty( $schedule ) || ! is_a( $schedule, 'ActionScheduler_Schedule' ) ) {
 			$schedule = new ActionScheduler_NullSchedule();
 		}
 		$group = wp_get_object_terms( $post->ID, self::GROUP_TAXONOMY, array('fields' => 'names') );


### PR DESCRIPTION
[This error](https://github.com/woocommerce/woocommerce/issues/22767) can be caused if the meta is not a valid `ActionScheduler_Schedule` object. You can force this to happen by spawning an event and editing the meta value to a non empty string.

This patch adds an additonal validation check to ensure the value is what we're expecting, and avoids the fatal error.