### PR TITLE
Revert "use scheduled_date when passed for recurring actions"

### DIFF
--- a/classes/ActionScheduler_wpPostStore.php
+++ b/classes/ActionScheduler_wpPostStore.php
@@ -19,13 +19,7 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 			$this->validate_action( $action );
 			$post_array = $this->create_post_array( $action, $scheduled_date );
 			$post_id = $this->save_post_array( $post_array );
-			$schedule = $action->get_schedule();
-
-			if ( ! is_null( $scheduled_date ) && $schedule->is_recurring() ) {
-				$schedule = new ActionScheduler_IntervalSchedule( $scheduled_date, $schedule->interval_in_seconds() );
-			}
-
-			$this->save_post_schedule( $post_id, $schedule );
+			$this->save_post_schedule( $post_id, $action->get_schedule() );
 			$this->save_action_group( $post_id, $action->get_group() );
 			do_action( 'action_scheduler_stored_action', $post_id );
 			return $post_id;


### PR DESCRIPTION
Reverts Prospress/action-scheduler#294

The patch in this PR effectively overwrote data passed into the save method (which should just save it, not determine what the data should be).

The patch also introduced a bug, because `ActionScheduler_CronSchedule::is_recurring()` also returns `true`, but `ActionScheduler_CronSchedule::interval_in_seconds()` is undefined (and even if it was defined, the patch would have morphed the `ActionScheduler_CronSchedule` into a `ActionScheduler_IntervalSchedule` because that schedule type wasn't being handled yet).

I'm pretty sure the diagnosis of `ActionScheduler_IntervalSchedule::$start` having an incorrect value is what is causing #293 (and likely also #256). However, I think `ActionScheduler_Abstract_QueueRunner::schedule_next_instance()` should be the method responsible for updating the schedule, rather than the `save_action()` method. For example, perhaps `schedule_next_instance()` should be calling `ActionScheduler::factory()->recurring()` or `ActionScheduler::factory()->cron()` instead of `save_action()` to make sure the schedule is up-to-date.