### PR TITLE
add exception handler for invalid schedule in make_action_from_post()

### DIFF
--- a/classes/ActionScheduler_Logger.php
+++ b/classes/ActionScheduler_Logger.php
@@ -55,6 +55,7 @@ abstract class ActionScheduler_Logger {
 		add_action( 'action_scheduler_unexpected_shutdown', array( $this, 'log_unexpected_shutdown' ), 10, 2 );
 		add_action( 'action_scheduler_reset_action', array( $this, 'log_reset_action' ), 10, 1 );
 		add_action( 'action_scheduler_execution_ignored', array( $this, 'log_ignored_action' ), 10, 1 );
+		add_action( 'action_scheduler_failed_fetch_action', array( $this, 'log_failed_fetch_action' ), 10, 1 );
 	}
 
 	public function log_stored_action( $action_id ) {
@@ -94,5 +95,8 @@ abstract class ActionScheduler_Logger {
 	public function log_ignored_action( $action_id ) {
 		$this->log( $action_id, __( 'action ignored', 'action-scheduler' ) );
 	}
+
+	public function log_failed_fetch_action( $action_id ) {
+		$this->log( $action_id, __( 'There was a failure fetching this action', 'action-scheduler' ) );
+	}
 }
- 

--- a/classes/ActionScheduler_wpPostStore.php
+++ b/classes/ActionScheduler_wpPostStore.php
@@ -143,6 +143,7 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 		} catch ( ActionScheduler_InvalidActionException $exception ) {
 			$schedule = new ActionScheduler_NullSchedule();
 			$args = array();
+			do_action( 'action_scheduler_failed_fetch_action', $post->ID );
 		}
 
 		$group = wp_get_object_terms( $post->ID, self::GROUP_TAXONOMY, array('fields' => 'names') );

--- a/classes/ActionScheduler_wpPostStore.php
+++ b/classes/ActionScheduler_wpPostStore.php
@@ -131,13 +131,19 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 
 	protected function make_action_from_post( $post ) {
 		$hook = $post->post_title;
-		$args = json_decode( $post->post_content, true );
-		$this->validate_args( $args, $post->ID );
 
-		$schedule = get_post_meta( $post->ID, self::SCHEDULE_META_KEY, true );
-		if ( empty( $schedule ) || ! is_a( $schedule, 'ActionScheduler_Schedule' ) ) {
+		try {
+			$args = json_decode( $post->post_content, true );
+			$this->validate_args( $args, $post->ID );
+
+			$schedule = get_post_meta( $post->ID, self::SCHEDULE_META_KEY, true );
+			if ( empty( $schedule ) || ! is_a( $schedule, 'ActionScheduler_Schedule' ) ) {
+				$schedule = new ActionScheduler_NullSchedule();
+			}
+		} catch ( ActionScheduler_InvalidActionException $exception ) {
 			$schedule = new ActionScheduler_NullSchedule();
 		}
+
 		$group = wp_get_object_terms( $post->ID, self::GROUP_TAXONOMY, array('fields' => 'names') );
 		$group = empty( $group ) ? '' : reset($group);
 

--- a/classes/ActionScheduler_wpPostStore.php
+++ b/classes/ActionScheduler_wpPostStore.php
@@ -138,10 +138,11 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 
 			$schedule = get_post_meta( $post->ID, self::SCHEDULE_META_KEY, true );
 			if ( empty( $schedule ) || ! is_a( $schedule, 'ActionScheduler_Schedule' ) ) {
-				$schedule = new ActionScheduler_NullSchedule();
+				throw ActionScheduler_InvalidActionException::from_decoding_args( $post->ID );
 			}
 		} catch ( ActionScheduler_InvalidActionException $exception ) {
 			$schedule = new ActionScheduler_NullSchedule();
+			$args = array();
 		}
 
 		$group = wp_get_object_terms( $post->ID, self::GROUP_TAXONOMY, array('fields' => 'names') );

--- a/tests/phpunit/jobstore/ActionScheduler_wpPostStore_Test.php
+++ b/tests/phpunit/jobstore/ActionScheduler_wpPostStore_Test.php
@@ -42,7 +42,6 @@ class ActionScheduler_wpPostStore_Test extends ActionScheduler_UnitTestCase {
 	}
 
 	/**
-	 * @expectedException ActionScheduler_InvalidActionException
 	 * @dataProvider provide_bad_args
 	 *
 	 * @param string $content
@@ -55,7 +54,8 @@ class ActionScheduler_wpPostStore_Test extends ActionScheduler_UnitTestCase {
 			'post_content' => $content,
 		) );
 
-		$store->fetch_action( $post_id );
+		$fetched = $store->fetch_action( $post_id );
+		$this->assertInstanceOf( 'ActionScheduler_NullSchedule', $fetched->get_schedule() );
 	}
 
 	public function provide_bad_args() {


### PR DESCRIPTION
This PR adds an exception handler for the WP post store retrieving the schedule from the post content. It's possible for the post content to be json_encoded and not an array.

@mikejolley Can you take a look at this as well?