### PR TITLE
WP CLI: add 'info' command

### DIFF
--- a/classes/ActionScheduler.php
+++ b/classes/ActionScheduler.php
@@ -110,6 +110,7 @@ abstract class ActionScheduler {
 
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			WP_CLI::add_command( 'action-scheduler', 'ActionScheduler_WPCLI' );
+			require_once( self::plugin_path('deprecated/ActionScheduler_WPCLI_Scheduler_command.php') );
 		}
 	}
 

--- a/classes/ActionScheduler_Abstract_WPCLI_Command.php
+++ b/classes/ActionScheduler_Abstract_WPCLI_Command.php
@@ -58,6 +58,17 @@ abstract class ActionScheduler_Abstract_WPCLI_Command {
 	}
 
 	/**
+	 * Wrapper for WP_CLI_Utils\format_items( 'table' )
+	 */
+	protected function table( $items, $columns ) {
+		\WP_CLI\Utils\format_items( 'table', $items, $columns );
+
+		if ( ! empty( $this->timestamp ) ) {
+			$this->log( sprintf( 'Table generated.', $this->output_timestamp() ) );
+		}
+	}
+
+	/**
 	 * Print timestamp to CLI, if enabled.
 	 *
 	 * @return string

--- a/classes/ActionScheduler_Abstract_WPCLI_Command.php
+++ b/classes/ActionScheduler_Abstract_WPCLI_Command.php
@@ -22,11 +22,6 @@ abstract class ActionScheduler_Abstract_WPCLI_Command {
 	protected $timestamp_format = 'Y-m-d H:i:s T';
 
 	/**
-	 * @var ActionScheduler_Store
-	 */
-	protected $store = null;
-
-	/**
 	 * Construct.
 	 */
 	public function __construct( $args, $assoc_args ) {

--- a/classes/ActionScheduler_Abstract_WPCLI_Command.php
+++ b/classes/ActionScheduler_Abstract_WPCLI_Command.php
@@ -22,6 +22,11 @@ abstract class ActionScheduler_Abstract_WPCLI_Command {
 	protected $timestamp_format = 'Y-m-d H:i:s T';
 
 	/**
+	 * @var ActionScheduler_Store
+	 */
+	protected $store = null;
+
+	/**
 	 * Construct.
 	 */
 	public function __construct( $args, $assoc_args ) {
@@ -29,6 +34,7 @@ abstract class ActionScheduler_Abstract_WPCLI_Command {
 		$this->assoc_args = $assoc_args;
 		$this->timestamp = (bool) \WP_CLI\Utils\get_flag_value( $assoc_args, 'time', false );
 		$this->timestamp_format = \WP_CLI\Utils\get_flag_value( $assoc_args, 'time-format', $this->timestamp_format );
+		$this->store = ActionScheduler::store();
 	}
 
 	/**

--- a/classes/ActionScheduler_Abstract_WPCLI_Command.php
+++ b/classes/ActionScheduler_Abstract_WPCLI_Command.php
@@ -12,91 +12,16 @@ abstract class ActionScheduler_Abstract_WPCLI_Command {
 	protected $assoc_args;
 
 	/**
-	 * @var bool Enable printing of timestamp.
-	 */
-	protected $timestamp = false;
-
-	/**
-	 * @var string Format of timestamp.
-	 */
-	protected $timestamp_format = 'Y-m-d H:i:s T';
-
-	/**
 	 * Construct.
 	 */
 	public function __construct( $args, $assoc_args ) {
 		$this->args = $args;
 		$this->assoc_args = $assoc_args;
-		$this->timestamp = (bool) \WP_CLI\Utils\get_flag_value( $assoc_args, 'time', false );
-		$this->timestamp_format = \WP_CLI\Utils\get_flag_value( $assoc_args, 'time-format', $this->timestamp_format );
 	}
 
 	/**
 	 * Execute command.
 	 */
 	abstract public function execute();
-
-	/**
-	 * Wrapper for WP_CLI::log()
-	 *
-	 * @param string $message
-	 */
-	protected function log( $message ) {
-		WP_CLI::log( sprintf( '%s%s', $this->output_timestamp(), $message ) );
-	}
-
-	/**
-	 * Wrapper for WP_CLI::warning()
-	 *
-	 * @param string $message
-	 */
-	protected function warning( $message ) {
-		WP_CLI::warning( sprintf( '%s%s', $this->output_timestamp(), $message ) );
-	}
-
-	/**
-	 * Wrapper for WP_CLI::error()
-	 *
-	 * @param string $message
-	 */
-	protected function error( $message ) {
-		WP_CLI::error( sprintf( '%s%s', $this->output_timestamp(), $message ) );
-	}
-
-	/**
-	 * Wrapper for WP_CLI::success()
-	 *
-	 * @param string $message
-	 */
-	protected function success( $message ) {
-		WP_CLI::success( sprintf( '%s%s', $this->output_timestamp(), $message ) );
-	}
-
-	/**
-	 * Wrapper for WP_CLI_Utils\format_items( 'table' )
-	 *
-	 * @param array $rows
-	 * @param string $columns
-	 */
-	protected function table( $rows, $columns ) {
-		\WP_CLI\Utils\format_items( 'table', $rows, $columns );
-
- 		if ( ! empty( $this->timestamp ) ) {
-			$this->log( sprintf( 'Table generated.', $this->output_timestamp() ) );
-		}
-	}
-
-	/**
-	 * Print timestamp to CLI, if enabled.
-	 *
-	 * @return string
-	 */
-	protected function output_timestamp() {
-		if ( empty( $this->timestamp ) ) {
-			return '';
-		}
-
-		return '[' . as_get_datetime_object()->format( $this->timestamp_format ) . '] ';
-	}
 
 }

--- a/classes/ActionScheduler_Abstract_WPCLI_Command.php
+++ b/classes/ActionScheduler_Abstract_WPCLI_Command.php
@@ -38,13 +38,26 @@ abstract class ActionScheduler_Abstract_WPCLI_Command {
 
 	/**
 	 * Wrapper for WP_CLI::log()
+	 *
+	 * @param string $message
 	 */
 	protected function log( $message ) {
 		WP_CLI::log( sprintf( '%s%s', $this->output_timestamp(), $message ) );
 	}
 
 	/**
+	 * Wrapper for WP_CLI::warning()
+	 *
+	 * @param string $message
+	 */
+	protected function warning( $message ) {
+		WP_CLI::warning( sprintf( '%s%s', $this->output_timestamp(), $message ) );
+	}
+
+	/**
 	 * Wrapper for WP_CLI::error()
+	 *
+	 * @param string $message
 	 */
 	protected function error( $message ) {
 		WP_CLI::error( sprintf( '%s%s', $this->output_timestamp(), $message ) );
@@ -52,9 +65,25 @@ abstract class ActionScheduler_Abstract_WPCLI_Command {
 
 	/**
 	 * Wrapper for WP_CLI::success()
+	 *
+	 * @param string $message
 	 */
 	protected function success( $message ) {
 		WP_CLI::success( sprintf( '%s%s', $this->output_timestamp(), $message ) );
+	}
+
+	/**
+	 * Wrapper for WP_CLI_Utils\format_items( 'table' )
+	 *
+	 * @param array $rows
+	 * @param string $columns
+	 */
+	protected function table( $rows, $columns ) {
+		\WP_CLI\Utils\format_items( 'table', $rows, $columns );
+
+ 		if ( ! empty( $this->timestamp ) ) {
+			$this->log( sprintf( 'Table generated.', $this->output_timestamp() ) );
+		}
 	}
 
 	/**

--- a/classes/ActionScheduler_Abstract_WPCLI_Command.php
+++ b/classes/ActionScheduler_Abstract_WPCLI_Command.php
@@ -29,7 +29,6 @@ abstract class ActionScheduler_Abstract_WPCLI_Command {
 		$this->assoc_args = $assoc_args;
 		$this->timestamp = (bool) \WP_CLI\Utils\get_flag_value( $assoc_args, 'time', false );
 		$this->timestamp_format = \WP_CLI\Utils\get_flag_value( $assoc_args, 'time-format', $this->timestamp_format );
-		$this->store = ActionScheduler::store();
 	}
 
 	/**

--- a/classes/ActionScheduler_WPCLI.php
+++ b/classes/ActionScheduler_WPCLI.php
@@ -43,4 +43,23 @@ class ActionScheduler_WPCLI extends WP_CLI_Command {
 		$command->execute();
 	}
 
+	/**
+	 * Get action status counts and dates
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--time]
+	 * : Whether to print timestamp on each line.
+	 *
+	 * [--time-format=<format>]
+	 * : Format for the timestamp. Defaults to Y-m-d H:i:s T.
+	 *
+	 * @param array $args Positional arguments.
+	 * @param array $assoc_args Keyed arguments.
+	 */
+	public function info( $args, $assoc_args ) {
+		$command = new ActionScheduler_WPCLI_Command_Info( $args, $assoc_args );
+		$command->execute();
+	}
+
 }

--- a/classes/ActionScheduler_WPCLI.php
+++ b/classes/ActionScheduler_WPCLI.php
@@ -48,11 +48,20 @@ class ActionScheduler_WPCLI extends WP_CLI_Command {
 	 *
 	 * ## OPTIONS
 	 *
+	 * [--columns]
+	 * : Table columns to show.
+	 *
+	 * [--hooks]
+	 * : Hooks to show data.
+	 *
 	 * [--time]
 	 * : Whether to print timestamp on each line.
 	 *
 	 * [--time-format=<format>]
 	 * : Format for the timestamp. Defaults to Y-m-d H:i:s T.
+	 *
+	 * [--past-due]
+	 * : Limit data to past due actions.
 	 *
 	 * @param array $args Positional arguments.
 	 * @param array $assoc_args Keyed arguments.

--- a/classes/ActionScheduler_WPCLI_Command_Info.php
+++ b/classes/ActionScheduler_WPCLI_Command_Info.php
@@ -1,26 +1,45 @@
 <?php
 
+/**
+ * Action Scheduler WP CLI command to display system status.
+ */
 class ActionScheduler_WPCLI_Command_Info extends ActionScheduler_Abstract_WPCLI_Command {
+
+	/**
+	 * @var ActionScheduler_Store
+	 */
+	protected $store = null;
 
 	/**
 	 * Execute command.
 	 */
 	public function execute() {
+		$this->store = ActionScheduler::store();
+
 		$this->completed_actions();
 		$this->pending_actions();
 		$this->overdue_actions();
 	}
 
+	/**
+	 * Print count of completed actions.
+	 */
 	protected function completed_actions() {
 		$completed_actions = (int) $this->store->query_actions( array( 'status' => $this->store::STATUS_COMPLETE ), 'count' );
 		$this->log( 'Completed actions: ' . $completed_actions );
 	}
 
+	/**
+	 * Print count of pending actions.
+	 */
 	protected function pending_actions() {
 		$pending_actions = (int) $this->store->query_actions( array( 'status' => $this->store::STATUS_PENDING ), 'count' );
 		$this->log( 'Pending actions: ' . $pending_actions );
 	}
 
+	/**
+	 * Print count of overdue actions.
+	 */
 	protected function overdue_actions() {
 		$overdue_actions = (int) $this->store->query_actions( array( 'status' => $this->store::STATUS_PENDING, 'date' => as_get_datetime_object()->format( 'Y-m-d H:i:s' ) ), 'count' );
 		$this->log( 'Overdue actions: ' . $overdue_actions );

--- a/classes/ActionScheduler_WPCLI_Command_Info.php
+++ b/classes/ActionScheduler_WPCLI_Command_Info.php
@@ -6,167 +6,24 @@ class ActionScheduler_WPCLI_Command_Info extends ActionScheduler_Abstract_WPCLI_
 	 * Execute command.
 	 */
 	public function execute() {
-		$hooks = \WP_CLI\Utils\get_flag_value( $this->assoc_args, 'hooks', false );
-		$past_due = \WP_CLI\Utils\get_flag_value( $this->assoc_args, 'past-due', false );
-
-		if ( $past_due ) {
-			$this->past_due( $hooks );
-		} else if ( $hooks ) {
-			$this->hooks( $hooks );
-		} else {
-			$this->default();
-		}
+		$this->completed_actions();
+		$this->pending_actions();
+		$this->overdue_actions();
 	}
 
-	/**
-	 * Print info on past due actions.
-	 *
-	 * @param string $hooks
-	 */
-	protected function past_due( $hooks ) {
-		$store = ActionScheduler::store();
-		$columns = explode( ',', \WP_CLI\Utils\get_flag_value( $this->assoc_args, 'columns', 'hook,total' ) );
-
-		if ( true === $hooks ) {
-			$hooks = $store->action_hooks();
-		} else if ( !empty( $hooks ) ) {
-			$hooks = explode( ',', $hooks );
-		}
-
-		$args = array(
-			'status' => 'pending',
-			'date' => as_get_datetime_object()->format( 'Y-m-d H:i:s' ),
-		);
-
-		if ( !empty( $hooks ) ) {
-			$rows = array();
-
-			foreach ( $hooks as $hook ) {
-				$args['hook'] = $hook;
-				$count = ( int ) $store->query_actions( $args, 'count' );
-
-				if ( 0 === $count )
-					continue;
-
-				$row = array(
-					'hook' => $hook,
-					'total' => $count,
-				);
-
-				if ( count( array_intersect( array( 'oldest', 'newest' ), $columns ) ) ) {
-					foreach ( array( 'oldest', 'newest' ) as $point ) {
-						$actions = $store->query_actions( array(
-							'hook'     => $hook,
-							'status'   => 'pending',
-							'claimed'  => false,
-							'per_page' => 1,
-							'order'    => ( 'oldest' === $point ? 'ASC' : 'DESC' ),
-							'date'     => as_get_datetime_object()->format( 'Y-m-d H:i:s' ),
-						) );
-
-						if ( ! empty( $actions ) ) {
-							$date_object = $store->get_date( $actions[0] );
-							$row[ $point ] = $date_object->format( 'Y-m-d H:i:s O' );
-						}
-					}
-				}
-
-				$rows[] = $row;
-			}
-
-			$this->table( $rows, $columns );
-		} else {
-			unset( $args['hook'] );
-			$this->log( 'Total past due: ' . $store->query_actions( $args, 'count' ) );
-
-			$args['order'] = 'ASC';
-			$actions = $store->query_actions( $args );
-			$date_object = $store->get_date( $actions[0] );
-			$this->log( 'Oldest: ' . $date_object->format( 'Y-m-d H:i:s O' ) );
-		}
+	protected function completed_actions() {
+		$completed_actions = (int) $this->store->query_actions( array( 'status' => $this->store::STATUS_COMPLETE ), 'count' );
+		$this->log( 'Completed actions: ' . $completed_actions );
 	}
 
-	/**
-	 * Print counts for hooks.
-	 *
-	 * @param string $hooks
-	 */
-	protected function hooks( $hooks ) {
-		$store = ActionScheduler::store();
-		$stati = array_keys( $store->get_status_labels() );
-		$columns = explode( ',', \WP_CLI\Utils\get_flag_value( $this->assoc_args, 'columns', 'hook,total' ) );
-
-		$rows = array();
-
-		if ( true === $hooks ) {
-			$hooks = $store->action_hooks();
-		} else {
-			$hooks = explode( ',', $hooks );
-		}
-
-		foreach ( $hooks as $hook ) {
-			$row = $args = array( 'hook' => $hook );
-
-			if ( in_array( 'total', $columns ) ) {
-				$row['total'] = ( int ) $store->query_actions( array( 'hook' => $hook ), 'count' );
-			}
-
-			if ( count( array_intersect( $stati, $columns ) ) ) {
-				foreach ( array_intersect( $columns, $stati ) as $status ) {
-					$args['status'] = $status;
-					$count = ( int ) $store->query_actions( $args, 'count' );
-					$row[ $status ] = $count;
-				}
-			}
-
-			if ( count( array_intersect( array( 'oldest', 'newest' ), $columns ) ) ) {
-				foreach ( array( 'oldest', 'newest' ) as $point ) {
-					$action = $store->query_actions( array(
-						'hook' => $hook,
-						'claimed'  => false,
-						'per_page' => 1,
-						'order'    => ( 'oldest' === $point ? 'ASC' : 'DESC' ),
-					) );
-
-					if ( ! empty( $action ) ) {
-						$date_object = $store->get_date( $action[0] );
-						$row[ $point ] = $date_object->format( 'Y-m-d H:i:s O' );
-					}
-				}
-			}
-
-			$rows[] = $row;
-		}
-
-		$this->table( $rows, $columns );
+	protected function pending_actions() {
+		$pending_actions = (int) $this->store->query_actions( array( 'status' => $this->store::STATUS_PENDING ), 'count' );
+		$this->log( 'Pending actions: ' . $pending_actions );
 	}
 
-	/**
-	 * Print counts for all statuses.
-	 */
-	protected function default() {
-		$store = ActionScheduler::store();
-		$columns = explode( ',', \WP_CLI\Utils\get_flag_value( $this->assoc_args, 'columns', 'status,count' ) );
-		$status_labels = $store->get_status_labels();
-		$action_counts = $store->action_counts();
-		$status_dates = $store->action_dates();
-
-		$rows = array();
-		$total = 0;
-
-		foreach ( $status_labels as $post_status => $label ) {
-			$rows[] = array(
-				'status' => $label,
-				'count' => $action_counts[ $post_status ],
-				'oldest' => $status_dates[ $post_status ]['oldest'],
-				'newest' => $status_dates[ $post_status ]['newest'],
-			);
-
-			$total += $action_counts[ $post_status ];
-		}
-
-		$this->table( $rows, $columns );
-		$this->log( 'Total: ' . $total );
+	protected function overdue_actions() {
+		$overdue_actions = (int) $this->store->query_actions( array( 'status' => $this->store::STATUS_PENDING, 'date' => as_get_datetime_object()->format( 'Y-m-d H:i:s' ) ), 'count' );
+		$this->log( 'Overdue actions: ' . $overdue_actions );
 	}
 
 }

--- a/classes/ActionScheduler_WPCLI_Command_Info.php
+++ b/classes/ActionScheduler_WPCLI_Command_Info.php
@@ -1,0 +1,30 @@
+<?php
+
+class ActionScheduler_WPCLI_Command_Info extends ActionScheduler_Abstract_WPCLI_Command {
+
+	/**
+	 * Execute command.
+	 */
+	public function execute() {
+		$columns = explode( ',', \WP_CLI\Utils\get_flag_value( $this->assoc_args, 'columns', 'status,count' ) );
+
+		$store = ActionScheduler::store();
+
+		$rows = array();
+		$status_labels = $store->get_status_labels();
+		$action_counts = $store->action_counts();
+		$status_dates = $store->action_dates();
+
+		foreach ( $status_labels as $post_status => $label ) {
+			$rows[] = array(
+				'status' => $label,
+				'count' => $action_counts[ $post_status ],
+				'oldest' => $status_dates[ $post_status ]['oldest'],
+				'newest' => $status_dates[ $post_status ]['newest'],
+			);
+		}
+
+		$this->table( $rows, $columns );
+	}
+
+}

--- a/classes/ActionScheduler_WPCLI_Command_Info.php
+++ b/classes/ActionScheduler_WPCLI_Command_Info.php
@@ -6,14 +6,131 @@ class ActionScheduler_WPCLI_Command_Info extends ActionScheduler_Abstract_WPCLI_
 	 * Execute command.
 	 */
 	public function execute() {
-		$columns = explode( ',', \WP_CLI\Utils\get_flag_value( $this->assoc_args, 'columns', 'status,count' ) );
+		$hooks = \WP_CLI\Utils\get_flag_value( $this->assoc_args, 'hooks', false );
+		$past_due = \WP_CLI\Utils\get_flag_value( $this->assoc_args, 'past-due', false );
 
+		if ( $past_due ) {
+			$this->past_due( $hooks );
+		} else if ( $hooks ) {
+			$this->hooks( $hooks );
+		} else {
+			$this->default();
+		}
+	}
+
+	/**
+	 * Print info on past due actions.
+	 *
+	 * @param string $hooks
+	 */
+	protected function past_due( $hooks ) {
 		$store = ActionScheduler::store();
+		$columns = explode( ',', \WP_CLI\Utils\get_flag_value( $this->assoc_args, 'columns', 'hook,total' ) );
+
+		if ( true === $hooks ) {
+			global $wpdb;
+
+			$query = $wpdb->prepare( "SELECT DISTINCT( post_title ) FROM $wpdb->posts WHERE post_type = %s", ActionScheduler_wpPostStore::POST_TYPE );
+			$hooks = $wpdb->get_col( $query );
+		} else if ( !empty( $hooks ) ) {
+			$hooks = explode( ',', $hooks );
+		}
+
+		$args = array(
+			'status' => 'pending',
+			'date' => as_get_datetime_object()->format( 'Y-m-d H:i:s' ),
+			'date_compare' => '<=',
+		);
+
+		if ( !empty( $hooks ) ) {
+			$rows = array();
+			
+			foreach ( $hooks as $hook ) {
+				$args['hook'] = $hook;
+
+				$rows[] = array(
+					'hook' => $hook,
+					'total' => $store->query_actions( $args, 'count' ),
+				);
+			}
+
+			$this->table( $rows, $columns );
+		}
+
+		unset( $args['hook'] );
+		$this->log( 'Total past due: ' . $store->query_actions( $args, 'count' ) );
+	}
+
+	/**
+	 * Print counts for hooks.
+	 *
+	 * @param string $hooks
+	 */
+	protected function hooks( $hooks ) {
+		$store = ActionScheduler::store();
+		$stati = array_keys( $store->get_status_labels() );
+		$columns = explode( ',', \WP_CLI\Utils\get_flag_value( $this->assoc_args, 'columns', 'hook,total' ) );
 
 		$rows = array();
+
+		if ( true === $hooks ) {
+			global $wpdb;
+
+			$query = $wpdb->prepare( "SELECT DISTINCT( post_title ) FROM $wpdb->posts WHERE post_type = %s", ActionScheduler_wpPostStore::POST_TYPE );
+			$hooks = $wpdb->get_col( $query );
+		} else {
+			$hooks = explode( ',', $hooks );
+		}
+
+		foreach ( $hooks as $hook ) {
+			$row = $args = array( 'hook' => $hook );
+
+			if ( in_array( 'total', $columns ) ) {
+				$row['total'] = $store->query_actions( array( 'hook' => $hook ), 'count' );
+			}
+
+			if ( count( array_intersect( $stati, $columns ) ) ) {
+				foreach ( array_intersect( $columns, $stati ) as $status ) {
+					$args['status'] = $status;
+					$count = $store->query_actions( $args, 'count' );;
+					$row[ $status ] = $count;
+				}
+			}
+
+			if ( count( array_intersect( array( 'oldest', 'newest' ), $columns ) ) ) {
+				foreach ( array( 'oldest', 'newest' ) as $point ) {
+					$action = $store->query_actions( array(
+						'hook' => $hook,
+						'claimed'  => false,
+						'per_page' => 1,
+						'order'    => ( 'oldest' === $point ? 'ASC' : 'DESC' ),
+					) );
+
+					if ( ! empty( $action ) ) {
+						$date_object = $store->get_date( $action[0] );
+						$row[ $point ] = $date_object->format( 'Y-m-d H:i:s O' );
+					}
+				}
+			}
+
+			$rows[] = $row;
+		}
+
+		$this->table( $rows, $columns );
+	}
+
+	/**
+	 * Print counts for all statuses.
+	 */
+	protected function default() {
+		$store = ActionScheduler::store();
+		$columns = explode( ',', \WP_CLI\Utils\get_flag_value( $this->assoc_args, 'columns', 'status,count' ) );
 		$status_labels = $store->get_status_labels();
 		$action_counts = $store->action_counts();
 		$status_dates = $store->action_dates();
+
+		$rows = array();
+		$total = 0;
 
 		foreach ( $status_labels as $post_status => $label ) {
 			$rows[] = array(
@@ -22,9 +139,12 @@ class ActionScheduler_WPCLI_Command_Info extends ActionScheduler_Abstract_WPCLI_
 				'oldest' => $status_dates[ $post_status ]['oldest'],
 				'newest' => $status_dates[ $post_status ]['newest'],
 			);
+
+			$total += $action_counts[ $post_status ];
 		}
 
 		$this->table( $rows, $columns );
+		$this->log( 'Total: ' . $total );
 	}
 
 }

--- a/classes/ActionScheduler_WPCLI_Command_Info.php
+++ b/classes/ActionScheduler_WPCLI_Command_Info.php
@@ -28,10 +28,7 @@ class ActionScheduler_WPCLI_Command_Info extends ActionScheduler_Abstract_WPCLI_
 		$columns = explode( ',', \WP_CLI\Utils\get_flag_value( $this->assoc_args, 'columns', 'hook,total' ) );
 
 		if ( true === $hooks ) {
-			global $wpdb;
-
-			$query = $wpdb->prepare( "SELECT DISTINCT( post_title ) FROM $wpdb->posts WHERE post_type = %s", ActionScheduler_wpPostStore::POST_TYPE );
-			$hooks = $wpdb->get_col( $query );
+			$hooks = $store->action_hooks();
 		} else if ( !empty( $hooks ) ) {
 			$hooks = explode( ',', $hooks );
 		}
@@ -44,7 +41,7 @@ class ActionScheduler_WPCLI_Command_Info extends ActionScheduler_Abstract_WPCLI_
 
 		if ( !empty( $hooks ) ) {
 			$rows = array();
-			
+
 			foreach ( $hooks as $hook ) {
 				$args['hook'] = $hook;
 
@@ -74,10 +71,7 @@ class ActionScheduler_WPCLI_Command_Info extends ActionScheduler_Abstract_WPCLI_
 		$rows = array();
 
 		if ( true === $hooks ) {
-			global $wpdb;
-
-			$query = $wpdb->prepare( "SELECT DISTINCT( post_title ) FROM $wpdb->posts WHERE post_type = %s", ActionScheduler_wpPostStore::POST_TYPE );
-			$hooks = $wpdb->get_col( $query );
+			$hooks = $store->action_hooks();
 		} else {
 			$hooks = explode( ',', $hooks );
 		}

--- a/classes/ActionScheduler_WPCLI_Command_Run.php
+++ b/classes/ActionScheduler_WPCLI_Command_Run.php
@@ -77,7 +77,7 @@ class ActionScheduler_WPCLI_Command_Run extends ActionScheduler_Abstract_WPCLI_C
 	 * @param int $total
 	 */
 	protected function print_total_actions( $total ) {
-		WP_CLI::log(
+		\WP_CLI::log(
 			sprintf(
 				/* translators: %d refers to how many scheduled taks were found to run */
 				'%s' . _n( 'Found %d scheduled task', 'Found %d scheduled tasks', $total, 'action-scheduler' ),
@@ -95,7 +95,7 @@ class ActionScheduler_WPCLI_Command_Run extends ActionScheduler_Abstract_WPCLI_C
 	 * @param int $batches_completed
 	 */
 	protected function print_total_batches( $batches_completed ) {
-		WP_CLI::log(
+		\WP_CLI::log(
 			sprintf(
 				/* translators: %d refers to the total number of batches executed */
 				'%s' . _n( '%d batch executed.', '%d batches executed.', $batches_completed, 'action-scheduler' ),
@@ -115,7 +115,7 @@ class ActionScheduler_WPCLI_Command_Run extends ActionScheduler_Abstract_WPCLI_C
 	 * @throws \WP_CLI\ExitException
 	 */
 	protected function print_error( Exception $e ) {
-		WP_CLI::error(
+		\WP_CLI::error(
 			sprintf(
 				/* translators: %s refers to the exception error message. */
 				'%s' . __( 'There was an error running the action scheduler: %s', 'action-scheduler' ),
@@ -133,7 +133,7 @@ class ActionScheduler_WPCLI_Command_Run extends ActionScheduler_Abstract_WPCLI_C
 	 * @param int $actions_completed
 	 */
 	protected function print_success( $actions_completed ) {
-		WP_CLI::success(
+		\WP_CLI::success(
 			sprintf(
 				/* translators: %d refers to the total number of taskes completed */
 				'%s' . _n( '%d scheduled task completed.', '%d scheduled tasks completed.', $actions_completed, 'action-scheduler' ),

--- a/classes/ActionScheduler_WPCLI_Command_Run.php
+++ b/classes/ActionScheduler_WPCLI_Command_Run.php
@@ -6,6 +6,26 @@
 class ActionScheduler_WPCLI_Command_Run extends ActionScheduler_Abstract_WPCLI_Command {
 
 	/**
+	 * @var bool Enable printing of timestamp.
+	 */
+	protected $timestamp = false;
+
+	/**
+	 * @var string Format of timestamp.
+	 */
+	protected $timestamp_format = 'Y-m-d H:i:s T';
+
+	/**
+	 * Construct.
+	 */
+	public function __construct( $args, $assoc_args ) {
+		parent::__construct( $args, $assoc_args );
+
+		$this->timestamp = (bool) \WP_CLI\Utils\get_flag_value( $assoc_args, 'time', false );
+		$this->timestamp_format = \WP_CLI\Utils\get_flag_value( $assoc_args, 'time-format', $this->timestamp_format );
+	}
+
+	/**
 	 * Execute command.
 	 */
 	public function execute() {
@@ -57,10 +77,11 @@ class ActionScheduler_WPCLI_Command_Run extends ActionScheduler_Abstract_WPCLI_C
 	 * @param int $total
 	 */
 	protected function print_total_actions( $total ) {
-		$this->log(
+		WP_CLI::log(
 			sprintf(
 				/* translators: %d refers to how many scheduled taks were found to run */
-				_n( 'Found %d scheduled task', 'Found %d scheduled tasks', $total, 'action-scheduler' ),
+				'%s' . _n( 'Found %d scheduled task', 'Found %d scheduled tasks', $total, 'action-scheduler' ),
+				$this->output_timestamp(),
 				number_format_i18n( $total )
 			)
 		);
@@ -74,10 +95,11 @@ class ActionScheduler_WPCLI_Command_Run extends ActionScheduler_Abstract_WPCLI_C
 	 * @param int $batches_completed
 	 */
 	protected function print_total_batches( $batches_completed ) {
-		$this->log(
+		WP_CLI::log(
 			sprintf(
 				/* translators: %d refers to the total number of batches executed */
-				_n( '%d batch executed.', '%d batches executed.', $batches_completed, 'action-scheduler' ),
+				'%s' . _n( '%d batch executed.', '%d batches executed.', $batches_completed, 'action-scheduler' ),
+				$this->output_timestamp(),
 				number_format_i18n( $batches_completed )
 			)
 		);
@@ -93,10 +115,11 @@ class ActionScheduler_WPCLI_Command_Run extends ActionScheduler_Abstract_WPCLI_C
 	 * @throws \WP_CLI\ExitException
 	 */
 	protected function print_error( Exception $e ) {
-		$this->error(
+		WP_CLI::error(
 			sprintf(
 				/* translators: %s refers to the exception error message. */
-				__( 'There was an error running the action scheduler: %s', 'action-scheduler' ),
+				'%s' . __( 'There was an error running the action scheduler: %s', 'action-scheduler' ),
+				$this->output_timestamp(),
 				$e->getMessage()
 			)
 		);
@@ -110,12 +133,26 @@ class ActionScheduler_WPCLI_Command_Run extends ActionScheduler_Abstract_WPCLI_C
 	 * @param int $actions_completed
 	 */
 	protected function print_success( $actions_completed ) {
-		$this->success(
+		WP_CLI::success(
 			sprintf(
 				/* translators: %d refers to the total number of taskes completed */
-				_n( '%d scheduled task completed.', '%d scheduled tasks completed.', $actions_completed, 'action-scheduler' ),
+				'%s' . _n( '%d scheduled task completed.', '%d scheduled tasks completed.', $actions_completed, 'action-scheduler' ),
+				$this->output_timestamp(),
 				number_format_i18n( $actions_completed )
 			)
 		);
+	}
+
+	/**
+	 * Print timestamp if enabled.
+	 *
+	 * @return string
+	 */
+	protected function output_timestamp() {
+		if ( empty( $this->timestamp ) ) {
+			return '';
+		}
+
+		return '[' . as_get_datetime_object()->format( $this->timestamp_format ) . '] ';
 	}
 }

--- a/classes/ActionScheduler_wcSystemStatus.php
+++ b/classes/ActionScheduler_wcSystemStatus.php
@@ -24,64 +24,9 @@ class ActionScheduler_wcSystemStatus {
 	public function print() {
 		$action_counts     = $this->store->action_counts();
 		$status_labels     = $this->store->get_status_labels();
-		$oldest_and_newest = $this->get_oldest_and_newest( array_keys( $status_labels ) );
+		$oldest_and_newest = $this->store->action_dates();
 
 		$this->get_template( $status_labels, $action_counts, $oldest_and_newest );
-	}
-
-	/**
-	 * Get oldest and newest scheduled dates for a given set of statuses.
-	 *
-	 * @param array $status_keys Set of statuses to find oldest & newest action for.
-	 * @return array
-	 */
-	protected function get_oldest_and_newest( $status_keys ) {
-
-		$oldest_and_newest = array();
-
-		foreach ( $status_keys as $status ) {
-			$oldest_and_newest[ $status ] = array(
-				'oldest' => '&ndash;',
-				'newest' => '&ndash;',
-			);
-
-			if ( 'in-progress' === $status ) {
-				continue;
-			}
-
-			$oldest_and_newest[ $status ]['oldest'] = $this->get_action_status_date( $status, 'oldest' );
-			$oldest_and_newest[ $status ]['newest'] = $this->get_action_status_date( $status, 'newest' );
-		}
-
-		return $oldest_and_newest;
-	}
-
-	/**
-	 * Get oldest or newest scheduled date for a given status.
-	 *
-	 * @param string $status Action status label/name string.
-	 * @param string $date_type Oldest or Newest.
-	 * @return DateTime
-	 */
-	protected function get_action_status_date( $status, $date_type = 'oldest' ) {
-
-		$order = 'oldest' === $date_type ? 'ASC' : 'DESC';
-
-		$action = $this->store->query_actions( array(
-			'claimed'  => false,
-			'status'   => $status,
-			'per_page' => 1,
-			'order'    => $order,
-		) );
-
-		if ( ! empty( $action ) ) {
-			$date_object = $this->store->get_date( $action[0] );
-			$action_date = $date_object->format( 'Y-m-d H:i:s O' );
-		} else {
-			$action_date = '&ndash;';
-		}
-
-		return $action_date;
 	}
 
 	/**
@@ -92,6 +37,13 @@ class ActionScheduler_wcSystemStatus {
 	 * @param array $oldest_and_newest Date of the oldest and newest action with each status.
 	 */
 	protected function get_template( $status_labels, $action_counts, $oldest_and_newest ) {
+		foreach ( $oldest_and_newest as $status => &$dates ) {
+			foreach ( $dates as $point => &$value ) {
+				if ( empty( $value ) ) {
+					$value = '&ndash;';
+				}
+			}
+		}
 		?>
 
 		<table class="wc_status_table widefat" cellspacing="0">

--- a/classes/ActionScheduler_wpPostStore.php
+++ b/classes/ActionScheduler_wpPostStore.php
@@ -465,6 +465,20 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 	}
 
 	/**
+	 * Get all unique action hooks.
+	 *
+	 * @return string[]
+	 */
+	public function action_hooks() {
+		global $wpdb;
+
+		$sql = "SELECT DISTINCT( p.post_title ) FROM {$wpdb->posts} p WHERE p.post_type = %s";
+		$sql = $wpdb->prepare( $sql, self::POST_TYPE );
+
+		return $wpdb->get_col( $sql );
+	}
+
+	/**
 	 * @param string $action_id
 	 *
 	 * @throws InvalidArgumentException

--- a/classes/ActionScheduler_wpPostStore.php
+++ b/classes/ActionScheduler_wpPostStore.php
@@ -431,54 +431,6 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 	}
 
 	/**
-	 * Get the oldest and newest action dates by status.
-	 *
-	 * @return array
-	 */
-	public function action_dates() {
-
-		$action_dates_by_status = array();
-		$action_stati = array_keys( $this->get_status_labels() );
-
-		foreach ( $action_stati as $status ) {
-			$action_dates_by_status[ $status ] = array(
-				'oldest' => null,
-				'newest' => null,
-			);
-
-			foreach ( array( 'oldest', 'newest' ) as $point ) {
-				$action = $this->query_actions( array(
-					'claimed'  => false,
-					'status'   => $status,
-					'per_page' => 1,
-					'order'    => ( 'oldest' === $point ? 'ASC' : 'DESC' ),
-				) );
-
-				if ( ! empty( $action ) ) {
-					$date_object = $this->get_date( $action[0] );
-					$action_dates_by_status[ $status ][ $point ] = $date_object->format( 'Y-m-d H:i:s O' );
-				}
-			}
-		}
-
-		return $action_dates_by_status;
-	}
-
-	/**
-	 * Get all unique action hooks.
-	 *
-	 * @return string[]
-	 */
-	public function action_hooks() {
-		global $wpdb;
-
-		$sql = "SELECT DISTINCT( p.post_title ) FROM {$wpdb->posts} p WHERE p.post_type = %s";
-		$sql = $wpdb->prepare( $sql, self::POST_TYPE );
-
-		return $wpdb->get_col( $sql );
-	}
-
-	/**
 	 * @param string $action_id
 	 *
 	 * @throws InvalidArgumentException

--- a/classes/ActionScheduler_wpPostStore.php
+++ b/classes/ActionScheduler_wpPostStore.php
@@ -431,6 +431,40 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 	}
 
 	/**
+	 * Get the oldest and newest action dates by status.
+	 *
+	 * @return array
+	 */
+	public function action_dates() {
+
+		$action_dates_by_status = array();
+		$action_stati = array_keys( $this->get_status_labels() );
+
+		foreach ( $action_stati as $status ) {
+			$action_dates_by_status[ $status ] = array(
+				'oldest' => null,
+				'newest' => null,
+			);
+
+			foreach ( array( 'oldest', 'newest' ) as $point ) {
+				$action = $this->query_actions( array(
+					'claimed'  => false,
+					'status'   => $status,
+					'per_page' => 1,
+					'order'    => ( 'oldest' === $point ? 'ASC' : 'DESC' ),
+				) );
+
+				if ( ! empty( $action ) ) {
+					$date_object = $this->get_date( $action[0] );
+					$action_dates_by_status[ $status ][ $point ] = $date_object->format( 'Y-m-d H:i:s O' );
+				}
+			}
+		}
+
+		return $action_dates_by_status;
+	}
+
+	/**
 	 * @param string $action_id
 	 *
 	 * @throws InvalidArgumentException

--- a/deprecated/ActionScheduler_WPCLI_Scheduler_command.php
+++ b/deprecated/ActionScheduler_WPCLI_Scheduler_command.php
@@ -5,7 +5,14 @@
  *
  * Retain public API for backwards compatibility.
  */
-class ActionScheduler_WPCLI_Scheduler_command {
+class ActionScheduler_WPCLI_Scheduler_command extends ActionScheduler_WPCLI_Command_Run {
+
+	/**
+	 * Construct.
+	 */
+	function __construct() {
+		_deprecated_function( __METHOD__, '2.3.0' );
+	}
 
 	/**
 	 * Deprecated 'run' command.
@@ -17,8 +24,9 @@ class ActionScheduler_WPCLI_Scheduler_command {
 	function run( $args, $assoc_args ) {
 		_deprecated_function( __METHOD__, '2.3.0' );
 
-		$command = new ActionScheduler_WPCLI_Command_Run( $args, $assoc_args );
-		$command->execute();
+		parent::__construct( $args, $assoc_args );
+
+		$this->execute();
 	}
 
 }

--- a/deprecated/ActionScheduler_WPCLI_Scheduler_command.php
+++ b/deprecated/ActionScheduler_WPCLI_Scheduler_command.php
@@ -5,7 +5,7 @@
  *
  * Retain public API for backwards compatibility.
  */
-class ActionScheduler_WPCLI_Scheduler_command extends ActionScheduler_WPCLI_Command_Run {
+class ActionScheduler_WPCLI_Scheduler_Command extends ActionScheduler_WPCLI_Command_Run {
 
 	/**
 	 * Construct.

--- a/deprecated/ActionScheduler_WPCLI_Scheduler_command.php
+++ b/deprecated/ActionScheduler_WPCLI_Scheduler_command.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * Class ActionScheduler_WPCLI_Scheduler_command
+ *
+ * Retain public API for backwards compatibility.
+ */
+class ActionScheduler_WPCLI_Scheduler_command {
+
+	/**
+	 * Deprecated 'run' command.
+	 *
+	 * @param array $args Positional arguments.
+	 * @param array $assoc_args Keyed arguments.
+	 * @uses ActionScheduler_WPCLI_Command_Run::execute()
+	 */
+	function run( $args, $assoc_args ) {
+		_deprecated_function( __METHOD__, '2.3.0' );
+
+		$command = new ActionScheduler_WPCLI_Command_Run( $args, $assoc_args );
+		$command->execute();
+	}
+
+}


### PR DESCRIPTION
## Command:
`wp action-scheduler info`

## To do:
- [x] get number of past events
- [ ] count by hook

## Screenshots
<img width="1002" alt="Screen Shot 2019-03-30 at 2 40 39 AM" src="https://user-images.githubusercontent.com/4573033/55272608-5fa89800-5295-11e9-9eb0-a87638176735.png">

<img width="1090" alt="Screen Shot 2019-03-30 at 2 43 18 AM" src="https://user-images.githubusercontent.com/4573033/55272631-9c748f00-5295-11e9-8c53-f4c84506c4a6.png">