### PR TITLE
Add check that function add_action() exists

### DIFF
--- a/action-scheduler.php
+++ b/action-scheduler.php
@@ -25,7 +25,7 @@
  *
  */
 
-if ( ! function_exists( 'action_scheduler_register_2_dot_2_dot_5' ) ) {
+if ( ! function_exists( 'action_scheduler_register_2_dot_2_dot_5' ) && function_exists( 'add_action' ) ) {
 
 	if ( ! class_exists( 'ActionScheduler_Versions' ) ) {
 		require_once( 'classes/ActionScheduler_Versions.php' );


### PR DESCRIPTION
By checking that the function add_action() exists, before we call it, we
can avoid throwing a fatal error when a PHP tool is run (e.g. phpcs)
even if we are loading `action-scheduler.php` via Composer's autoload.

See #303