### PR TITLE
QueueRunner::process_action() - check $action before schedule_next_instance()

### DIFF
--- a/classes/ActionScheduler_Abstract_QueueRunner.php
+++ b/classes/ActionScheduler_Abstract_QueueRunner.php
@@ -63,7 +63,10 @@ abstract class ActionScheduler_Abstract_QueueRunner extends ActionScheduler_Abst
 			$this->store->mark_failure( $action_id );
 			do_action( 'action_scheduler_failed_execution', $action_id, $e );
 		}
-		$this->schedule_next_instance( $action );
+
+		if ( isset( $action ) && is_a( $action, 'ActionScheduler_Action' ) ) {
+			$this->schedule_next_instance( $action );
+		}
 	}
 
 	/**


### PR DESCRIPTION
Only attempt to schedule the next instance of an action if it was successfully fetched.

If an exception is thrown during an action fetch (here: [#](https://github.com/Prospress/action-scheduler/blob/master/classes/ActionScheduler_Abstract_QueueRunner.php#L57)), `$action` will be undefined when `schedule_next_instance()` is called here [#](https://github.com/Prospress/action-scheduler/blob/master/classes/ActionScheduler_Abstract_QueueRunner.php#L66).

This PR adds a check to ensure that `$action` is a `ActionScheduler_Action`. Includes test.