### PR TITLE
mark actions with invalid schedules as failures

### DIFF
--- a/classes/ActionScheduler_Store.php
+++ b/classes/ActionScheduler_Store.php
@@ -188,6 +188,13 @@ abstract class ActionScheduler_Store {
 
 	public function init() {}
 
+	/**
+	 * Mark an action that failed to fetch correctly as failed.
+	 *
+	 * @since 2.2.6
+	 *
+	 * @param int $action_id The ID of the action.
+	 */
 	public function mark_failed_fetch_action( $action_id ) {
 		self::$store->mark_failure( $action_id );
 	}

--- a/classes/ActionScheduler_Store.php
+++ b/classes/ActionScheduler_Store.php
@@ -188,13 +188,36 @@ abstract class ActionScheduler_Store {
 
 	public function init() {}
 
+	public function mark_failed_fetch_action( $action_id ) {
+		self::$store->mark_failure( $action_id );
+	}
+
+	/**
+	 * Add base hooks
+	 *
+	 * @since 2.2.6
+	 */
+	protected static function hook() {
+		add_action( 'action_scheduler_failed_fetch_action', array( self::$store, 'mark_failed_fetch_action' ), 20 );
+	}
+
+	/**
+	 * Remove base hooks
+	 *
+	 * @since 2.2.6
+	 */
+	protected static function unhook() {
+		remove_action( 'action_scheduler_failed_fetch_action', array( self::$store, 'mark_failed_fetch_action' ), 20 );
+	}
+
 	/**
 	 * @return ActionScheduler_Store
 	 */
 	public static function instance() {
 		if ( empty(self::$store) ) {
-			$class = apply_filters('action_scheduler_store_class', 'ActionScheduler_wpPostStore');
+			$class = apply_filters( 'action_scheduler_store_class', 'ActionScheduler_wpPostStore' );
 			self::$store = new $class();
+			self::hook();
 		}
 		return self::$store;
 	}


### PR DESCRIPTION
Fixes #296 .

This PR marks actions with invalid recurring schedules as failed so they do not interfere with replacement scheduled actions.

Follow the reproduce steps outlined in the issue description. The action with the invalid schedule should be moved to the failed list and only one replacement action should be created.
