### PR TITLE
Version 2.2.1

### DIFF
--- a/action-scheduler.php
+++ b/action-scheduler.php
@@ -25,21 +25,21 @@
  *
  */
 
-if ( ! function_exists( 'action_scheduler_register_2_dot_2_dot_0' ) ) {
+if ( ! function_exists( 'action_scheduler_register_2_dot_2_dot_1' ) ) {
 
 	if ( ! class_exists( 'ActionScheduler_Versions' ) ) {
 		require_once( 'classes/ActionScheduler_Versions.php' );
 		add_action( 'plugins_loaded', array( 'ActionScheduler_Versions', 'initialize_latest_version' ), 1, 0 );
 	}
 
-	add_action( 'plugins_loaded', 'action_scheduler_register_2_dot_2_dot_0', 0, 0 );
+	add_action( 'plugins_loaded', 'action_scheduler_register_2_dot_2_dot_1', 0, 0 );
 
-	function action_scheduler_register_2_dot_2_dot_0() {
+	function action_scheduler_register_2_dot_2_dot_1() {
 		$versions = ActionScheduler_Versions::instance();
-		$versions->register( '2.2.0', 'action_scheduler_initialize_2_dot_2_dot_0' );
+		$versions->register( '2.2.1', 'action_scheduler_initialize_2_dot_2_dot_1' );
 	}
 
-	function action_scheduler_initialize_2_dot_2_dot_0() {
+	function action_scheduler_initialize_2_dot_2_dot_1() {
 		require_once( 'classes/ActionScheduler.php' );
 		ActionScheduler::init( __FILE__ );
 	}


### PR DESCRIPTION
```
* Fix: Stake claim by group missing some actions when environment time zone not set
* Fix: Text domain on translated strings 
* Fix: Validate schedule meta when retrieving a scheduled action
* Add: Scheduled action stats to WooCommerce System Status
```