### PR TITLE
add check for interval_in_seconds method

### DIFF
--- a/classes/ActionScheduler_wpPostStore.php
+++ b/classes/ActionScheduler_wpPostStore.php
@@ -21,7 +21,7 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 			$post_id = $this->save_post_array( $post_array );
 			$schedule = $action->get_schedule();
 
-			if ( ! is_null( $scheduled_date ) && $schedule->is_recurring() ) {
+			if ( ! is_null( $scheduled_date ) && $schedule->is_recurring() && method_exists( $schedule, 'interval_in_seconds' ) ) {
 				$schedule = new ActionScheduler_IntervalSchedule( $scheduled_date, $schedule->interval_in_seconds() );
 			}
 


### PR DESCRIPTION
Fixes #308

This PR adds a check that the `interval_in_seconds` method exists which should have been included in https://github.com/Prospress/action-scheduler/commit/88359f0a2bb4438bbe6a1227d9918225f6b14cb6 .
