### PR TITLE
Fix marking actions with invalid schedules as failed

### DIFF
--- a/classes/abstracts/ActionScheduler_Store.php
+++ b/classes/abstracts/ActionScheduler_Store.php
@@ -4,7 +4,7 @@
  * Class ActionScheduler_Store
  * @codeCoverageIgnore
  */
-abstract class ActionScheduler_Store {
+abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 	const STATUS_COMPLETE = 'complete';
 	const STATUS_PENDING  = 'pending';
 	const STATUS_RUNNING  = 'in-progress';
@@ -214,16 +214,5 @@ abstract class ActionScheduler_Store {
 			self::$store = new $class();
 		}
 		return self::$store;
-	}
-
-	/**
-	 * Get the site's local time.
-	 *
-	 * @deprecated 2.1.0
-	 * @return DateTimeZone
-	 */
-	protected function get_local_timezone() {
-		_deprecated_function( __FUNCTION__, '2.1.0', 'ActionScheduler_TimezoneHelper::set_local_timezone()' );
-		return ActionScheduler_TimezoneHelper::get_local_timezone();
 	}
 }

--- a/classes/abstracts/ActionScheduler_Store.php
+++ b/classes/abstracts/ActionScheduler_Store.php
@@ -206,42 +206,12 @@ abstract class ActionScheduler_Store {
 	public function init() {}
 
 	/**
-	 * Mark an action that failed to fetch correctly as failed.
-	 *
-	 * @since 2.2.6
-	 *
-	 * @param int $action_id The ID of the action.
-	 */
-	public function mark_failed_fetch_action( $action_id ) {
-		self::$store->mark_failure( $action_id );
-	}
-
-	/**
-	 * Add base hooks
-	 *
-	 * @since 2.2.6
-	 */
-	public static function hook() {
-		add_action( 'action_scheduler_failed_fetch_action', array( self::$store, 'mark_failed_fetch_action' ), 20 );
-	}
-
-	/**
-	 * Remove base hooks
-	 *
-	 * @since 2.2.6
-	 */
-	public static function unhook() {
-		remove_action( 'action_scheduler_failed_fetch_action', array( self::$store, 'mark_failed_fetch_action' ), 20 );
-	}
-
-	/**
 	 * @return ActionScheduler_Store
 	 */
 	public static function instance() {
 		if ( empty( self::$store ) ) {
 			$class = apply_filters( 'action_scheduler_store_class', self::DEFAULT_CLASS );
 			self::$store = new $class();
-			self::hook();
 		}
 		return self::$store;
 	}

--- a/deprecated/ActionScheduler_Store_Deprecated.php
+++ b/deprecated/ActionScheduler_Store_Deprecated.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * Class ActionScheduler_Store_Deprecated
+ * @codeCoverageIgnore
+ */
+abstract class ActionScheduler_Store_Deprecated {
+
+	/**
+	 * Get the site's local time.
+	 *
+	 * @deprecated 2.1.0
+	 * @return DateTimeZone
+	 */
+	protected function get_local_timezone() {
+		_deprecated_function( __FUNCTION__, '2.1.0', 'ActionScheduler_TimezoneHelper::set_local_timezone()' );
+		return ActionScheduler_TimezoneHelper::get_local_timezone();
+	}
+}

--- a/deprecated/ActionScheduler_Store_Deprecated.php
+++ b/deprecated/ActionScheduler_Store_Deprecated.php
@@ -7,6 +7,36 @@
 abstract class ActionScheduler_Store_Deprecated {
 
 	/**
+	 * Mark an action that failed to fetch correctly as failed.
+	 *
+	 * @since 2.2.6
+	 *
+	 * @param int $action_id The ID of the action.
+	 */
+	public function mark_failed_fetch_action( $action_id ) {
+		_deprecated_function( __METHOD__, '3.0.0', 'ActionScheduler_Store::mark_failure()' );
+		self::$store->mark_failure( $action_id );
+	}
+
+	/**
+	 * Add base hooks
+	 *
+	 * @since 2.2.6
+	 */
+	protected static function hook() {
+		_deprecated_function( __METHOD__, '3.0.0' );
+	}
+
+	/**
+	 * Remove base hooks
+	 *
+	 * @since 2.2.6
+	 */
+	protected static function unhook() {
+		_deprecated_function( __METHOD__, '3.0.0' );
+	}
+
+	/**
 	 * Get the site's local time.
 	 *
 	 * @deprecated 2.1.0

--- a/tests/phpunit/jobstore/ActionScheduler_wpPostStore_Test.php
+++ b/tests/phpunit/jobstore/ActionScheduler_wpPostStore_Test.php
@@ -54,9 +54,7 @@ class ActionScheduler_wpPostStore_Test extends ActionScheduler_UnitTestCase {
 			'post_content' => $content,
 		) );
 
-		ActionScheduler_Store::unhook();
 		$fetched = $store->fetch_action( $post_id );
-		ActionScheduler_Store::hook();
 		$this->assertInstanceOf( 'ActionScheduler_NullSchedule', $fetched->get_schedule() );
 	}
 


### PR DESCRIPTION
This PR reverts Prospress/action-scheduler#297 because it would mark the action as failed every time it was fetched, which included things like every time an admin page loads to display the action. The desired behaviour is to mark the action as failed once, when an attempt to run it is undertaken (and that attempt fails). I will introduce that in a separate PR, because it relies on some other improvements to how exceptions are handled when failing to fetch the action.

Because the code from Prospress/action-scheduler#297 has already been released, I've added a new `ActionScheduler_Store_Deprecated` class to safely deprecate the public and protected methods being reverted.