### PR TITLE
Fix concurrent queue notice

### DIFF
--- a/classes/ActionScheduler_ListTable.php
+++ b/classes/ActionScheduler_ListTable.php
@@ -318,7 +318,7 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 		if ( $this->store->get_claim_count() >= $this->runner->get_allowed_concurrent_batches() ) {
 			$this->admin_notices[] = array(
 				'class'   => 'updated',
-				'message' => sprintf( __( 'Maximum simultaneous batches already in progress (%s queues). No actions will be processed until the current batches are complete.', 'action-scheduler' ), $this->store->get_claim_count() ),
+				'message' => sprintf( __( 'Maximum simultaneous queues already in progress (%s queues). No additional queues will begin processing until the current queues are complete.', 'action-scheduler' ), $this->store->get_claim_count() ),
 			);
 		}
 


### PR DESCRIPTION
The notice displayed to alert an admin about the maximum number of queues being processed used the term "batches", which is incorrect. Even when the queue concurrency has been reached, new batches may be claimed.

It also said "_No actions will be processed until_", which is incorrect - actions continue to be processed by the active queues, but no additional queues will be initiated.