### PR TITLE
allow queue cleaner to be disabled via filter

### DIFF
--- a/classes/ActionScheduler_QueueCleaner.php
+++ b/classes/ActionScheduler_QueueCleaner.php
@@ -31,7 +31,11 @@ class ActionScheduler_QueueCleaner {
 
 	public function delete_old_actions() {
 		$lifespan = apply_filters( 'action_scheduler_retention_period', $this->month_in_seconds );
-		$cutoff = as_get_datetime_object($lifespan.' seconds ago');
+		if ( null === $lifespan ) {
+			return;
+		}
+
+		$cutoff = as_get_datetime_object( $lifespan . ' seconds ago' );
 
 		$statuses_to_purge = array(
 			ActionScheduler_Store::STATUS_COMPLETE,

--- a/tests/phpunit/runner/ActionScheduler_QueueRunner_Test.php
+++ b/tests/phpunit/runner/ActionScheduler_QueueRunner_Test.php
@@ -104,7 +104,7 @@ class ActionScheduler_QueueRunner_Test extends ActionScheduler_UnitTestCase {
 
 
 		$this->assertEquals( $random, $new_action->get_hook() );
-		$this->assertEquals( $schedule->next( as_get_datetime_object() )->getTimestamp(), $new_action->get_schedule()->next( as_get_datetime_object() )->getTimestamp(), '', 1 );
+		$this->assertEquals( $schedule->next( as_get_datetime_object() )->getTimestamp(), $new_action->get_schedule()->next( as_get_datetime_object() )->getTimestamp(), '', 2 );
 	}
 
 	public function test_hooked_into_wp_cron() {


### PR DESCRIPTION
Fixes #313

This PR disables the queue cleaner when the `action_scheduler_retention_period` returns a `null`.

### Testing instructions

- Add a filter `add_filter( 'action_scheduler_retention_period', '__return_null' );`
- Modify a completed scheduled action in the database to have a modified date older than 30 days.
- Run the action scheduler through WP CLI `$ wp action-scheduler run`
- Check that the modified action is still in the database.

Note: `__return_zero` is used in the unit tests to clear all the completed/cancelled actions from the queue. The alternative of `null` is used.