### PR TITLE
WP CLI: Add timestamps to output

### DIFF
--- a/classes/ActionScheduler_DateTime.php
+++ b/classes/ActionScheduler_DateTime.php
@@ -73,15 +73,4 @@ class ActionScheduler_DateTime extends DateTime {
 	public function getOffsetTimestamp() {
 		return $this->getTimestamp() + $this->getOffset();
 	}
-
-	/**
-	 * Get the timestamp for use in WP CLI output.
-	 *
-	 * @return string
-	 */
-	public function getCliTimestamp() {
-		if ( defined( 'AS_CLI_TIMESTAMP' ) && AS_CLI_TIMESTAMP ) {
-			return '[' . date_i18n( AS_CLI_TIMESTAMP, $this->format( 'U' ) ) . '] ';
-		}
-	}
 }

--- a/classes/ActionScheduler_DateTime.php
+++ b/classes/ActionScheduler_DateTime.php
@@ -80,6 +80,8 @@ class ActionScheduler_DateTime extends DateTime {
 	 * @return string
 	 */
 	public function getCliTimestamp() {
-		return '[' . date_i18n( 'Y-m-d H:i:s', $this->format( 'U' ) ) . '] ';
+		if ( defined( 'AS_CLI_TIMESTAMP' ) && AS_CLI_TIMESTAMP ) {
+			return '[' . date_i18n( AS_CLI_TIMESTAMP, $this->format( 'U' ) ) . '] ';
+		}
 	}
 }

--- a/classes/ActionScheduler_DateTime.php
+++ b/classes/ActionScheduler_DateTime.php
@@ -80,6 +80,6 @@ class ActionScheduler_DateTime extends DateTime {
 	 * @return string
 	 */
 	public function getCliTimestamp() {
-		return '[' . $this->format( 'Y-m-d H:i:s' ) . '] ';
+		return '[' . date_i18n( 'Y-m-d H:i:s', $this->format( 'U' ) ) . '] ';
 	}
 }

--- a/classes/ActionScheduler_DateTime.php
+++ b/classes/ActionScheduler_DateTime.php
@@ -73,4 +73,13 @@ class ActionScheduler_DateTime extends DateTime {
 	public function getOffsetTimestamp() {
 		return $this->getTimestamp() + $this->getOffset();
 	}
+
+	/**
+	 * Get the timestamp for use in WP CLI output.
+	 *
+	 * @return string
+	 */
+	public function getCliTimestamp() {
+		return '[' . $this->format( 'Y-m-d H:i:s' ) . '] ';
+	}
 }

--- a/classes/ActionScheduler_WPCLI_QueueRunner.php
+++ b/classes/ActionScheduler_WPCLI_QueueRunner.php
@@ -61,9 +61,9 @@ class ActionScheduler_WPCLI_QueueRunner extends ActionScheduler_Abstract_QueueRu
 		$too_many    = $claim_count >= $this->get_allowed_concurrent_batches();
 		if ( $too_many ) {
 			if ( $force ) {
-				WP_CLI::warning( as_get_datetime_object()->getCliTimestamp() . __( 'There are too many concurrent batches, but the run is forced to continue.', 'action-scheduler' ) );
+				WP_CLI::warning( as_get_formatted_cli_timestamp() . __( 'There are too many concurrent batches, but the run is forced to continue.', 'action-scheduler' ) );
 			} else {
-				WP_CLI::error( as_get_datetime_object()->getCliTimestamp() . __( 'There are too many concurrent batches.', 'action-scheduler' ) );
+				WP_CLI::error( as_get_formatted_cli_timestamp() . __( 'There are too many concurrent batches.', 'action-scheduler' ) );
 			}
 		}
 
@@ -111,7 +111,7 @@ class ActionScheduler_WPCLI_QueueRunner extends ActionScheduler_Abstract_QueueRu
 		foreach ( $this->actions as $action_id ) {
 			// Error if we lost the claim.
 			if ( ! in_array( $action_id, $this->store->find_actions_by_claim_id( $this->claim->get_id() ) ) ) {
-				WP_CLI::warning( as_get_datetime_object()->getCliTimestamp() . __( 'The claim has been lost. Aborting current batch.', 'action-scheduler' ) );
+				WP_CLI::warning( as_get_formatted_cli_timestamp() . __( 'The claim has been lost. Aborting current batch.', 'action-scheduler' ) );
 				break;
 			}
 
@@ -141,7 +141,7 @@ class ActionScheduler_WPCLI_QueueRunner extends ActionScheduler_Abstract_QueueRu
 	 */
 	public function before_execute( $action_id ) {
 		/* translators: %s refers to the action ID */
-		WP_CLI::log( sprintf( '%s' . __( 'Started processing action %s', 'action-scheduler' ), as_get_datetime_object()->getCliTimestamp(), $action_id ) );
+		WP_CLI::log( sprintf( '%s' . __( 'Started processing action %s', 'action-scheduler' ), as_get_formatted_cli_timestamp(), $action_id ) );
 	}
 
 	/**
@@ -158,7 +158,7 @@ class ActionScheduler_WPCLI_QueueRunner extends ActionScheduler_Abstract_QueueRu
 			$action = $this->store->fetch_action( $action_id );
 		}
 		/* translators: %s refers to the action ID */
-		WP_CLI::log( sprintf( '%s' . __( 'Completed processing action %s with hook: %s', 'action-scheduler' ), as_get_datetime_object()->getCliTimestamp(), $action_id, $action->get_hook() ) );
+		WP_CLI::log( sprintf( '%s' . __( 'Completed processing action %s with hook: %s', 'action-scheduler' ), as_get_formatted_cli_timestamp(), $action_id, $action->get_hook() ) );
 	}
 
 	/**
@@ -173,7 +173,7 @@ class ActionScheduler_WPCLI_QueueRunner extends ActionScheduler_Abstract_QueueRu
 	public function action_failed( $action_id, $exception ) {
 		WP_CLI::error(
 			/* translators: %2$s refers to the action ID, %3$s refers to the Exception message */
-			sprintf( '%1$s' . __( 'Error processing action %2$s: %3$s', 'action-scheduler' ), as_get_datetime_object()->getCliTimestamp(), $action_id, $exception->getMessage() ),
+			sprintf( '%1$s' . __( 'Error processing action %2$s: %3$s', 'action-scheduler' ), as_get_formatted_cli_timestamp(), $action_id, $exception->getMessage() ),
 			false
 		);
 	}
@@ -185,11 +185,11 @@ class ActionScheduler_WPCLI_QueueRunner extends ActionScheduler_Abstract_QueueRu
 	 */
 	protected function stop_the_insanity( $sleep_time = 0 ) {
 		if ( 0 < $sleep_time ) {
-			WP_CLI::warning( sprintf( '%sStopped the insanity for %d %s', as_get_datetime_object()->getCliTimestamp(), $sleep_time, _n( 'second', 'seconds', $sleep_time ) ) );
+			WP_CLI::warning( sprintf( '%sStopped the insanity for %d %s', as_get_formatted_cli_timestamp(), $sleep_time, _n( 'second', 'seconds', $sleep_time ) ) );
 			sleep( $sleep_time );
 		}
 
-		WP_CLI::warning( as_get_datetime_object()->getCliTimestamp() . __( 'Attempting to reduce used memory...', 'action-scheduler' ) );
+		WP_CLI::warning( as_get_formatted_cli_timestamp() . __( 'Attempting to reduce used memory...', 'action-scheduler' ) );
 
 		/**
 		 * @var $wpdb            \wpdb

--- a/classes/ActionScheduler_WPCLI_QueueRunner.php
+++ b/classes/ActionScheduler_WPCLI_QueueRunner.php
@@ -16,9 +16,6 @@ class ActionScheduler_WPCLI_QueueRunner extends ActionScheduler_Abstract_QueueRu
 	/** @var \cli\progress\Bar */
 	protected $progress_bar;
 
-	/** @var bool */
-	protected $print_timestamp = false;
-
 	/**
 	 * ActionScheduler_WPCLI_QueueRunner constructor.
 	 *
@@ -51,8 +48,6 @@ class ActionScheduler_WPCLI_QueueRunner extends ActionScheduler_Abstract_QueueRu
 	 * @throws \WP_CLI\ExitException When there are too many concurrent batches.
 	 */
 	public function setup( $batch_size, $hooks = array(), $group = '', $force = false ) {
-		$this->print_timestamp = $print_timestamp;
-
 		$this->run_cleanup();
 		$this->add_hooks();
 

--- a/classes/ActionScheduler_WPCLI_QueueRunner.php
+++ b/classes/ActionScheduler_WPCLI_QueueRunner.php
@@ -16,6 +16,9 @@ class ActionScheduler_WPCLI_QueueRunner extends ActionScheduler_Abstract_QueueRu
 	/** @var \cli\progress\Bar */
 	protected $progress_bar;
 
+	/** @var bool */
+	protected $print_timestamp = false;
+
 	/**
 	 * ActionScheduler_WPCLI_QueueRunner constructor.
 	 *
@@ -39,15 +42,18 @@ class ActionScheduler_WPCLI_QueueRunner extends ActionScheduler_Abstract_QueueRu
 	 *
 	 * @author Jeremy Pry
 	 *
-	 * @param int    $batch_size The batch size to process.
-	 * @param array  $hooks      The hooks being used to filter the actions claimed in this batch.
-	 * @param string $group      The group of actions to claim with this batch.
-	 * @param bool   $force      Whether to force running even with too many concurrent processes.
+	 * @param int    $batch_size       The batch size to process.
+	 * @param array  $hooks            The hooks being used to filter the actions claimed in this batch.
+	 * @param string $group            The group of actions to claim with this batch.
+	 * @param bool   $force            Whether to force running even with too many concurrent processes.
+	 * @param bool   $print_timestamp  Whether to print the timestamp on each line.
 	 *
 	 * @return int The number of actions that will be run.
 	 * @throws \WP_CLI\ExitException When there are too many concurrent batches.
 	 */
-	public function setup( $batch_size, $hooks = array(), $group = '', $force = false ) {
+	public function setup( $batch_size, $hooks = array(), $group = '', $force = false, $print_timestamp = false ) {
+		$this->print_timestamp = $print_timestamp;
+
 		$this->run_cleanup();
 		$this->add_hooks();
 
@@ -56,9 +62,9 @@ class ActionScheduler_WPCLI_QueueRunner extends ActionScheduler_Abstract_QueueRu
 		$too_many    = $claim_count >= $this->get_allowed_concurrent_batches();
 		if ( $too_many ) {
 			if ( $force ) {
-				WP_CLI::warning( __( 'There are too many concurrent batches, but the run is forced to continue.', 'action-scheduler' ) );
+				WP_CLI::warning( $this->maybe_get_timestamp() . __( 'There are too many concurrent batches, but the run is forced to continue.', 'action-scheduler' ) );
 			} else {
-				WP_CLI::error( __( 'There are too many concurrent batches.', 'action-scheduler' ) );
+				WP_CLI::error( $this->maybe_get_timestamp() . __( 'There are too many concurrent batches.', 'action-scheduler' ) );
 			}
 		}
 
@@ -106,7 +112,7 @@ class ActionScheduler_WPCLI_QueueRunner extends ActionScheduler_Abstract_QueueRu
 		foreach ( $this->actions as $action_id ) {
 			// Error if we lost the claim.
 			if ( ! in_array( $action_id, $this->store->find_actions_by_claim_id( $this->claim->get_id() ) ) ) {
-				WP_CLI::warning( __( 'The claim has been lost. Aborting current batch.', 'action-scheduler' ) );
+				WP_CLI::warning( $this->maybe_get_timestamp() . __( 'The claim has been lost. Aborting current batch.', 'action-scheduler' ) );
 				break;
 			}
 
@@ -136,7 +142,7 @@ class ActionScheduler_WPCLI_QueueRunner extends ActionScheduler_Abstract_QueueRu
 	 */
 	public function before_execute( $action_id ) {
 		/* translators: %s refers to the action ID */
-		WP_CLI::log( sprintf( __( 'Started processing action %s', 'action-scheduler' ), $action_id ) );
+		WP_CLI::log( sprintf( '%s' . __( 'Started processing action %s', 'action-scheduler' ), $this->maybe_get_timestamp(), $action_id ) );
 	}
 
 	/**
@@ -153,7 +159,7 @@ class ActionScheduler_WPCLI_QueueRunner extends ActionScheduler_Abstract_QueueRu
 			$action = $this->store->fetch_action( $action_id );
 		}
 		/* translators: %s refers to the action ID */
-		WP_CLI::log( sprintf( __( 'Completed processing action %s with hook: %s', 'action-scheduler' ), $action_id, $action->get_hook() ) );
+		WP_CLI::log( sprintf( '%s' . __( 'Completed processing action %s with hook: %s', 'action-scheduler' ), $this->maybe_get_timestamp(), $action_id, $action->get_hook() ) );
 	}
 
 	/**
@@ -167,8 +173,8 @@ class ActionScheduler_WPCLI_QueueRunner extends ActionScheduler_Abstract_QueueRu
 	 */
 	public function action_failed( $action_id, $exception ) {
 		WP_CLI::error(
-			/* translators: %1$s refers to the action ID, %2$s refers to the Exception message */
-			sprintf( __( 'Error processing action %1$s: %2$s', 'action-scheduler' ), $action_id, $exception->getMessage() ),
+			/* translators: %2$s refers to the action ID, %3$s refers to the Exception message */
+			sprintf( '%1$s' . __( 'Error processing action %2$s: %3$s', 'action-scheduler' ), $this->maybe_get_timestamp(), $action_id, $exception->getMessage() ),
 			false
 		);
 	}
@@ -180,11 +186,11 @@ class ActionScheduler_WPCLI_QueueRunner extends ActionScheduler_Abstract_QueueRu
 	 */
 	protected function stop_the_insanity( $sleep_time = 0 ) {
 		if ( 0 < $sleep_time ) {
-			WP_CLI::warning( sprintf( 'Stopped the insanity for %d %s', $sleep_time, _n( 'second', 'seconds', $sleep_time ) ) );
+			WP_CLI::warning( sprintf( '%sStopped the insanity for %d %s', $this->maybe_get_timestamp(), $sleep_time, _n( 'second', 'seconds', $sleep_time ) ) );
 			sleep( $sleep_time );
 		}
 
-		WP_CLI::warning( __( 'Attempting to reduce used memory...', 'action-scheduler' ) );
+		WP_CLI::warning( $this->maybe_get_timestamp() . __( 'Attempting to reduce used memory...', 'action-scheduler' ) );
 
 		/**
 		 * @var $wpdb            \wpdb
@@ -205,6 +211,18 @@ class ActionScheduler_WPCLI_QueueRunner extends ActionScheduler_Abstract_QueueRu
 
 		if ( is_callable( array( $wp_object_cache, '__remoteset' ) ) ) {
 			call_user_func( array( $wp_object_cache, '__remoteset' ) ); // important
+		}
+	}
+
+	/**
+	 * Get timestamp if property 'print_timestamp' is truthy.
+	 *
+	 * @uses ActionScheduler_DateTime::getCliTimestamp()
+	 * @return null|string
+	 */
+	protected function maybe_get_timestamp() {
+		if ( $this->print_timestamp ) {
+			return as_get_datetime_object()->getCliTimestamp();
 		}
 	}
 }

--- a/classes/ActionScheduler_WPCLI_Scheduler_command.php
+++ b/classes/ActionScheduler_WPCLI_Scheduler_command.php
@@ -96,7 +96,7 @@ class ActionScheduler_WPCLI_Scheduler_command extends WP_CLI_Command {
 			sprintf(
 				/* translators: %d refers to how many scheduled taks were found to run */
 				_n( '%sFound %d scheduled task', '%sFound %d scheduled tasks', $total, 'action-scheduler' ),
-				as_get_datetime_object()->getCliTimestamp(),
+				as_get_formatted_cli_timestamp(),
 				number_format_i18n( $total )
 			)
 		);
@@ -114,7 +114,7 @@ class ActionScheduler_WPCLI_Scheduler_command extends WP_CLI_Command {
 			sprintf(
 				/* translators: %d refers to the total number of batches executed */
 				'%s' . _n( '%d batch executed.', '%d batches executed.', $batches_completed, 'action-scheduler' ),
-				as_get_datetime_object()->getCliTimestamp(),
+				as_get_formatted_cli_timestamp(),
 				number_format_i18n( $batches_completed )
 			)
 		);
@@ -134,7 +134,7 @@ class ActionScheduler_WPCLI_Scheduler_command extends WP_CLI_Command {
 			sprintf(
 				/* translators: %s refers to the exception error message. */
 				'%s' . __( 'There was an error running the action scheduler: %s', 'action-scheduler' ),
-				as_get_datetime_object()->getCliTimestamp(),
+				as_get_formatted_cli_timestamp(),
 				$e->getMessage()
 			)
 		);
@@ -152,7 +152,7 @@ class ActionScheduler_WPCLI_Scheduler_command extends WP_CLI_Command {
 			sprintf(
 				/* translators: %d refers to the total number of taskes completed */
 				'%s' . _n( '%d scheduled task completed.', '%s%d scheduled tasks completed.', $actions_completed, 'action-scheduler' ),
-				as_get_datetime_object()->getCliTimestamp(),
+				as_get_formatted_cli_timestamp(),
 				number_format_i18n( $actions_completed )
 			)
 		);

--- a/classes/ActionScheduler_WPCLI_Scheduler_command.php
+++ b/classes/ActionScheduler_WPCLI_Scheduler_command.php
@@ -50,7 +50,7 @@ class ActionScheduler_WPCLI_Scheduler_command extends WP_CLI_Command {
 		$actions_completed = 0;
 		$unlimited         = $batches === 0;
 
-		if ( $time !== (string) $time ) {
+		if ( true === $time ) {
 			$time = 'Y-m-d H:i:s T';
 		}
 

--- a/classes/ActionScheduler_WPCLI_Scheduler_command.php
+++ b/classes/ActionScheduler_WPCLI_Scheduler_command.php
@@ -95,7 +95,7 @@ class ActionScheduler_WPCLI_Scheduler_command extends WP_CLI_Command {
 		WP_CLI::log(
 			sprintf(
 				/* translators: %d refers to how many scheduled taks were found to run */
-				_n( '%sFound %d scheduled task', '%sFound %d scheduled tasks', $total, 'action-scheduler' ),
+				'%s' . _n( 'Found %d scheduled task', 'Found %d scheduled tasks', $total, 'action-scheduler' ),
 				as_get_formatted_cli_timestamp(),
 				number_format_i18n( $total )
 			)
@@ -151,7 +151,7 @@ class ActionScheduler_WPCLI_Scheduler_command extends WP_CLI_Command {
 		WP_CLI::success(
 			sprintf(
 				/* translators: %d refers to the total number of taskes completed */
-				'%s' . _n( '%d scheduled task completed.', '%s%d scheduled tasks completed.', $actions_completed, 'action-scheduler' ),
+				'%s' . _n( '%d scheduled task completed.', '%d scheduled tasks completed.', $actions_completed, 'action-scheduler' ),
 				as_get_formatted_cli_timestamp(),
 				number_format_i18n( $actions_completed )
 			)

--- a/classes/ActionScheduler_WPCLI_Scheduler_command.php
+++ b/classes/ActionScheduler_WPCLI_Scheduler_command.php
@@ -28,8 +28,8 @@ class ActionScheduler_WPCLI_Scheduler_command extends WP_CLI_Command {
 	 * [--force]
 	 * : Whether to force execution despite the maximum number of concurrent processes being exceeded.
 	 *
-	 * [--t]
-	 * : Whether to print timestamp on each line.
+	 * [--time]
+	 * : Whether to print timestamp on each line. Also accepts a string of charactes for the timestamps format.
 	 *
 	 * @param array $args Positional arguments.
 	 * @param array $assoc_args Keyed arguments.
@@ -37,18 +37,24 @@ class ActionScheduler_WPCLI_Scheduler_command extends WP_CLI_Command {
 	 */
 	public function run( $args, $assoc_args ) {
 		// Handle passed arguments.
-		$batch           = absint( \WP_CLI\Utils\get_flag_value( $assoc_args, 'batch-size', 100 ) );
-		$batches         = absint( \WP_CLI\Utils\get_flag_value( $assoc_args, 'batches', 0 ) );
-		$clean           = absint( \WP_CLI\Utils\get_flag_value( $assoc_args, 'cleanup-batch-size', $batch ) );
-		$hooks           = explode( ',', WP_CLI\Utils\get_flag_value( $assoc_args, 'hooks', '' ) );
-		$hooks           = array_filter( array_map( 'trim', $hooks ) );
-		$group           = \WP_CLI\Utils\get_flag_value( $assoc_args, 'group', '' );
-		$force           = \WP_CLI\Utils\get_flag_value( $assoc_args, 'force', false );
-		$print_timestamp = \WP_CLI\Utils\get_flag_value( $assoc_args, 't', false );
+		$batch   = absint( \WP_CLI\Utils\get_flag_value( $assoc_args, 'batch-size', 100 ) );
+		$batches = absint( \WP_CLI\Utils\get_flag_value( $assoc_args, 'batches', 0 ) );
+		$clean   = absint( \WP_CLI\Utils\get_flag_value( $assoc_args, 'cleanup-batch-size', $batch ) );
+		$hooks   = explode( ',', WP_CLI\Utils\get_flag_value( $assoc_args, 'hooks', '' ) );
+		$hooks   = array_filter( array_map( 'trim', $hooks ) );
+		$group   = \WP_CLI\Utils\get_flag_value( $assoc_args, 'group', '' );
+		$force   = \WP_CLI\Utils\get_flag_value( $assoc_args, 'force', false );
+		$time    = \WP_CLI\Utils\get_flag_value( $assoc_args, 'time', false );
 
 		$batches_completed = 0;
 		$actions_completed = 0;
 		$unlimited         = $batches === 0;
+
+		if ( $time !== (string) $time ) {
+			$time = 'Y-m-d H:i:s T';
+		}
+
+		define( 'AS_CLI_TIMESTAMP', $time );
 
 		try {
 			// Custom queue cleaner instance.
@@ -58,23 +64,23 @@ class ActionScheduler_WPCLI_Scheduler_command extends WP_CLI_Command {
 			$runner = new ActionScheduler_WPCLI_QueueRunner( null, null, $cleaner );
 
 			// Determine how many tasks will be run in the first batch.
-			$total = $runner->setup( $batch, $hooks, $group, $force, $print_timestamp );
+			$total = $runner->setup( $batch, $hooks, $group, $force );
 
 			// Run actions for as long as possible.
 			while ( $total > 0 ) {
-				$this->print_total_actions( $total, $print_timestamp );
+				$this->print_total_actions( $total );
 				$actions_completed += $runner->run();
 				$batches_completed++;
 
 				// Maybe set up tasks for the next batch.
-				$total = ( $unlimited || $batches_completed < $batches ) ? $runner->setup( $batch, $hooks, $group, $force, $print_timestamp ) : 0;
+				$total = ( $unlimited || $batches_completed < $batches ) ? $runner->setup( $batch, $hooks, $group, $force ) : 0;
 			}
 		} catch ( Exception $e ) {
-			$this->print_error( $e, $print_timestamp );
+			$this->print_error( $e );
 		}
 
-		$this->print_total_batches( $batches_completed, $print_timestamp );
-		$this->print_success( $actions_completed, $print_timestamp );
+		$this->print_total_batches( $batches_completed );
+		$this->print_success( $actions_completed );
 	}
 
 	/**
@@ -84,14 +90,13 @@ class ActionScheduler_WPCLI_Scheduler_command extends WP_CLI_Command {
 	 *
 	 * @param int $total
 	 */
-	protected function print_total_actions( $total, $print_timestamp = false ) {
-		$timestamp = $print_timestamp ? as_get_datetime_object()->getCliTimestamp() : '';
+	protected function print_total_actions( $total ) {
 
 		WP_CLI::log(
 			sprintf(
 				/* translators: %d refers to how many scheduled taks were found to run */
 				_n( '%sFound %d scheduled task', '%sFound %d scheduled tasks', $total, 'action-scheduler' ),
-				$timestamp,
+				as_get_datetime_object()->getCliTimestamp(),
 				number_format_i18n( $total )
 			)
 		);
@@ -104,14 +109,12 @@ class ActionScheduler_WPCLI_Scheduler_command extends WP_CLI_Command {
 	 *
 	 * @param int $batches_completed
 	 */
-	protected function print_total_batches( $batches_completed, $print_timestamp = false ) {
-		$timestamp = $print_timestamp ? as_get_datetime_object()->getCliTimestamp() : '';
-
+	protected function print_total_batches( $batches_completed ) {
 		WP_CLI::log(
 			sprintf(
 				/* translators: %d refers to the total number of batches executed */
-				_n( '%s%d batch executed.', '%s%d batches executed.', $batches_completed, 'action-scheduler' ),
-				$timestamp,
+				'%s' . _n( '%d batch executed.', '%d batches executed.', $batches_completed, 'action-scheduler' ),
+				as_get_datetime_object()->getCliTimestamp(),
 				number_format_i18n( $batches_completed )
 			)
 		);
@@ -126,14 +129,12 @@ class ActionScheduler_WPCLI_Scheduler_command extends WP_CLI_Command {
 	 *
 	 * @throws \WP_CLI\ExitException
 	 */
-	protected function print_error( Exception $e, $print_timestamp = false ) {
-		$timestamp = $print_timestamp ? as_get_datetime_object()->getCliTimestamp() : '';
-
+	protected function print_error( Exception $e ) {
 		WP_CLI::error(
 			sprintf(
 				/* translators: %s refers to the exception error message. */
-				__( '%sThere was an error running the action scheduler: %s', 'action-scheduler' ),
-				$timestamp,
+				'%s' . __( 'There was an error running the action scheduler: %s', 'action-scheduler' ),
+				as_get_datetime_object()->getCliTimestamp(),
 				$e->getMessage()
 			)
 		);
@@ -146,14 +147,12 @@ class ActionScheduler_WPCLI_Scheduler_command extends WP_CLI_Command {
 	 *
 	 * @param int $actions_completed
 	 */
-	protected function print_success( $actions_completed, $print_timestamp = false ) {
-		$timestamp = $print_timestamp ? as_get_datetime_object()->getCliTimestamp() : '';
-
+	protected function print_success( $actions_completed ) {
 		WP_CLI::success(
 			sprintf(
 				/* translators: %d refers to the total number of taskes completed */
-				_n( '%s%d scheduled task completed.', '%s%d scheduled tasks completed.', $actions_completed, 'action-scheduler' ),
-				$timestamp,
+				'%s' . _n( '%d scheduled task completed.', '%s%d scheduled tasks completed.', $actions_completed, 'action-scheduler' ),
+				as_get_datetime_object()->getCliTimestamp(),
 				number_format_i18n( $actions_completed )
 			)
 		);

--- a/functions.php
+++ b/functions.php
@@ -215,6 +215,6 @@ function as_get_datetime_object( $date_string = null, $timezone = 'UTC' ) {
  */
 function as_get_formatted_cli_timestamp() {
 	if ( defined( 'AS_CLI_TIMESTAMP' ) && AS_CLI_TIMESTAMP ) {
-		return '[' . date_i18n( AS_CLI_TIMESTAMP, $this->format( 'U' ) ) . '] ';
+		return '[' . as_get_datetime_object()->format( AS_CLI_TIMESTAMP ) . '] ';
 	}
 }

--- a/functions.php
+++ b/functions.php
@@ -213,7 +213,7 @@ function as_get_datetime_object( $date_string = null, $timezone = 'UTC' ) {
  *
  * @return string
  */
-function as_get_formatted_cli_timestamp()() {
+function as_get_formatted_cli_timestamp() {
 	if ( defined( 'AS_CLI_TIMESTAMP' ) && AS_CLI_TIMESTAMP ) {
 		return '[' . date_i18n( AS_CLI_TIMESTAMP, $this->format( 'U' ) ) . '] ';
 	}

--- a/functions.php
+++ b/functions.php
@@ -209,11 +209,11 @@ function as_get_datetime_object( $date_string = null, $timezone = 'UTC' ) {
 }
 
 /**
- * Get the timestamp for use in WP CLI output.
+ * Get the formatted timestamp for use in WP CLI output.
  *
  * @return string
  */
-public function as_get_formatted_cli_timestamp()() {
+function as_get_formatted_cli_timestamp()() {
 	if ( defined( 'AS_CLI_TIMESTAMP' ) && AS_CLI_TIMESTAMP ) {
 		return '[' . date_i18n( AS_CLI_TIMESTAMP, $this->format( 'U' ) ) . '] ';
 	}

--- a/functions.php
+++ b/functions.php
@@ -207,3 +207,14 @@ function as_get_datetime_object( $date_string = null, $timezone = 'UTC' ) {
 	}
 	return $date;
 }
+
+/**
+ * Get the timestamp for use in WP CLI output.
+ *
+ * @return string
+ */
+public function as_get_formatted_cli_timestamp()() {
+	if ( defined( 'AS_CLI_TIMESTAMP' ) && AS_CLI_TIMESTAMP ) {
+		return '[' . date_i18n( AS_CLI_TIMESTAMP, $this->format( 'U' ) ) . '] ';
+	}
+}


### PR DESCRIPTION
PR for #175.

Notes:
1. Adds a flag `--t` to print timestamps.
1. While I attempted to be DRY, likely will need to be adjusted to fit Prospress preferred design.
1. No timestamp on progress bar, because the timestamp doesn't update.
1. Because effort is made to always use UTC, no timezone output on timestamp.
1. Timestamps are added outside of translation functions (ex: `__()`) when possible, but `date_i18n()` is used on the date's format. May need to be adjusted; not sure what's proper here.