### PR TITLE
WP CLI: 'version' command

### DIFF
--- a/classes/ActionScheduler.php
+++ b/classes/ActionScheduler.php
@@ -110,6 +110,7 @@ abstract class ActionScheduler {
 
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			WP_CLI::add_command( 'action-scheduler', 'ActionScheduler_WPCLI' );
+			require_once( self::plugin_path('deprecated/ActionScheduler_WPCLI_Scheduler_command.php') );
 		}
 	}
 

--- a/classes/ActionScheduler_Abstract_WPCLI_Command.php
+++ b/classes/ActionScheduler_Abstract_WPCLI_Command.php
@@ -12,91 +12,16 @@ abstract class ActionScheduler_Abstract_WPCLI_Command {
 	protected $assoc_args;
 
 	/**
-	 * @var bool Enable printing of timestamp.
-	 */
-	protected $timestamp = false;
-
-	/**
-	 * @var string Format of timestamp.
-	 */
-	protected $timestamp_format = 'Y-m-d H:i:s T';
-
-	/**
 	 * Construct.
 	 */
 	public function __construct( $args, $assoc_args ) {
 		$this->args = $args;
 		$this->assoc_args = $assoc_args;
-		$this->timestamp = (bool) \WP_CLI\Utils\get_flag_value( $assoc_args, 'time', false );
-		$this->timestamp_format = \WP_CLI\Utils\get_flag_value( $assoc_args, 'time-format', $this->timestamp_format );
 	}
 
 	/**
 	 * Execute command.
 	 */
 	abstract public function execute();
-
-	/**
-	 * Wrapper for WP_CLI::log()
-	 *
-	 * @param string $message
-	 */
-	protected function log( $message ) {
-		WP_CLI::log( sprintf( '%s%s', $this->output_timestamp(), $message ) );
-	}
-
-	/**
-	 * Wrapper for WP_CLI::warning()
-	 *
-	 * @param string $message
-	 */
-	protected function warning( $message ) {
-		WP_CLI::warning( sprintf( '%s%s', $this->output_timestamp(), $message ) );
-	}
-
-	/**
-	 * Wrapper for WP_CLI::error()
-	 *
-	 * @param string $message
-	 */
-	protected function error( $message ) {
-		WP_CLI::error( sprintf( '%s%s', $this->output_timestamp(), $message ) );
-	}
-
-	/**
-	 * Wrapper for WP_CLI::success()
-	 *
-	 * @param string $message
-	 */
-	protected function success( $message ) {
-		WP_CLI::success( sprintf( '%s%s', $this->output_timestamp(), $message ) );
-	}
-
-	/**
-	 * Wrapper for WP_CLI_Utils\format_items( 'table' )
-	 *
-	 * @param array $rows
-	 * @param string $columns
-	 */
-	protected function table( $rows, $columns ) {
-		\WP_CLI\Utils\format_items( 'table', $rows, $columns );
-
- 		if ( ! empty( $this->timestamp ) ) {
-			$this->log( sprintf( 'Table generated.', $this->output_timestamp() ) );
-		}
-	}
-
-	/**
-	 * Print timestamp to CLI, if enabled.
-	 *
-	 * @return string
-	 */
-	protected function output_timestamp() {
-		if ( empty( $this->timestamp ) ) {
-			return '';
-		}
-
-		return '[' . as_get_datetime_object()->format( $this->timestamp_format ) . '] ';
-	}
 
 }

--- a/classes/ActionScheduler_Abstract_WPCLI_Command.php
+++ b/classes/ActionScheduler_Abstract_WPCLI_Command.php
@@ -38,13 +38,26 @@ abstract class ActionScheduler_Abstract_WPCLI_Command {
 
 	/**
 	 * Wrapper for WP_CLI::log()
+	 *
+	 * @param string $message
 	 */
 	protected function log( $message ) {
 		WP_CLI::log( sprintf( '%s%s', $this->output_timestamp(), $message ) );
 	}
 
 	/**
+	 * Wrapper for WP_CLI::warning()
+	 *
+	 * @param string $message
+	 */
+	protected function warning( $message ) {
+		WP_CLI::warning( sprintf( '%s%s', $this->output_timestamp(), $message ) );
+	}
+
+	/**
 	 * Wrapper for WP_CLI::error()
+	 *
+	 * @param string $message
 	 */
 	protected function error( $message ) {
 		WP_CLI::error( sprintf( '%s%s', $this->output_timestamp(), $message ) );
@@ -52,9 +65,25 @@ abstract class ActionScheduler_Abstract_WPCLI_Command {
 
 	/**
 	 * Wrapper for WP_CLI::success()
+	 *
+	 * @param string $message
 	 */
 	protected function success( $message ) {
 		WP_CLI::success( sprintf( '%s%s', $this->output_timestamp(), $message ) );
+	}
+
+	/**
+	 * Wrapper for WP_CLI_Utils\format_items( 'table' )
+	 *
+	 * @param array $rows
+	 * @param string $columns
+	 */
+	protected function table( $rows, $columns ) {
+		\WP_CLI\Utils\format_items( 'table', $rows, $columns );
+
+ 		if ( ! empty( $this->timestamp ) ) {
+			$this->log( sprintf( 'Table generated.', $this->output_timestamp() ) );
+		}
 	}
 
 	/**

--- a/classes/ActionScheduler_Abstract_WPCLI_Command.php
+++ b/classes/ActionScheduler_Abstract_WPCLI_Command.php
@@ -57,6 +57,14 @@ abstract class ActionScheduler_Abstract_WPCLI_Command {
 		WP_CLI::success( sprintf( '%s%s', $this->output_timestamp(), $message ) );
 	}
 
+	protected function table( $items, $columns ) {
+		\WP_CLI\Utils\format_items( 'table', $items, $columns );
+
+		if ( ! empty( $this->timestamp ) ) {
+			$this->log( sprintf( 'Generated at %s', $this->output_timestamp() ) );
+		}
+	}
+
 	/**
 	 * Print timestamp to CLI, if enabled.
 	 *

--- a/classes/ActionScheduler_Versions.php
+++ b/classes/ActionScheduler_Versions.php
@@ -12,11 +12,11 @@ class ActionScheduler_Versions {
 	private $versions = array();
 
 	public function register( $version_string, $initialization_callback ) {
-		if ( isset($this->versions[$version_string]) ) {
-			return FALSE;
+		if ( ! isset($this->versions[$version_string]) ) {
+			$this->versions[$version_string] = array();
 		}
-		$this->versions[$version_string] = $initialization_callback;
-		return TRUE;
+		$this->versions[$version_string][] = $initialization_callback;
+		return count( $this->versions[$version_string] ) < 2;
 	}
 
 	public function get_versions() {
@@ -37,7 +37,7 @@ class ActionScheduler_Versions {
 		if ( empty($latest) || !isset($this->versions[$latest]) ) {
 			return '__return_null';
 		}
-		return $this->versions[$latest];
+		return $this->versions[$latest][0];
 	}
 
 	/**
@@ -59,4 +59,3 @@ class ActionScheduler_Versions {
 		call_user_func($self->latest_version_callback());
 	}
 }
- 

--- a/classes/ActionScheduler_WPCLI.php
+++ b/classes/ActionScheduler_WPCLI.php
@@ -43,4 +43,20 @@ class ActionScheduler_WPCLI extends WP_CLI_Command {
 		$command->execute();
 	}
 
+	/**
+	 * Get Action Scheduler version(s)
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--all]
+	 * : Prints a table of all registered versions.
+	 *
+	 * @param array $args Positional arguments.
+	 * @param array $assoc_args Keyed arguments.
+	 */
+	public function version( $args, $assoc_args ) {
+		$command = new ActionScheduler_WPCLI_Command_Version( $args, $assoc_args );
+		$command->execute();
+	}
+
 }

--- a/classes/ActionScheduler_WPCLI_Command_Run.php
+++ b/classes/ActionScheduler_WPCLI_Command_Run.php
@@ -77,7 +77,7 @@ class ActionScheduler_WPCLI_Command_Run extends ActionScheduler_Abstract_WPCLI_C
 	 * @param int $total
 	 */
 	protected function print_total_actions( $total ) {
-		WP_CLI::log(
+		\WP_CLI::log(
 			sprintf(
 				/* translators: %d refers to how many scheduled taks were found to run */
 				'%s' . _n( 'Found %d scheduled task', 'Found %d scheduled tasks', $total, 'action-scheduler' ),
@@ -95,7 +95,7 @@ class ActionScheduler_WPCLI_Command_Run extends ActionScheduler_Abstract_WPCLI_C
 	 * @param int $batches_completed
 	 */
 	protected function print_total_batches( $batches_completed ) {
-		WP_CLI::log(
+		\WP_CLI::log(
 			sprintf(
 				/* translators: %d refers to the total number of batches executed */
 				'%s' . _n( '%d batch executed.', '%d batches executed.', $batches_completed, 'action-scheduler' ),
@@ -115,7 +115,7 @@ class ActionScheduler_WPCLI_Command_Run extends ActionScheduler_Abstract_WPCLI_C
 	 * @throws \WP_CLI\ExitException
 	 */
 	protected function print_error( Exception $e ) {
-		WP_CLI::error(
+		\WP_CLI::error(
 			sprintf(
 				/* translators: %s refers to the exception error message. */
 				'%s' . __( 'There was an error running the action scheduler: %s', 'action-scheduler' ),
@@ -133,7 +133,7 @@ class ActionScheduler_WPCLI_Command_Run extends ActionScheduler_Abstract_WPCLI_C
 	 * @param int $actions_completed
 	 */
 	protected function print_success( $actions_completed ) {
-		WP_CLI::success(
+		\WP_CLI::success(
 			sprintf(
 				/* translators: %d refers to the total number of taskes completed */
 				'%s' . _n( '%d scheduled task completed.', '%d scheduled tasks completed.', $actions_completed, 'action-scheduler' ),

--- a/classes/ActionScheduler_WPCLI_Command_Run.php
+++ b/classes/ActionScheduler_WPCLI_Command_Run.php
@@ -6,6 +6,26 @@
 class ActionScheduler_WPCLI_Command_Run extends ActionScheduler_Abstract_WPCLI_Command {
 
 	/**
+	 * @var bool Enable printing of timestamp.
+	 */
+	protected $timestamp = false;
+
+	/**
+	 * @var string Format of timestamp.
+	 */
+	protected $timestamp_format = 'Y-m-d H:i:s T';
+
+	/**
+	 * Construct.
+	 */
+	public function __construct( $args, $assoc_args ) {
+		parent::__construct( $args, $assoc_args );
+
+		$this->timestamp = (bool) \WP_CLI\Utils\get_flag_value( $assoc_args, 'time', false );
+		$this->timestamp_format = \WP_CLI\Utils\get_flag_value( $assoc_args, 'time-format', $this->timestamp_format );
+	}
+
+	/**
 	 * Execute command.
 	 */
 	public function execute() {
@@ -57,10 +77,11 @@ class ActionScheduler_WPCLI_Command_Run extends ActionScheduler_Abstract_WPCLI_C
 	 * @param int $total
 	 */
 	protected function print_total_actions( $total ) {
-		$this->log(
+		WP_CLI::log(
 			sprintf(
 				/* translators: %d refers to how many scheduled taks were found to run */
-				_n( 'Found %d scheduled task', 'Found %d scheduled tasks', $total, 'action-scheduler' ),
+				'%s' . _n( 'Found %d scheduled task', 'Found %d scheduled tasks', $total, 'action-scheduler' ),
+				$this->output_timestamp(),
 				number_format_i18n( $total )
 			)
 		);
@@ -74,10 +95,11 @@ class ActionScheduler_WPCLI_Command_Run extends ActionScheduler_Abstract_WPCLI_C
 	 * @param int $batches_completed
 	 */
 	protected function print_total_batches( $batches_completed ) {
-		$this->log(
+		WP_CLI::log(
 			sprintf(
 				/* translators: %d refers to the total number of batches executed */
-				_n( '%d batch executed.', '%d batches executed.', $batches_completed, 'action-scheduler' ),
+				'%s' . _n( '%d batch executed.', '%d batches executed.', $batches_completed, 'action-scheduler' ),
+				$this->output_timestamp(),
 				number_format_i18n( $batches_completed )
 			)
 		);
@@ -93,10 +115,11 @@ class ActionScheduler_WPCLI_Command_Run extends ActionScheduler_Abstract_WPCLI_C
 	 * @throws \WP_CLI\ExitException
 	 */
 	protected function print_error( Exception $e ) {
-		$this->error(
+		WP_CLI::error(
 			sprintf(
 				/* translators: %s refers to the exception error message. */
-				__( 'There was an error running the action scheduler: %s', 'action-scheduler' ),
+				'%s' . __( 'There was an error running the action scheduler: %s', 'action-scheduler' ),
+				$this->output_timestamp(),
 				$e->getMessage()
 			)
 		);
@@ -110,12 +133,26 @@ class ActionScheduler_WPCLI_Command_Run extends ActionScheduler_Abstract_WPCLI_C
 	 * @param int $actions_completed
 	 */
 	protected function print_success( $actions_completed ) {
-		$this->success(
+		WP_CLI::success(
 			sprintf(
 				/* translators: %d refers to the total number of taskes completed */
-				_n( '%d scheduled task completed.', '%d scheduled tasks completed.', $actions_completed, 'action-scheduler' ),
+				'%s' . _n( '%d scheduled task completed.', '%d scheduled tasks completed.', $actions_completed, 'action-scheduler' ),
+				$this->output_timestamp(),
 				number_format_i18n( $actions_completed )
 			)
 		);
+	}
+
+	/**
+	 * Print timestamp if enabled.
+	 *
+	 * @return string
+	 */
+	protected function output_timestamp() {
+		if ( empty( $this->timestamp ) ) {
+			return '';
+		}
+
+		return '[' . as_get_datetime_object()->format( $this->timestamp_format ) . '] ';
 	}
 }

--- a/classes/ActionScheduler_WPCLI_Command_Version.php
+++ b/classes/ActionScheduler_WPCLI_Command_Version.php
@@ -38,11 +38,13 @@ class ActionScheduler_WPCLI_Command_Version extends ActionScheduler_Abstract_WPC
 			foreach ( $callbacks as $callback ) {
 				$reflection = new ReflectionFunction( $callback );
 				$reflection_filepath = $reflection->getFileName();
+				$is_active = dirname( $reflection_filepath ) === ActionScheduler::plugin_path( '' );
 
 				$items[] = array(
 					'version' => $version,
 					'callback' => $callback,
 					'component' => $this->get_component( $reflection_filepath ),
+					'active' => $is_active ? 'X' : '',
 				);
 
 				$version_strings[] = $version;
@@ -51,7 +53,7 @@ class ActionScheduler_WPCLI_Command_Version extends ActionScheduler_Abstract_WPC
 
 		// array_multisort( array_column( $items, 'version' ), $items );
 
-		$this->table( $items, array( 'version', 'component' ) );
+		$this->table( $items, array( 'version', 'component', 'active' ) );
 	}
 
 	/**

--- a/classes/ActionScheduler_WPCLI_Command_Version.php
+++ b/classes/ActionScheduler_WPCLI_Command_Version.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * WP CLI command to get Action Scheduler versions.
+ */
+class ActionScheduler_WPCLI_Command_Version extends ActionScheduler_Abstract_WPCLI_Command {
+
+	/**
+	 * Execute command.
+	 */
+	public function execute() {
+		$all = (bool) \WP_CLI\Utils\get_flag_value( $this->assoc_args, 'all', false );
+		$helper = ActionScheduler_Versions::instance();
+
+		if ( $all ) {
+			$this->print_all( $helper->get_versions() );
+		} else {
+			$this->log( $helper->latest_version() );
+		}
+	}
+
+	/**
+	 * Print table of versions.
+	 */
+	protected function print_all( $versions ) {
+		$versions = array_keys( $versions );
+		usort( $versions, 'version_compare' );
+
+		$items = array();
+
+		foreach ( $versions as $version ) {
+			$items[] = array(
+				'version' => $version
+			);
+		}
+
+		$this->table( $items, 'version' );
+	}
+
+}

--- a/deprecated/ActionScheduler_WPCLI_Scheduler_command.php
+++ b/deprecated/ActionScheduler_WPCLI_Scheduler_command.php
@@ -5,7 +5,14 @@
  *
  * Retain public API for backwards compatibility.
  */
-class ActionScheduler_WPCLI_Scheduler_command {
+class ActionScheduler_WPCLI_Scheduler_command extends ActionScheduler_WPCLI_Command_Run {
+
+	/**
+	 * Construct.
+	 */
+	function __construct() {
+		_deprecated_function( __METHOD__, '2.3.0' );
+	}
 
 	/**
 	 * Deprecated 'run' command.
@@ -17,8 +24,9 @@ class ActionScheduler_WPCLI_Scheduler_command {
 	function run( $args, $assoc_args ) {
 		_deprecated_function( __METHOD__, '2.3.0' );
 
-		$command = new ActionScheduler_WPCLI_Command_Run( $args, $assoc_args );
-		$command->execute();
+		parent::__construct( $args, $assoc_args );
+
+		$this->execute();
 	}
 
 }

--- a/deprecated/ActionScheduler_WPCLI_Scheduler_command.php
+++ b/deprecated/ActionScheduler_WPCLI_Scheduler_command.php
@@ -5,7 +5,7 @@
  *
  * Retain public API for backwards compatibility.
  */
-class ActionScheduler_WPCLI_Scheduler_command extends ActionScheduler_WPCLI_Command_Run {
+class ActionScheduler_WPCLI_Scheduler_Command extends ActionScheduler_WPCLI_Command_Run {
 
 	/**
 	 * Construct.

--- a/deprecated/ActionScheduler_WPCLI_Scheduler_command.php
+++ b/deprecated/ActionScheduler_WPCLI_Scheduler_command.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * Class ActionScheduler_WPCLI_Scheduler_command
+ *
+ * Retain public API for backwards compatibility.
+ */
+class ActionScheduler_WPCLI_Scheduler_command {
+
+	/**
+	 * Deprecated 'run' command.
+	 *
+	 * @param array $args Positional arguments.
+	 * @param array $assoc_args Keyed arguments.
+	 * @uses ActionScheduler_WPCLI_Command_Run::execute()
+	 */
+	function run( $args, $assoc_args ) {
+		_deprecated_function( __METHOD__, '2.3.0' );
+
+		$command = new ActionScheduler_WPCLI_Command_Run( $args, $assoc_args );
+		$command->execute();
+	}
+
+}


### PR DESCRIPTION
The [second commit of `version` command](https://github.com/crstauf/action-scheduler/commit/5750802b0bfa4dca7ba4750551907af9ce60ba55) may not be wanted, as it makes some changes to `ActionScheduler_Versions` class; I went ahead and built it, as I see benefit, but also recognize it may not be wanted. Please let me know, and I can revert before merging.

Screenshot of `version` command output:

<img width="842" alt="Screen Shot 2019-03-27 at 12 40 35 AM" src="https://user-images.githubusercontent.com/4573033/55050811-fc1a3280-5028-11e9-9a88-43a62e5c66c2.png">