### PR TITLE
Tweak fetch exception handling

### DIFF
--- a/classes/ActionScheduler_InvalidActionException.php
+++ b/classes/ActionScheduler_InvalidActionException.php
@@ -10,6 +10,22 @@
 class ActionScheduler_InvalidActionException extends \InvalidArgumentException implements ActionScheduler_Exception {
 
 	/**
+	 * Create a new exception when the action's schedule cannot be fetched.
+	 *
+	 * @param string $action_id The action ID with bad args.
+	 * @return static
+	 */
+	public static function from_schedule( $action_id, $schedule ) {
+		$message = sprintf(
+			__( 'Action [%s] has an invalid schedule: %s', 'action-scheduler' ),
+			$action_id,
+			var_export( $schedule, true )
+		);
+
+		return new static( $message );
+	}
+
+	/**
 	 * Create a new exception when the action's args cannot be decoded to an array.
 	 *
 	 * @author Jeremy Pry

--- a/classes/ActionScheduler_InvalidActionException.php
+++ b/classes/ActionScheduler_InvalidActionException.php
@@ -17,10 +17,11 @@ class ActionScheduler_InvalidActionException extends \InvalidArgumentException i
 	 * @param string $action_id The action ID with bad args.
 	 * @return static
 	 */
-	public static function from_decoding_args( $action_id ) {
+	public static function from_decoding_args( $action_id, $args = array() ) {
 		$message = sprintf(
-			__( 'Action [%s] has invalid arguments. It cannot be JSON decoded to an array.', 'action-scheduler' ),
-			$action_id
+			__( 'Action [%s] has invalid arguments. It cannot be JSON decoded to an array. $args = %s', 'action-scheduler' ),
+			$action_id,
+			var_export( $args, true )
 		);
 
 		return new static( $message );

--- a/classes/abstracts/ActionScheduler_Logger.php
+++ b/classes/abstracts/ActionScheduler_Logger.php
@@ -55,7 +55,7 @@ abstract class ActionScheduler_Logger {
 		add_action( 'action_scheduler_unexpected_shutdown', array( $this, 'log_unexpected_shutdown' ), 10, 2 );
 		add_action( 'action_scheduler_reset_action', array( $this, 'log_reset_action' ), 10, 1 );
 		add_action( 'action_scheduler_execution_ignored', array( $this, 'log_ignored_action' ), 10, 1 );
-		add_action( 'action_scheduler_failed_fetch_action', array( $this, 'log_failed_fetch_action' ), 10, 1 );
+		add_action( 'action_scheduler_failed_fetch_action', array( $this, 'log_failed_fetch_action' ), 10, 2 );
 	}
 
 	public function hook_stored_action() {
@@ -104,7 +104,20 @@ abstract class ActionScheduler_Logger {
 		$this->log( $action_id, __( 'action ignored', 'action-scheduler' ) );
 	}
 
-	public function log_failed_fetch_action( $action_id ) {
-		$this->log( $action_id, __( 'There was a failure fetching this action', 'action-scheduler' ) );
+	/**
+	 * @param string $action_id
+	 * @param Exception|NULL $exception The exception which occured when fetching the action. NULL by default for backward compatibility.
+	 *
+	 * @return ActionScheduler_LogEntry[]
+	 */
+	public function log_failed_fetch_action( $action_id, Exception $exception = NULL ) {
+
+		if ( ! is_null( $exception ) ) {
+			$log_message = sprintf( __( 'There was a failure fetching this action: %s', 'action-scheduler' ), $exception->getMessage() );
+		} else {
+			$log_message = __( 'There was a failure fetching this action', 'action-scheduler' );
+		}
+
+		$this->log( $action_id, $log_message );
 	}
 }

--- a/classes/abstracts/ActionScheduler_Store.php
+++ b/classes/abstracts/ActionScheduler_Store.php
@@ -175,6 +175,40 @@ abstract class ActionScheduler_Store {
 	}
 
 	/**
+	 * Validate that we could decode action arguments.
+	 *
+	 * @param mixed $args      The decoded arguments.
+	 * @param int   $action_id The action ID.
+	 *
+	 * @throws ActionScheduler_InvalidActionException When the decoded arguments are invalid.
+	 */
+	protected function validate_args( $args, $action_id ) {
+		// Ensure we have an array of args.
+		if ( ! is_array( $args ) ) {
+			throw ActionScheduler_InvalidActionException::from_decoding_args( $action_id );
+		}
+
+		// Validate JSON decoding if possible.
+		if ( function_exists( 'json_last_error' ) && JSON_ERROR_NONE !== json_last_error() ) {
+			throw ActionScheduler_InvalidActionException::from_decoding_args( $action_id, $args );
+		}
+	}
+
+	/**
+	 * Validate a ActionScheduler_Schedule object.
+	 *
+	 * @param mixed $schedule  The unserialized ActionScheduler_Schedule object.
+	 * @param int   $action_id The action ID.
+	 *
+	 * @throws ActionScheduler_InvalidActionException When the schedule is invalid.
+	 */
+	protected function validate_schedule( $schedule, $action_id ) {
+		if ( empty( $schedule ) || ! is_a( $schedule, 'ActionScheduler_Schedule' ) ) {
+			throw ActionScheduler_InvalidActionException::from_schedule( $post->ID, $schedule );
+		}
+	}
+
+	/**
 	 * @return array
 	 */
 	public function get_status_labels() {

--- a/classes/data-stores/ActionScheduler_wpPostStore.php
+++ b/classes/data-stores/ActionScheduler_wpPostStore.php
@@ -162,7 +162,7 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 		} catch ( ActionScheduler_InvalidActionException $exception ) {
 			$schedule = new ActionScheduler_NullSchedule();
 			$args = array();
-			do_action( 'action_scheduler_failed_fetch_action', $post->ID );
+			do_action( 'action_scheduler_failed_fetch_action', $post->ID, $exception );
 		}
 
 		$group = wp_get_object_terms( $post->ID, self::GROUP_TAXONOMY, array('fields' => 'names') );

--- a/classes/data-stores/ActionScheduler_wpPostStore.php
+++ b/classes/data-stores/ActionScheduler_wpPostStore.php
@@ -157,7 +157,7 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 
 			$schedule = get_post_meta( $post->ID, self::SCHEDULE_META_KEY, true );
 			if ( empty( $schedule ) || ! is_a( $schedule, 'ActionScheduler_Schedule' ) ) {
-				throw ActionScheduler_InvalidActionException::from_decoding_args( $post->ID );
+				throw ActionScheduler_InvalidActionException::from_schedule( $post->ID, $schedule );
 			}
 		} catch ( ActionScheduler_InvalidActionException $exception ) {
 			$schedule = new ActionScheduler_NullSchedule();

--- a/classes/data-stores/ActionScheduler_wpPostStore.php
+++ b/classes/data-stores/ActionScheduler_wpPostStore.php
@@ -163,9 +163,7 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 		$this->validate_args( $args, $post->ID );
 
 		$schedule = get_post_meta( $post->ID, self::SCHEDULE_META_KEY, true );
-		if ( empty( $schedule ) || ! is_a( $schedule, 'ActionScheduler_Schedule' ) ) {
-			throw ActionScheduler_InvalidActionException::from_schedule( $post->ID, $schedule );
-		}
+		$this->validate_schedule( $schedule, $post->ID );
 
 		$group = wp_get_object_terms( $post->ID, self::GROUP_TAXONOMY, array('fields' => 'names') );
 		$group = empty( $group ) ? '' : reset($group);
@@ -813,25 +811,5 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 
 		$taxonomy_registrar = new ActionScheduler_wpPostStore_TaxonomyRegistrar();
 		$taxonomy_registrar->register();
-	}
-
-	/**
-	 * Validate that we could decode action arguments.
-	 *
-	 * @param mixed $args      The decoded arguments.
-	 * @param int   $action_id The action ID.
-	 *
-	 * @throws ActionScheduler_InvalidActionException When the decoded arguments are invalid.
-	 */
-	private function validate_args( $args, $action_id ) {
-		// Ensure we have an array of args.
-		if ( ! is_array( $args ) ) {
-			throw ActionScheduler_InvalidActionException::from_decoding_args( $action_id );
-		}
-
-		// Validate JSON decoding if possible.
-		if ( function_exists( 'json_last_error' ) && JSON_ERROR_NONE !== json_last_error() ) {
-			throw ActionScheduler_InvalidActionException::from_decoding_args( $action_id, $args );
-		}
 	}
 }

--- a/classes/data-stores/ActionScheduler_wpPostStore.php
+++ b/classes/data-stores/ActionScheduler_wpPostStore.php
@@ -829,7 +829,7 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 
 		// Validate JSON decoding if possible.
 		if ( function_exists( 'json_last_error' ) && JSON_ERROR_NONE !== json_last_error() ) {
-			throw ActionScheduler_InvalidActionException::from_decoding_args( $action_id );
+			throw ActionScheduler_InvalidActionException::from_decoding_args( $action_id, $args );
 		}
 	}
 }


### PR DESCRIPTION
This PR is an extension of work done in a number of prior PRs to handle corrupted data. Specifically, if an action has a corrupted schedule or set of args in the database, fetching those would cause an exception. The first approach to address this was to throw the exception. While this was fine for the purposes of running the queue, other calls to `ActionScheduler::store()->fetch_action()` were not updated to catch exceptions, leading to errors.

The next iteration attempted to catch the exception and log it. This prevents the exceptions halting code execution, but it also lead to other potential bugs, because a valid action was still being returned by `fetch_action()`, when really, once we know data is corrupted, we should be avoiding giving any indication the action is valid, because we really don't know what's happened, and we definitely don't want the action to be run (i.e. `$action->execute()`) because we might be running it on the wrong schedule, or with invalid args (leading to other fatal errors).

This iteration uses a similar approach to that done for an invalid `$action_id` - return an instance of `ActionScheduler_NullAction`. This helps avoid throwing an exception, because we are returnign a valid. But it also avoids harder to catch diagnose errors due to _not_ throwing an exception when the data is corrupted, becuase `ActionScheduler_NullAction::execute()` does nothing, instead of calling `do_action_ref_array()`.

The one thing not being done well with this patch is that on #326 is merged, the action will simply be marked as `complete` after being claimed & processed and then remain as `complete`. It should be marked as `failed`. That can be done by having `ActionScheduler_Abstract_QueueRunner::process_action()` throw an exception if `$this->store->fetch_action( $action_id )` returns a `ActionScheduler_NullAction`.