### PR TITLE
Tag version 2.2.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 phpunit.xml
 vendor
+docs
+tests
 .idea
+.github
+.travis.yml
+codecov.yml

--- a/action-scheduler.php
+++ b/action-scheduler.php
@@ -5,7 +5,7 @@
  * Description: A robust scheduling library for use in WordPress plugins.
  * Author: Prospress
  * Author URI: http://prospress.com/
- * Version: 2.2.2
+ * Version: 2.2.3
  * License: GPLv3
  *
  * Copyright 2019 Prospress, Inc.  (email : freedoms@prospress.com)
@@ -25,21 +25,21 @@
  *
  */
 
-if ( ! function_exists( 'action_scheduler_register_2_dot_2_dot_2' ) ) {
+if ( ! function_exists( 'action_scheduler_register_2_dot_2_dot_3' ) ) {
 
 	if ( ! class_exists( 'ActionScheduler_Versions' ) ) {
 		require_once( 'classes/ActionScheduler_Versions.php' );
 		add_action( 'plugins_loaded', array( 'ActionScheduler_Versions', 'initialize_latest_version' ), 1, 0 );
 	}
 
-	add_action( 'plugins_loaded', 'action_scheduler_register_2_dot_2_dot_2', 0, 0 );
+	add_action( 'plugins_loaded', 'action_scheduler_register_2_dot_2_dot_3', 0, 0 );
 
-	function action_scheduler_register_2_dot_2_dot_2() {
+	function action_scheduler_register_2_dot_2_dot_3() {
 		$versions = ActionScheduler_Versions::instance();
-		$versions->register( '2.2.2', 'action_scheduler_initialize_2_dot_2_dot_2' );
+		$versions->register( '2.2.3', 'action_scheduler_initialize_2_dot_2_dot_3' );
 	}
 
-	function action_scheduler_initialize_2_dot_2_dot_2() {
+	function action_scheduler_initialize_2_dot_2_dot_3() {
 		require_once( 'classes/ActionScheduler.php' );
 		ActionScheduler::init( __FILE__ );
 	}

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,6 @@
   "minimum-stability": "dev",
   "require": {},
   "require-dev": {
-    "wp-cli/wp-cli": "^1.3"
+    "wp-cli/wp-cli": "1.5.1"
   }
 }


### PR DESCRIPTION
To add a few improvements to the release process, namely:

* Do not include the `/docs/` or `/tests/` directories and other dev related files, like `.github` or `.travis.yml`, in releases
* Pin dependency wp-cli/wp-cli to 1.5.1 to match changes made in WooCommerce core: woocommerce/woocommerce#23028
