### PR TITLE
Add async queue processing

### DIFF
--- a/classes/ActionScheduler_AsyncRequest_QueueRunner.php
+++ b/classes/ActionScheduler_AsyncRequest_QueueRunner.php
@@ -58,18 +58,11 @@ class ActionScheduler_AsyncRequest_QueueRunner extends WP_Async_Request {
 	 * dispatch an async request to process them.
 	 */
 	public function maybe_dispatch() {
-		if ( ! $this->allow() ) {
+		if ( ! $this->allow() || ! $this->store->has_pending_actions_due() ) {
 			return;
 		}
 
-		$pending_actions = $this->store->query_actions( array(
-			'date'   => as_get_datetime_object(),
-			'status' => ActionScheduler_Store::STATUS_PENDING,
-		) );
-
-		if ( $pending_actions ) {
-			$this->dispatch();
-		}
+		$this->dispatch();
 	}
 
 	/**

--- a/classes/ActionScheduler_AsyncRequest_QueueRunner.php
+++ b/classes/ActionScheduler_AsyncRequest_QueueRunner.php
@@ -54,9 +54,14 @@ class ActionScheduler_AsyncRequest_QueueRunner extends WP_Async_Request {
 	}
 
 	/**
-	 * If there are pending actions, dispatch an async request to process them.
+	 * If the async request runner is allowed, and there are pending actions,
+	 * dispatch an async request to process them.
 	 */
 	public function maybe_dispatch() {
+		if ( ! $this->allow() ) {
+			return;
+		}
+
 		$pending_actions = $this->store->query_actions( array(
 			'date'   => as_get_datetime_object(),
 			'status' => ActionScheduler_Store::STATUS_PENDING,
@@ -65,5 +70,12 @@ class ActionScheduler_AsyncRequest_QueueRunner extends WP_Async_Request {
 		if ( $pending_actions ) {
 			$this->dispatch();
 		}
+	}
+
+	/**
+	 * Allow 3rd party code to disable running actions via async requets.
+	 */
+	protected function allow() {
+		return apply_filters( 'action_scheduler_allow_async_request_runner', true );
 	}
 }

--- a/classes/ActionScheduler_AsyncRequest_QueueRunner.php
+++ b/classes/ActionScheduler_AsyncRequest_QueueRunner.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * ActionScheduler_AsyncRequest_QueueRunner
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * ActionScheduler_AsyncRequest_QueueRunner class.
+ */
+class ActionScheduler_AsyncRequest_QueueRunner extends WP_Async_Request {
+
+	/**
+	 * Data store for querying actions
+	 *
+	 * @var ActionScheduler_Store
+	 * @access protected
+	 */
+	protected $store;
+
+	/**
+	 * Prefix for ajax hooks
+	 *
+	 * @var string
+	 * @access protected
+	 */
+	protected $prefix = 'as';
+
+	/**
+	 * Action for ajax hooks
+	 *
+	 * @var string
+	 * @access protected
+	 */
+	protected $action = 'async_request_queue_runner';
+
+	/**
+	 * Initiate new async request
+	 */
+	public function __construct( ActionScheduler_Store $store ) {
+		parent::__construct();
+		$this->store = $store;
+	}
+
+	/**
+	 * Handle async requests
+	 *
+	 * Run a queue, and maybe dispatch another async request to run another queue
+	 * if there are still pending actions after completing a queue in this request.
+	 */
+	protected function handle() {
+		do_action( 'action_scheduler_run_queue' ); // run a queue in the exact same way as WP Cron
+		$this->maybe_dispatch();
+	}
+
+	/**
+	 * If there are pending actions, dispatch an async request to process them.
+	 */
+	public function maybe_dispatch() {
+		$pending_actions = $this->store->query_actions( array(
+			'date'   => as_get_datetime_object(),
+			'status' => ActionScheduler_Store::STATUS_PENDING,
+		) );
+
+		if ( $pending_actions ) {
+			$this->dispatch();
+		}
+	}
+}

--- a/classes/ActionScheduler_ListTable.php
+++ b/classes/ActionScheduler_ListTable.php
@@ -320,6 +320,22 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 				'class'   => 'updated',
 				'message' => sprintf( __( 'Maximum simultaneous batches already in progress (%s queues). No actions will be processed until the current batches are complete.', 'action-scheduler' ), $this->store->get_claim_count() ),
 			);
+		} elseif ( $this->store->has_pending_actions_due() ) {
+
+			$async_request_lock_expiration = ActionScheduler::lock()->get_expiration( 'async-request-runner' );
+
+			// No lock set or lock expired
+			if ( false === $async_request_lock_expiration || $async_request_lock_expiration < time() ) {
+				$in_progress_url       = add_query_arg( 'status', 'in-progress', remove_query_arg( 'status' ) );
+				$async_request_message = sprintf( __( 'A new queue has begun processing. %sView actions in-progress%s', 'action-scheduler' ), '<a href="' . esc_url( $in_progress_url ) . '">', ' &raquo;</a>' );
+			} else {
+				$async_request_message = sprintf( __( 'The next queue will begin processing in approximately %d seconds.', 'action-scheduler' ), $async_request_lock_expiration - time() );
+			}
+
+			$this->admin_notices[] = array(
+				'class'   => 'notice notice-info',
+				'message' => $async_request_message,
+			);
 		}
 
 		$notification = get_transient( 'action_scheduler_admin_notice' );

--- a/classes/ActionScheduler_ListTable.php
+++ b/classes/ActionScheduler_ListTable.php
@@ -315,7 +315,7 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 	 */
 	public function display_admin_notices() {
 
-		if ( $this->store->get_claim_count() >= $this->runner->get_allowed_concurrent_batches() ) {
+		if ( $this->runner->has_maximum_concurrent_batches() ) {
 			$this->admin_notices[] = array(
 				'class'   => 'updated',
 				'message' => sprintf( __( 'Maximum simultaneous batches already in progress (%s queues). No actions will be processed until the current batches are complete.', 'action-scheduler' ), $this->store->get_claim_count() ),

--- a/classes/ActionScheduler_OptionLock.php
+++ b/classes/ActionScheduler_OptionLock.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * Provide a way to set simple transient locks to block behaviour
+ * for up-to a given duration.
+ *
+ * Class ActionScheduler_OptionLock
+ * @since 3.0.0
+ */
+class ActionScheduler_OptionLock extends ActionScheduler_Lock {
+
+	/**
+	 * Set a lock using options for a given amount of time (60 seconds by default).
+	 *
+	 * Using an autoloaded option avoids running database queries or other resource intensive tasks
+	 * on frequently triggered hooks, like 'init' or 'shutdown'.
+	 *
+	 * For example, ActionScheduler_QueueRunner->maybe_dispatch_async_request() uses a lock to avoid
+	 * calling ActionScheduler_QueueRunner->has_maximum_concurrent_batches() every time the 'shutdown',
+	 * hook is triggered, because that method calls ActionScheduler_QueueRunner->store->get_claim_count()
+	 * to find the current number of claims in the database.
+	 *
+	 * @param string $lock_type A string to identify different lock types.
+	 * @bool True if lock value has changed, false if not or if set failed.
+	 */
+	public function set( $lock_type ) {
+		return update_option( $this->get_key( $lock_type ), time() + $this->get_duration( $lock_type ) );
+	}
+
+	/**
+	 * If a lock is set, return the timestamp it was set to expiry.
+	 *
+	 * @param string $lock_type A string to identify different lock types.
+	 * @return bool|int False if no lock is set, otherwise the timestamp for when the lock is set to expire.
+	 */
+	public function get_expiration( $lock_type ) {
+		return get_option( $this->get_key( $lock_type ) );
+	}
+
+	/**
+	 * Get the key to use for storing the lock in the transient
+	 *
+	 * @param string $lock_type A string to identify different lock types.
+	 * @return string
+	 */
+	protected function get_key( $lock_type ) {
+		return sprintf( 'action_scheduler_lock_%s', $lock_type );
+	}
+}

--- a/classes/ActionScheduler_QueueRunner.php
+++ b/classes/ActionScheduler_QueueRunner.php
@@ -57,11 +57,11 @@ class ActionScheduler_QueueRunner extends ActionScheduler_Abstract_QueueRunner {
 	}
 
 	/**
-	 * If we're in the admin context, haven't exceeded the number of allowed batches and async
-	 * runner is enabled, then maybe dispatch another request if there are pending actions.
+	 * If we're in the admin context and haven't exceeded the number of allowed batches, then
+	 * maybe dispatch another request to process pending actions.
 	 */
 	public function maybe_dispatch_async_request() {
-		if ( is_admin() && ! $this->has_maximum_concurrent_batches() && apply_filters( 'action_scheduler_allow_async_runner', true ) ) {
+		if ( is_admin() && ! $this->has_maximum_concurrent_batches() ) {
 			$this->async_request->maybe_dispatch();
 		}
 	}

--- a/classes/ActionScheduler_QueueRunner.php
+++ b/classes/ActionScheduler_QueueRunner.php
@@ -55,7 +55,7 @@ class ActionScheduler_QueueRunner extends ActionScheduler_Abstract_QueueRunner {
 		do_action( 'action_scheduler_before_process_queue' );
 		$this->run_cleanup();
 		$processed_actions = 0;
-		if ( $this->store->get_claim_count() < $this->get_allowed_concurrent_batches() ) {
+		if ( false === $this->has_maximum_concurrent_batches() ) {
 			$batch_size = apply_filters( 'action_scheduler_queue_runner_batch_size', 25 );
 			do {
 				$processed_actions_in_batch = $this->do_batch( $batch_size );

--- a/classes/WP_CLI/ActionScheduler_WPCLI_QueueRunner.php
+++ b/classes/WP_CLI/ActionScheduler_WPCLI_QueueRunner.php
@@ -52,9 +52,7 @@ class ActionScheduler_WPCLI_QueueRunner extends ActionScheduler_Abstract_QueueRu
 		$this->add_hooks();
 
 		// Check to make sure there aren't too many concurrent processes running.
-		$claim_count = $this->store->get_claim_count();
-		$too_many    = $claim_count >= $this->get_allowed_concurrent_batches();
-		if ( $too_many ) {
+		if ( $this->has_maximum_concurrent_batches() ) {
 			if ( $force ) {
 				WP_CLI::warning( __( 'There are too many concurrent batches, but the run is forced to continue.', 'action-scheduler' ) );
 			} else {

--- a/classes/abstracts/ActionScheduler.php
+++ b/classes/abstracts/ActionScheduler.php
@@ -87,6 +87,8 @@ abstract class ActionScheduler {
 			}
 		} elseif ( strpos( $class, 'CronExpression' ) === 0 ) {
 			$dir = self::plugin_path( 'lib' . $d . 'cron-expression' . $d );
+		} elseif ( strpos( $class, 'WP_Async_Request' ) === 0 ) {
+			$dir = self::plugin_path( 'lib' . $d );
 		} else {
 			return;
 		}

--- a/classes/abstracts/ActionScheduler.php
+++ b/classes/abstracts/ActionScheduler.php
@@ -20,6 +20,10 @@ abstract class ActionScheduler {
 		return ActionScheduler_Store::instance();
 	}
 
+	public static function lock() {
+		return ActionScheduler_Lock::instance();
+	}
+
 	public static function logger() {
 		return ActionScheduler_Logger::instance();
 	}
@@ -151,6 +155,7 @@ abstract class ActionScheduler {
 			'ActionScheduler'                      => true,
 			'ActionScheduler_Abstract_ListTable'   => true,
 			'ActionScheduler_Abstract_QueueRunner' => true,
+			'ActionScheduler_Lock'                 => true,
 			'ActionScheduler_Logger'               => true,
 			'ActionScheduler_Store'                => true,
 			'ActionScheduler_TimezoneHelper'       => true,

--- a/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php
+++ b/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php
@@ -98,7 +98,7 @@ abstract class ActionScheduler_Abstract_QueueRunner extends ActionScheduler_Abst
 	 * @return int
 	 */
 	public function get_allowed_concurrent_batches() {
-		return apply_filters( 'action_scheduler_queue_runner_concurrent_batches', 5 );
+		return apply_filters( 'action_scheduler_queue_runner_concurrent_batches', 2 );
 	}
 
 	/**

--- a/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php
+++ b/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php
@@ -102,6 +102,15 @@ abstract class ActionScheduler_Abstract_QueueRunner extends ActionScheduler_Abst
 	}
 
 	/**
+	 * Check if the number of allowed concurrent batches is met or exceeded.
+	 *
+	 * @return bool
+	 */
+	public function has_maximum_concurrent_batches() {
+		return $this->store->get_claim_count() >= $this->get_allowed_concurrent_batches();
+	}
+
+	/**
 	 * Get the maximum number of seconds a batch can run for.
 	 *
 	 * @return int The number of seconds.

--- a/classes/abstracts/ActionScheduler_Lock.php
+++ b/classes/abstracts/ActionScheduler_Lock.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * Abstract class for setting a basic lock to throttle some action.
+ *
+ * Class ActionScheduler_Lock
+ */
+abstract class ActionScheduler_Lock {
+
+	/** @var ActionScheduler_Lock */
+	private static $locker = NULL;
+
+	/** @var int */
+	protected static $lock_duration = MINUTE_IN_SECONDS;
+
+	/**
+	 * Check if a lock is set for a given lock type.
+	 *
+	 * @param string $lock_type A string to identify different lock types.
+	 * @return bool
+	 */
+	public function is_locked( $lock_type ) {
+		return ( $this->get_expiration( $lock_type ) >= time() );
+	}
+
+	/**
+	 * Set a lock.
+	 *
+	 * @param string $lock_type A string to identify different lock types.
+	 * @return bool
+	 */
+	abstract public function set( $lock_type );
+
+	/**
+	 * If a lock is set, return the timestamp it was set to expiry.
+	 *
+	 * @param string $lock_type A string to identify different lock types.
+	 * @return bool|int False if no lock is set, otherwise the timestamp for when the lock is set to expire.
+	 */
+	abstract public function get_expiration( $lock_type );
+
+	/**
+	 * Get the amount of time to set for a given lock. 60 seconds by default.
+	 *
+	 * @param string $lock_type A string to identify different lock types.
+	 * @return int
+	 */
+	protected function get_duration( $lock_type ) {
+		return apply_filters( 'action_scheduler_lock_duration', self::$lock_duration, $lock_type );
+	}
+
+	/**
+	 * @return ActionScheduler_Lock
+	 */
+	public static function instance() {
+		if ( empty( self::$locker ) ) {
+			$class = apply_filters( 'action_scheduler_lock_class', 'ActionScheduler_OptionLock' );
+			self::$locker = new $class();
+		}
+		return self::$locker;
+	}
+}

--- a/classes/abstracts/ActionScheduler_Store.php
+++ b/classes/abstracts/ActionScheduler_Store.php
@@ -186,6 +186,22 @@ abstract class ActionScheduler_Store {
 		);
 	}
 
+	/**
+	 * Check if there are any pending scheduled actions due to run.
+	 *
+	 * @param ActionScheduler_Action $action
+	 * @param DateTime $scheduled_date (optional)
+	 * @return string
+	 */
+	public function has_pending_actions_due() {
+		$pending_actions = $this->query_actions( array(
+			'date'   => as_get_datetime_object(),
+			'status' => ActionScheduler_Store::STATUS_PENDING,
+		) );
+
+		return ! empty( $pending_actions );
+	}
+
 	public function init() {}
 
 	/**

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -8,7 +8,7 @@ To use it in your plugin, simply require the `action-scheduler/action-scheduler.
 
 ### I don't want to use WP-Cron. Does Action Scheduler depend on WP-Cron?
 
-By default, Action Scheduler is initiated by WP-Cron. However, it has no dependency on the WP-Cron system. You can initiate the Action Scheduler queue in other ways with just one or two lines of code.
+By default, Action Scheduler is initiated by WP-Cron (and the `'shutdown'` hook on admin requests). However, it has no dependency on the WP-Cron system. You can initiate the Action Scheduler queue in other ways with just one or two lines of code.
 
 For example, you can start a queue directly by calling:
 

--- a/lib/WP_Async_Request.php
+++ b/lib/WP_Async_Request.php
@@ -1,0 +1,170 @@
+<?php
+/**
+ * WP Async Request
+ *
+ * @package WP-Background-Processing
+ */
+/*
+Library URI: https://github.com/deliciousbrains/wp-background-processing/blob/fbbc56f2480910d7959972ec9ec0819a13c6150a/classes/wp-async-request.php
+Author: Delicious Brains Inc.
+Author URI: https://deliciousbrains.com/
+License: GNU General Public License v2.0
+License URI: https://github.com/deliciousbrains/wp-background-processing/commit/126d7945dd3d39f39cb6488ca08fe1fb66cb351a
+*/
+
+if ( ! class_exists( 'WP_Async_Request' ) ) {
+
+	/**
+	 * Abstract WP_Async_Request class.
+	 *
+	 * @abstract
+	 */
+	abstract class WP_Async_Request {
+
+		/**
+		 * Prefix
+		 *
+		 * (default value: 'wp')
+		 *
+		 * @var string
+		 * @access protected
+		 */
+		protected $prefix = 'wp';
+
+		/**
+		 * Action
+		 *
+		 * (default value: 'async_request')
+		 *
+		 * @var string
+		 * @access protected
+		 */
+		protected $action = 'async_request';
+
+		/**
+		 * Identifier
+		 *
+		 * @var mixed
+		 * @access protected
+		 */
+		protected $identifier;
+
+		/**
+		 * Data
+		 *
+		 * (default value: array())
+		 *
+		 * @var array
+		 * @access protected
+		 */
+		protected $data = array();
+
+		/**
+		 * Initiate new async request
+		 */
+		public function __construct() {
+			$this->identifier = $this->prefix . '_' . $this->action;
+
+			add_action( 'wp_ajax_' . $this->identifier, array( $this, 'maybe_handle' ) );
+			add_action( 'wp_ajax_nopriv_' . $this->identifier, array( $this, 'maybe_handle' ) );
+		}
+
+		/**
+		 * Set data used during the request
+		 *
+		 * @param array $data Data.
+		 *
+		 * @return $this
+		 */
+		public function data( $data ) {
+			$this->data = $data;
+
+			return $this;
+		}
+
+		/**
+		 * Dispatch the async request
+		 *
+		 * @return array|WP_Error
+		 */
+		public function dispatch() {
+			$url  = add_query_arg( $this->get_query_args(), $this->get_query_url() );
+			$args = $this->get_post_args();
+
+			return wp_remote_post( esc_url_raw( $url ), $args );
+		}
+
+		/**
+		 * Get query args
+		 *
+		 * @return array
+		 */
+		protected function get_query_args() {
+			if ( property_exists( $this, 'query_args' ) ) {
+				return $this->query_args;
+			}
+
+			return array(
+				'action' => $this->identifier,
+				'nonce'  => wp_create_nonce( $this->identifier ),
+			);
+		}
+
+		/**
+		 * Get query URL
+		 *
+		 * @return string
+		 */
+		protected function get_query_url() {
+			if ( property_exists( $this, 'query_url' ) ) {
+				return $this->query_url;
+			}
+
+			return admin_url( 'admin-ajax.php' );
+		}
+
+		/**
+		 * Get post args
+		 *
+		 * @return array
+		 */
+		protected function get_post_args() {
+			if ( property_exists( $this, 'post_args' ) ) {
+				return $this->post_args;
+			}
+
+			return array(
+				'timeout'   => 0.01,
+				'blocking'  => false,
+				'body'      => $this->data,
+				'cookies'   => $_COOKIE,
+				'sslverify' => apply_filters( 'https_local_ssl_verify', false ),
+			);
+		}
+
+		/**
+		 * Maybe handle
+		 *
+		 * Check for correct nonce and pass to handler.
+		 */
+		public function maybe_handle() {
+			// Don't lock up other requests while processing
+			session_write_close();
+
+			check_ajax_referer( $this->identifier, 'nonce' );
+
+			$this->handle();
+
+			wp_die();
+		}
+
+		/**
+		 * Handle
+		 *
+		 * Override this method to perform any actions required
+		 * during the async request.
+		 */
+		abstract protected function handle();
+
+	}
+}

--- a/tests/phpunit/lock/ActionScheduler_OptionLock_Test.php
+++ b/tests/phpunit/lock/ActionScheduler_OptionLock_Test.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * Class ActionScheduler_Lock_Test
+ * @package test_cases\lock
+ */
+class ActionScheduler_OptionLock_Test extends ActionScheduler_UnitTestCase {
+	public function test_instance() {
+		$lock = ActionScheduler::lock();
+		$this->assertInstanceOf( 'ActionScheduler_Lock', $lock );
+		$this->assertInstanceOf( 'ActionScheduler_OptionLock', $lock );
+	}
+
+	public function test_is_locked() {
+		$lock      = ActionScheduler::lock();
+		$lock_type = md5( rand() );
+
+		$this->assertFalse( $lock->is_locked( $lock_type ) );
+
+		$lock->set( $lock_type );
+		$this->assertTrue( $lock->is_locked( $lock_type ) );
+	}
+
+	public function test_set() {
+		$lock      = ActionScheduler::lock();
+		$lock_type = md5( rand() );
+
+		$lock->set( $lock_type );
+		$this->assertTrue( $lock->is_locked( $lock_type ) );
+	}
+
+	public function test_get_expiration() {
+		$lock      = ActionScheduler::lock();
+		$lock_type = md5( rand() );
+
+		$lock->set( $lock_type );
+
+		$expiration   = $lock->get_expiration( $lock_type );
+		$current_time = time();
+
+		$this->assertGreaterThanOrEqual( 0, $expiration );
+		$this->assertGreaterThan( $current_time, $expiration );
+		$this->assertLessThan( $current_time + MINUTE_IN_SECONDS + 1, $expiration );
+	}
+}

--- a/tests/phpunit/runner/ActionScheduler_QueueRunner_Test.php
+++ b/tests/phpunit/runner/ActionScheduler_QueueRunner_Test.php
@@ -121,14 +121,14 @@ class ActionScheduler_QueueRunner_Test extends ActionScheduler_UnitTestCase {
 		add_action( $random, array( $mock, 'action' ) );
 		$schedule = new ActionScheduler_SimpleSchedule(new ActionScheduler_DateTime('1 day ago'));
 
-		for ( $i = 0 ; $i < 30 ; $i++ ) {
+		for ( $i = 0 ; $i < 15 ; $i++ ) {
 			$action = new ActionScheduler_Action( $random, array($random), $schedule );
 			$store->save_action( $action );
 		}
 
 		$claims = array();
 
-		for ( $i = 0 ; $i < 5 ; $i++ ) {
+		for ( $i = 0 ; $i < 2 ; $i++ ) {
 			$claims[] = $store->stake_claim( 5 );
 		}
 


### PR DESCRIPTION
This is part two of #319 - the async queue processing. Part one - async action APIs - can be found in #322.

This PR extends the default `ActionScheduler_QueueRunner` class to include async processing. Queues are now run in asynchronous requests, as well as WP Cron requests.

These requests are initiated via the 'shutdown' hook on admin requests when Action Scheduler is not already processing the maximum number of allowed queues. The `'shutdown'` hook is the same approach taken by Jetpack and [Async Task](https://github.com/techcrunch/wp-async-task).

This removes Action Scheduler's dependence on WP Cron. While `ActionScheduler_QueueRunner` still uses WP Cron to process queues, queues will also now be processed anytime an admin request is made and there are pending actions.

Beyond removing the dependency on WP Cron, this has another major advantage - speed.

The approach taken here includes async request chaining (as initially discussed in #131). Whenever one async request processes a batch of actions to the allowed limits (the 20 second time limit is normally the limit that would be hit), a new async request to start processing a new batch of actions will be initiated if there are still other async actions to process.

This reduces the lag between processing each batch, and combined with queue concurrency, it substantially increases throughput when more than one queue is being processed by async requests (especially given the fact that each async request is also an admin request, so it will also initiate a 2nd async request on `'shutdown'` in addition to the async request created to chain processing for the original request).

Importantly, this differs substantially to the process currently used with WP Cron, which is to simply process as many actions/batches as possible within a given time limit during that single request, then wait for another WP Cron request before starting another batch.

### Implementation Notes

#### Keeping WP Cron

I've kept the WP Cron processing, because it's a helpful fallback for when loopback requests are not supported by the site/server.

#### Running Queues via the `'action_scheduler_run_queue'` Action

Importantly, queues are run in the async request by triggering the ` 'action_scheduler_run_queue'` hook, rather than calling `ActionScheduler::runner()->run()` directly.

This maintains compatibility with the WP Cron runner, and helps ensure existing code will apply to this new method for processing queues, like this plugin: https://github.com/Prospress/action-scheduler-disable-default-runner

#### Reduced Default Queue Concurrency

Importantly, given the increased likelihood of concurrent queues now occurring on all sites (instead of just sites tweaking things with Action Scheduler), there is a need to be more conservative with the default concurrency allowed by Action Scheduler.

SHA: f493e7d9914b5ad7e66d5 takes care of this, by reducing the default concurrency to two queues, from five. This prevents consuming too many resources by default. The concurrency can still be [increased](https://actionscheduler.org/perf/#increasing-concurrent-batches) when possible, if needed. I expect the chained async requests will increase throughput enough that concurrency increases will be required less now.

#### Disabling Async Queues with `'action_scheduler_allow_async_runner'`

As mentioned [here](https://github.com/Prospress/action-scheduler/issues/131#issuecomment-391227809), chained async requests without a kill-switch can be a dangerous thing.

To mitigate this, I've included a new `'action_scheduler_allow_async_runner'` filter. This can be used to both:

1. prevent any actions being run via async requests
1. terminate an async request chain part way through

- [ ] this new filter will need to be added to [the docs](https://actionscheduler.org/).

#### Initialising the `ActionScheduler_AsyncRequest_QueueRunner`

I'm injecting the `ActionScheduler_AsyncRequest_QueueRunner` class into the `ActionScheduler_QueueRunner`. That's to match the approach taken for other dependencies by `ActionScheduler_QueueRunner`; however, I don't see much need to swap it.

#### `WP_Async_Request`

I've used the `WP_Async_Request` library used by [WP Background Processing](https://github.com/deliciousbrains/wp-background-processing) for handling the request. This wasn't really necessary, as its mostly just a wrapper around `wp_remote_post()`, but I figured using it was better than starting from scratch.

## Testing

A fun way to test this is with the following snippet and visiting a page on your site with the URL param `?as_add_async_actions=true`. It will require the patch in #322 to get the `as_enqueue_async_action()` method.

```php
function as_test_schedule_async_action() {

	if ( ! isset( $_GET['as_add_async_actions'] ) ) {
		return;
	}

	for( $i = 1; $i < 300; $i++ ) {
		as_enqueue_async_action( 'test_async_action', array( 'timestamp' => time(), 'i' => $i ), 'async' );
	}
}
add_action( 'shutdown', 'as_test_schedule_async_action' );

function as_test_schedule_async_action_sleep() {
	sleep( 1 );
}
add_action( 'test_async_action', 'as_test_schedule_async_action_sleep' );
```

This will add hundreds of actions, and process them at a sustained rate of 120 / minute, as each action takes 1 second to process, and two concurrent queues will be processing them. With WP Cron only, the maximum throughput would be 20 / minute.