### PR TITLE
update date_query to use before parameter

### DIFF
--- a/classes/ActionScheduler_wpPostStore.php
+++ b/classes/ActionScheduler_wpPostStore.php
@@ -626,8 +626,9 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 				'ID'         => 'ASC',
 			),
 			'date_query'       => array(
-				'column' => 'post_date',
-				'before' => $date->format( 'Y-m-d H:i:s' ),
+				'column' => 'post_date_gmt',
+				'before' => $date->format( 'Y-m-d H:i' ),
+				'inclusive' => true,
 			),
 			'tax_query' => array(
 				array(

--- a/classes/ActionScheduler_wpPostStore.php
+++ b/classes/ActionScheduler_wpPostStore.php
@@ -627,15 +627,7 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 			),
 			'date_query'       => array(
 				'column' => 'post_date',
-				array(
-					'compare' => '<=',
-					'year'    => $date->format( 'Y' ),
-					'month'   => $date->format( 'n' ),
-					'day'     => $date->format( 'j' ),
-					'hour'    => $date->format( 'G' ),
-					'minute'  => $date->format( 'i' ),
-					'second'  => $date->format( 's' ),
-				),
+				'before' => $date->format( 'Y-m-d H:i:s' ),
 			),
 			'tax_query' => array(
 				array(


### PR DESCRIPTION
Fixes #248 

This PR updates `ActionScheduler_wpPostStore::get_actions_by_group()` to use the `before` parameter to select eligible actions.

Use the steps outlined in #248 with this PR to run the edited scheduled action.