### PR TITLE
use scheduled_date when passed for recurring actions

### DIFF
--- a/classes/ActionScheduler_wpPostStore.php
+++ b/classes/ActionScheduler_wpPostStore.php
@@ -19,7 +19,13 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 			$this->validate_action( $action );
 			$post_array = $this->create_post_array( $action, $scheduled_date );
 			$post_id = $this->save_post_array( $post_array );
-			$this->save_post_schedule( $post_id, $action->get_schedule() );
+			$schedule = $action->get_schedule();
+
+			if ( ! is_null( $scheduled_date ) && $schedule->is_recurring() ) {
+				$schedule = new ActionScheduler_IntervalSchedule( $scheduled_date, $schedule->interval_in_seconds() );
+			}
+
+			$this->save_post_schedule( $post_id, $schedule );
 			$this->save_action_group( $post_id, $action->get_group() );
 			do_action( 'action_scheduler_stored_action', $post_id );
 			return $post_id;


### PR DESCRIPTION
Fixes #293 

This PR updates the post store save_action function to use the `$scheduled_date` parameter for scheduling the next instance of the scheduled action.

### Testing instructions
- Follow the steps to reproduce the issue outlined in the issue
- The new scheduled action should be scheduled for a recurrence period into the future instead of `Now`.