### PR TITLE
Restore "Improve WP CLI Extendability" for 2.3.0

### DIFF
--- a/classes/ActionScheduler.php
+++ b/classes/ActionScheduler.php
@@ -109,7 +109,7 @@ abstract class ActionScheduler {
 		}
 
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
-			WP_CLI::add_command( 'action-scheduler', 'ActionScheduler_WPCLI_Scheduler_command' );
+			WP_CLI::add_command( 'action-scheduler', 'ActionScheduler_WPCLI' );
 		}
 	}
 

--- a/classes/ActionScheduler_Abstract_WPCLI_Command.php
+++ b/classes/ActionScheduler_Abstract_WPCLI_Command.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * Action Scheduler abstract class for WP CLI commands.
+ */
+abstract class ActionScheduler_Abstract_WPCLI_Command {
+
+	/**
+	 * @var array
+	 */
+	protected $args;
+	protected $assoc_args;
+
+	/**
+	 * @var bool Enable printing of timestamp.
+	 */
+	protected $timestamp = false;
+
+	/**
+	 * @var string Format of timestamp.
+	 */
+	protected $timestamp_format = 'Y-m-d H:i:s T';
+
+	/**
+	 * Construct.
+	 */
+	public function __construct( $args, $assoc_args ) {
+		$this->args = $args;
+		$this->assoc_args = $assoc_args;
+		$this->timestamp = (bool) \WP_CLI\Utils\get_flag_value( $assoc_args, 'time', false );
+		$this->timestamp_format = \WP_CLI\Utils\get_flag_value( $assoc_args, 'time-format', $this->timestamp_format );
+	}
+
+	/**
+	 * Execute command.
+	 */
+	abstract public function execute();
+
+	/**
+	 * Wrapper for WP_CLI::log()
+	 */
+	protected function log( $message ) {
+		WP_CLI::log( sprintf( '%s%s', $this->output_timestamp(), $message ) );
+	}
+
+	/**
+	 * Wrapper for WP_CLI::error()
+	 */
+	protected function error( $message ) {
+		WP_CLI::error( sprintf( '%s%s', $this->output_timestamp(), $message ) );
+	}
+
+	/**
+	 * Wrapper for WP_CLI::success()
+	 */
+	protected function success( $message ) {
+		WP_CLI::success( sprintf( '%s%s', $this->output_timestamp(), $message ) );
+	}
+
+	/**
+	 * Print timestamp to CLI, if enabled.
+	 *
+	 * @return string
+	 */
+	protected function output_timestamp() {
+		if ( empty( $this->timestamp ) ) {
+			return '';
+		}
+
+		return '[' . as_get_datetime_object()->format( $this->timestamp_format ) . '] ';
+	}
+
+}

--- a/classes/ActionScheduler_WPCLI.php
+++ b/classes/ActionScheduler_WPCLI.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * Commands for the Action Scheduler by Prospress.
+ */
+class ActionScheduler_WPCLI extends WP_CLI_Command {
+
+	/**
+	 * Run the Action Scheduler
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--batch-size=<size>]
+	 * : The maximum number of actions to run. Defaults to 100.
+	 *
+	 * [--batches=<size>]
+	 * : Limit execution to a number of batches. Defaults to 0, meaning batches will continue being executed until all actions are complete.
+	 *
+	 * [--cleanup-batch-size=<size>]
+	 * : The maximum number of actions to clean up. Defaults to the value of --batch-size.
+	 *
+	 * [--hooks=<hooks>]
+	 * : Only run actions with the specified hook. Omitting this option runs actions with any hook. Define multiple hooks as a comma separated string (without spaces), e.g. `--hooks=hook_one,hook_two,hook_three`
+	 *
+	 * [--group=<group>]
+	 * : Only run actions from the specified group. Omitting this option runs actions from all groups.
+	 *
+	 * [--force]
+	 * : Whether to force execution despite the maximum number of concurrent processes being exceeded.
+	 *
+	 * [--time]
+	 * : Whether to print timestamp on each line.
+	 *
+	 * [--time-format=<format>]
+	 * : Format for the timestamp. Defaults to Y-m-d H:i:s T.
+	 *
+	 * @param array $args Positional arguments.
+	 * @param array $assoc_args Keyed arguments.
+	 * @throws \WP_CLI\ExitException When an error occurs.
+	 */
+	public function run( $args, $assoc_args ) {
+		$command = new ActionScheduler_WPCLI_Command_Run( $args, $assoc_args );
+		$command->execute();
+	}
+
+}

--- a/classes/ActionScheduler_WPCLI_Command_Run.php
+++ b/classes/ActionScheduler_WPCLI_Command_Run.php
@@ -1,46 +1,22 @@
 <?php
 
 /**
- * Commands for the Action Scheduler by Prospress.
+ * Action Scheduler WP CLI command to run the queue.
  */
-class ActionScheduler_WPCLI_Scheduler_command extends WP_CLI_Command {
+class ActionScheduler_WPCLI_Command_Run extends ActionScheduler_Abstract_WPCLI_Command {
 
 	/**
-	 * Run the Action Scheduler
-	 *
-	 * ## OPTIONS
-	 *
-	 * [--batch-size=<size>]
-	 * : The maximum number of actions to run. Defaults to 100.
-	 *
-	 * [--batches=<size>]
-	 * : Limit execution to a number of batches. Defaults to 0, meaning batches will continue being executed until all actions are complete.
-	 *
-	 * [--cleanup-batch-size=<size>]
-	 * : The maximum number of actions to clean up. Defaults to the value of --batch-size.
-	 *
-	 * [--hooks=<hooks>]
-	 * : Only run actions with the specified hook. Omitting this option runs actions with any hook. Define multiple hooks as a comma separated string (without spaces), e.g. `--hooks=hook_one,hook_two,hook_three`
-	 *
-	 * [--group=<group>]
-	 * : Only run actions from the specified group. Omitting this option runs actions from all groups.
-	 *
-	 * [--force]
-	 * : Whether to force execution despite the maximum number of concurrent processes being exceeded.
-	 *
-	 * @param array $args Positional arguments.
-	 * @param array $assoc_args Keyed arguments.
-	 * @throws \WP_CLI\ExitException When an error occurs.
+	 * Execute command.
 	 */
-	public function run( $args, $assoc_args ) {
+	public function execute() {
 		// Handle passed arguments.
-		$batch   = absint( \WP_CLI\Utils\get_flag_value( $assoc_args, 'batch-size', 100 ) );
-		$batches = absint( \WP_CLI\Utils\get_flag_value( $assoc_args, 'batches', 0 ) );
-		$clean   = absint( \WP_CLI\Utils\get_flag_value( $assoc_args, 'cleanup-batch-size', $batch ) );
-		$hooks   = explode( ',', WP_CLI\Utils\get_flag_value( $assoc_args, 'hooks', '' ) );
+		$batch   = absint( \WP_CLI\Utils\get_flag_value( $this->assoc_args, 'batch-size', 100 ) );
+		$batches = absint( \WP_CLI\Utils\get_flag_value( $this->assoc_args, 'batches', 0 ) );
+		$clean   = absint( \WP_CLI\Utils\get_flag_value( $this->assoc_args, 'cleanup-batch-size', $batch ) );
+		$hooks   = explode( ',', WP_CLI\Utils\get_flag_value( $this->assoc_args, 'hooks', '' ) );
 		$hooks   = array_filter( array_map( 'trim', $hooks ) );
-		$group   = \WP_CLI\Utils\get_flag_value( $assoc_args, 'group', '' );
-		$force   = \WP_CLI\Utils\get_flag_value( $assoc_args, 'force', false );
+		$group   = \WP_CLI\Utils\get_flag_value( $this->assoc_args, 'group', '' );
+		$force   = \WP_CLI\Utils\get_flag_value( $this->assoc_args, 'force', false );
 
 		$batches_completed = 0;
 		$actions_completed = 0;
@@ -81,7 +57,7 @@ class ActionScheduler_WPCLI_Scheduler_command extends WP_CLI_Command {
 	 * @param int $total
 	 */
 	protected function print_total_actions( $total ) {
-		WP_CLI::log(
+		$this->log(
 			sprintf(
 				/* translators: %d refers to how many scheduled taks were found to run */
 				_n( 'Found %d scheduled task', 'Found %d scheduled tasks', $total, 'action-scheduler' ),
@@ -98,7 +74,7 @@ class ActionScheduler_WPCLI_Scheduler_command extends WP_CLI_Command {
 	 * @param int $batches_completed
 	 */
 	protected function print_total_batches( $batches_completed ) {
-		WP_CLI::log(
+		$this->log(
 			sprintf(
 				/* translators: %d refers to the total number of batches executed */
 				_n( '%d batch executed.', '%d batches executed.', $batches_completed, 'action-scheduler' ),
@@ -117,7 +93,7 @@ class ActionScheduler_WPCLI_Scheduler_command extends WP_CLI_Command {
 	 * @throws \WP_CLI\ExitException
 	 */
 	protected function print_error( Exception $e ) {
-		WP_CLI::error(
+		$this->error(
 			sprintf(
 				/* translators: %s refers to the exception error message. */
 				__( 'There was an error running the action scheduler: %s', 'action-scheduler' ),
@@ -134,7 +110,7 @@ class ActionScheduler_WPCLI_Scheduler_command extends WP_CLI_Command {
 	 * @param int $actions_completed
 	 */
 	protected function print_success( $actions_completed ) {
-		WP_CLI::success(
+		$this->success(
 			sprintf(
 				/* translators: %d refers to the total number of taskes completed */
 				_n( '%d scheduled task completed.', '%d scheduled tasks completed.', $actions_completed, 'action-scheduler' ),


### PR DESCRIPTION
Reverts Prospress/action-scheduler#273 which reverted #267 so that we could ship smaller fixes in 2.2.2. But #267 is code we actually want to release, just not until 2.3.0, so this PR restores that code in the `release/2.3.0` branch.