### PR TITLE
include actions with no group when sorting actions by group

### DIFF
--- a/classes/ActionScheduler_wpPostStore.php
+++ b/classes/ActionScheduler_wpPostStore.php
@@ -308,11 +308,8 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 			$sql .= " INNER JOIN {$wpdb->term_relationships} tr ON tr.object_id=p.ID";
 			$sql .= " INNER JOIN {$wpdb->term_taxonomy} tt ON tr.term_taxonomy_id=tt.term_taxonomy_id";
 			$sql .= " INNER JOIN {$wpdb->terms} t ON tt.term_id=t.term_id";
-
-			if ( ! empty( $query['group'] ) ) {
-				$sql .= " AND t.slug=%s";
-				$sql_params[] = $query['group'];
-			}
+			$sql .= " AND t.slug=%s";
+			$sql_params[] = $query['group'];
 		}
 		$sql .= " WHERE post_type=%s";
 		$sql_params[] = self::POST_TYPE;

--- a/classes/ActionScheduler_wpPostStore.php
+++ b/classes/ActionScheduler_wpPostStore.php
@@ -300,7 +300,11 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 		$sql  = ( 'count' === $select_or_count ) ? 'SELECT count(p.ID)' : 'SELECT p.ID ';
 		$sql .= "FROM {$wpdb->posts} p";
 		$sql_params = array();
-		if ( ! empty( $query['group'] ) || 'group' === $query['orderby'] ) {
+		if ( empty( $query['group'] ) && 'group' === $query['orderby'] ) {
+			$sql .= " LEFT JOIN {$wpdb->term_relationships} tr ON tr.object_id=p.ID";
+			$sql .= " LEFT JOIN {$wpdb->term_taxonomy} tt ON tr.term_taxonomy_id=tt.term_taxonomy_id";
+			$sql .= " LEFT JOIN {$wpdb->terms} t ON tt.term_id=t.term_id";
+		} elseif ( ! empty( $query['group'] ) ) {
 			$sql .= " INNER JOIN {$wpdb->term_relationships} tr ON tr.object_id=p.ID";
 			$sql .= " INNER JOIN {$wpdb->term_taxonomy} tt ON tr.term_taxonomy_id=tt.term_taxonomy_id";
 			$sql .= " INNER JOIN {$wpdb->terms} t ON tt.term_id=t.term_id";


### PR DESCRIPTION
Fixes #298 

This PR changes the WP Post Store get actions SQL for `orderby` => `group` queries to use `LEFT JOIN` to allow actions without a group to be included in the query results.

### Steps to test
1. Follow the steps to reproduce outlined in the issue
1. The new action should be returned in the results of step 2.