### PR TITLE
Add as_enqueue_async_action() and async action APIs

### DIFF
--- a/classes/ActionScheduler_ActionFactory.php
+++ b/classes/ActionScheduler_ActionFactory.php
@@ -45,6 +45,28 @@ class ActionScheduler_ActionFactory {
 	}
 
 	/**
+	 * Enqueue an action to run one time, as soon as possible (rather a specific scheduled time).
+	 *
+	 * This method creates a new action with the NULLSchedule. This schedule maps to a MySQL datetime string of
+	 * 0000-00-00 00:00:00. This is done to create a psuedo "async action" type that is fully backward compatible.
+	 * Existing queries to claim actions claim by date, meaning actions scheduled for 0000-00-00 00:00:00 will
+	 * always be claimed prior to actions scheduled for a specific date. This makes sure that any async action is
+	 * given priority in queue processing. This has the added advantage of making sure async actions can be
+	 * claimed by both the existing WP Cron and WP CLI runners, as well as a new async request runner.
+	 *
+	 * @param string $hook The hook to trigger when this action runs
+	 * @param array $args Args to pass when the hook is triggered
+	 * @param string $group A group to put the action in
+	 *
+	 * @return string The ID of the stored action
+	 */
+	public function async( $hook, $args = array(), $group = '' ) {
+		$schedule = new ActionScheduler_NullSchedule();
+		$action = new ActionScheduler_Action( $hook, $args, $schedule, $group );
+		return $this->store( $action );
+	}
+
+	/**
 	 * @param string $hook The hook to trigger when this action runs
 	 * @param array $args Args to pass when the hook is triggered
 	 * @param int $when Unix timestamp when the action will run

--- a/classes/ActionScheduler_ListTable.php
+++ b/classes/ActionScheduler_ListTable.php
@@ -380,7 +380,7 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 		$schedule_display_string = '';
 
 		if ( ! $schedule->next() ) {
-			return $schedule_display_string;
+			return '0000-00-00 00:00:00';
 		}
 
 		$next_timestamp = $schedule->next()->getTimestamp();

--- a/classes/abstracts/ActionScheduler_Store.php
+++ b/classes/abstracts/ActionScheduler_Store.php
@@ -149,7 +149,7 @@ abstract class ActionScheduler_Store {
 	protected function get_scheduled_date_string( ActionScheduler_Action $action, DateTime $scheduled_date = NULL ) {
 		$next = null === $scheduled_date ? $action->get_schedule()->next() : $scheduled_date;
 		if ( ! $next ) {
-			throw new InvalidArgumentException( __( 'Invalid schedule. Cannot save action.', 'action-scheduler' ) );
+			return '0000-00-00 00:00:00';
 		}
 		$next->setTimezone( new DateTimeZone( 'UTC' ) );
 
@@ -166,7 +166,7 @@ abstract class ActionScheduler_Store {
 	protected function get_scheduled_date_string_local( ActionScheduler_Action $action, DateTime $scheduled_date = NULL ) {
 		$next = null === $scheduled_date ? $action->get_schedule()->next() : $scheduled_date;
 		if ( ! $next ) {
-			throw new InvalidArgumentException( __( 'Invalid schedule. Cannot save action.', 'action-scheduler' ) );
+			return '0000-00-00 00:00:00';
 		}
 
 		ActionScheduler_TimezoneHelper::set_local_timezone( $next );

--- a/functions.php
+++ b/functions.php
@@ -124,7 +124,9 @@ function as_unschedule_all_actions( $hook, $args = array(), $group = '' ) {
  * @return int|bool The timestamp for the next occurrence, or false if nothing was found
  */
 function as_next_scheduled_action( $hook, $args = NULL, $group = '' ) {
-	$params = array();
+	$params = array(
+		'status' => ActionScheduler_Store::STATUS_PENDING,
+	);
 	if ( is_array($args) ) {
 		$params['args'] = $args;
 	}

--- a/functions.php
+++ b/functions.php
@@ -121,7 +121,7 @@ function as_unschedule_all_actions( $hook, $args = array(), $group = '' ) {
  * @param array $args
  * @param string $group
  *
- * @return int|bool The timestamp for the next occurrence, or false if nothing was found
+ * @return int|bool The timestamp for the next occurrence of a scheduled action, true for an async action or false if there is no matching, pending action.
  */
 function as_next_scheduled_action( $hook, $args = NULL, $group = '' ) {
 	$params = array(
@@ -141,6 +141,8 @@ function as_next_scheduled_action( $hook, $args = NULL, $group = '' ) {
 	$next = $job->get_schedule()->next();
 	if ( $next ) {
 		return (int)($next->format('U'));
+	} elseif ( NULL === $next ) { // pending async action with NullSchedule
+		return true;
 	}
 	return false;
 }

--- a/functions.php
+++ b/functions.php
@@ -5,6 +5,18 @@
  */
 
 /**
+ * Enqueue an action to run one time, as soon as possible
+ *
+ * @param string $hook The hook to trigger.
+ * @param array  $args Arguments to pass when the hook triggers.
+ * @param string $group The group to assign this job to.
+ * @return string The action ID.
+ */
+function as_enqueue_async_action( $hook, $args = array(), $group = '' ) {
+	return ActionScheduler::factory()->async( $hook, $args, $group );
+}
+
+/**
  * Schedule an action to run one time
  *
  * @param int $timestamp When the job will run

--- a/tests/phpunit/procedural_api/procedural_api_Test.php
+++ b/tests/phpunit/procedural_api/procedural_api_Test.php
@@ -50,6 +50,32 @@ class procedural_api_Test extends ActionScheduler_UnitTestCase {
 		$this->assertEquals( $time->getTimestamp(), $next );
 	}
 
+	public function test_get_next_async() {
+		$hook = md5(rand());
+		$action_id = as_enqueue_async_action( $hook );
+
+		$next = as_next_scheduled_action( $hook );
+
+		$this->assertTrue( $next );
+
+		$store = ActionScheduler::store();
+
+		// Completed async actions should still return false
+		$store->mark_complete( $action_id );
+		$next = as_next_scheduled_action( $hook );
+		$this->assertFalse( $next );
+
+		// Failed async actions should still return false
+		$store->mark_failure( $action_id );
+		$next = as_next_scheduled_action( $hook );
+		$this->assertFalse( $next );
+
+		// Cancelled async actions should still return false
+		$store->cancel_action( $action_id );
+		$next = as_next_scheduled_action( $hook );
+		$this->assertFalse( $next );
+	}
+
 	public function provider_time_hook_args_group() {
 		$time  = time() + 60 * 2;
 		$hook  = md5( rand() );


### PR DESCRIPTION
The PR introduces a new set of APIs for scheduling actions to run "as soon as possible". This is to achieve the async action type required as part of #319.

### Background

Typically, an action is scheduled for a date. In cases where that action needed to run "as soon as possible", that date would have been set to the current time, e.g. `time()`. For an example, see [`WC_Action_Queue::add()`](https://github.com/woocommerce/woocommerce/blob/3.6.5/includes/queue/class-wc-action-queue.php#L22-L32). The problem with "now" is that there is no way to make sure that action is run sooner than any other action scheduled to run now, including those that may have been scheduled to run at that time months in advance.

In practice, an async action should take priority over a scheduled action, because there is an expectation it will be run very soon after being added to the queue. Whereas a scheduled action, like a subscription payment, may have been scheduled months in advance so if it processes a few minutes late, most of the time there's no harm done as no one is really sitting around expecting it to go through.

### Notes on Approach

This patch makes it acceptable to save an action with a `NULL` schedule. This mapps its MySQL datetime string to `0000-00-00 00:00:00`.

The advantage of this approach is that it is fully backward compatible. Existing queries to claim actions claim them by date, meaning actions with the `0000-00-00 00:00:00` scheduled time will always be claimed prior to actions scheduled for a specific date. This makes sure that any async action is given priority in queue processing. This has the added advantage of making sure async actions can be claimed by both the existing WP Cron and WP CLI runners, as well as a new async request runner.

As this makes async APIs backward compatible with both existing datastores and the new custom table data stores coming in #259, and it has none of the issues mentioned in #319 that would stem from using other backward comptaible APIs, like the using the action group, I've chosen this approach.

The downside is that `0000-00-00 00:00:00` is a bit of a hack and will allow for potentially critical bugs in 3rd party code, as seen by the fact that I had to remove existing validation against `NULL` dates for it to be possible. 3rd parties can now accidentally schedule actions with a `NULL` date, instead of receiving an exception to alert them to errors.