### PR TITLE
Add context to action processing

### DIFF
--- a/classes/ActionScheduler_AsyncRequest_QueueRunner.php
+++ b/classes/ActionScheduler_AsyncRequest_QueueRunner.php
@@ -49,7 +49,7 @@ class ActionScheduler_AsyncRequest_QueueRunner extends WP_Async_Request {
 	 * if there are still pending actions after completing a queue in this request.
 	 */
 	protected function handle() {
-		do_action( 'action_scheduler_run_queue' ); // run a queue in the exact same way as WP Cron
+		do_action( 'action_scheduler_run_queue', 'Async Request' ); // run a queue in the same way as WP Cron, but declare the Async Request context
 		$this->maybe_dispatch();
 	}
 

--- a/classes/ActionScheduler_ListTable.php
+++ b/classes/ActionScheduler_ListTable.php
@@ -458,7 +458,7 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 		try {
 			switch ( $row_action_type ) {
 				case 'run' :
-					$this->runner->process_action( $action_id );
+					$this->runner->process_action( $action_id, 'Admin List Table' );
 					break;
 				case 'cancel' :
 					$this->store->cancel_action( $action_id );

--- a/classes/WP_CLI/ActionScheduler_WPCLI_QueueRunner.php
+++ b/classes/WP_CLI/ActionScheduler_WPCLI_QueueRunner.php
@@ -110,7 +110,7 @@ class ActionScheduler_WPCLI_QueueRunner extends ActionScheduler_Abstract_QueueRu
 				break;
 			}
 
-			$this->process_action( $action_id );
+			$this->process_action( $action_id, 'WP CLI' );
 			$this->progress_bar->tick();
 		}
 

--- a/classes/abstracts/ActionScheduler_Logger.php
+++ b/classes/abstracts/ActionScheduler_Logger.php
@@ -48,13 +48,13 @@ abstract class ActionScheduler_Logger {
 	public function init() {
 		$this->hook_stored_action();
 		add_action( 'action_scheduler_canceled_action', array( $this, 'log_canceled_action' ), 10, 1 );
-		add_action( 'action_scheduler_before_execute', array( $this, 'log_started_action' ), 10, 1 );
-		add_action( 'action_scheduler_after_execute', array( $this, 'log_completed_action' ), 10, 1 );
-		add_action( 'action_scheduler_failed_execution', array( $this, 'log_failed_action' ), 10, 2 );
+		add_action( 'action_scheduler_before_execute', array( $this, 'log_started_action' ), 10, 2 );
+		add_action( 'action_scheduler_after_execute', array( $this, 'log_completed_action' ), 10, 3 );
+		add_action( 'action_scheduler_failed_execution', array( $this, 'log_failed_action' ), 10, 3 );
 		add_action( 'action_scheduler_failed_action', array( $this, 'log_timed_out_action' ), 10, 2 );
 		add_action( 'action_scheduler_unexpected_shutdown', array( $this, 'log_unexpected_shutdown' ), 10, 2 );
 		add_action( 'action_scheduler_reset_action', array( $this, 'log_reset_action' ), 10, 1 );
-		add_action( 'action_scheduler_execution_ignored', array( $this, 'log_ignored_action' ), 10, 1 );
+		add_action( 'action_scheduler_execution_ignored', array( $this, 'log_ignored_action' ), 10, 2 );
 		add_action( 'action_scheduler_failed_fetch_action', array( $this, 'log_failed_fetch_action' ), 10, 2 );
 	}
 
@@ -74,16 +74,31 @@ abstract class ActionScheduler_Logger {
 		$this->log( $action_id, __( 'action canceled', 'action-scheduler' ) );
 	}
 
-	public function log_started_action( $action_id ) {
-		$this->log( $action_id, __( 'action started', 'action-scheduler' ) );
+	public function log_started_action( $action_id, $context = '' ) {
+		if ( ! empty( $context ) ) {
+			$message = sprintf( __( 'action started via %s', 'action-scheduler' ), $context );
+		} else {
+			$message = __( 'action started', 'action-scheduler' );
+		}
+		$this->log( $action_id, $message );
 	}
 
-	public function log_completed_action( $action_id ) {
-		$this->log( $action_id, __( 'action complete', 'action-scheduler' ) );
+	public function log_completed_action( $action_id, $action = NULL, $context = '' ) {
+		if ( ! empty( $context ) ) {
+			$message = sprintf( __( 'action complete via %s', 'action-scheduler' ), $context );
+		} else {
+			$message = __( 'action complete', 'action-scheduler' );
+		}
+		$this->log( $action_id, $message );
 	}
 
-	public function log_failed_action( $action_id, Exception $exception ) {
-		$this->log( $action_id, sprintf( __( 'action failed: %s', 'action-scheduler' ), $exception->getMessage() ) );
+	public function log_failed_action( $action_id, Exception $exception, $context = '' ) {
+		if ( ! empty( $context ) ) {
+			$message = sprintf( __( 'action failed via %s: %s', 'action-scheduler' ), $context, $exception->getMessage() );
+		} else {
+			$message = sprintf( __( 'action failed: %s', 'action-scheduler' ), $exception->getMessage() );
+		}
+		$this->log( $action_id, $message );
 	}
 
 	public function log_timed_out_action( $action_id, $timeout ) {
@@ -100,7 +115,12 @@ abstract class ActionScheduler_Logger {
 		$this->log( $action_id, __( 'action reset', 'action_scheduler' ) );
 	}
 
-	public function log_ignored_action( $action_id ) {
+	public function log_ignored_action( $action_id, $context = '' ) {
+		if ( ! empty( $context ) ) {
+			$message = sprintf( __( 'action ignored via %s', 'action-scheduler' ), $context );
+		} else {
+			$message = __( 'action ignored', 'action-scheduler' );
+		}
 		$this->log( $action_id, __( 'action ignored', 'action-scheduler' ) );
 	}
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -19,7 +19,7 @@ ActionScheduler::runner()->run();
 Or trigger the `'action_scheduler_run_queue'` hook and let Action Scheduler do it for you:
 
 ```php
-do_action( 'action_scheduler_run_queue' );
+do_action( 'action_scheduler_run_queue', $context_identifier );
 ```
 
 Further customization can be done by extending the `ActionScheduler_Abstract_QueueRunner` class to create a custom Queue Runner. For an example of a customized queue runner, see the [`ActionScheduler_WPCLI_QueueRunner`](https://github.com/Prospress/action-scheduler/blob/master/classes/ActionScheduler_WPCLI_QueueRunner.php), which is used when running WP CLI.

--- a/tests/phpunit/logging/ActionScheduler_DBLogger_Test.php
+++ b/tests/phpunit/logging/ActionScheduler_DBLogger_Test.php
@@ -43,11 +43,11 @@ class ActionScheduler_DBLogger_Test extends ActionScheduler_UnitTestCase {
 	public function test_execution_logs() {
 		$action_id = as_schedule_single_action( time(), __METHOD__ );
 		$logger = ActionScheduler::logger();
-		$started = new ActionScheduler_LogEntry( $action_id, 'action started' );
-		$finished = new ActionScheduler_LogEntry( $action_id, 'action complete' );
+		$started = new ActionScheduler_LogEntry( $action_id, 'action started via Unit Tests' );
+		$finished = new ActionScheduler_LogEntry( $action_id, 'action complete via Unit Tests' );
 
 		$runner = new ActionScheduler_QueueRunner();
-		$runner->run();
+		$runner->run( 'Unit Tests' );
 
 		// Expect 3 logs with the correct action ID.
 		$logs = $logger->get_logs( $action_id );
@@ -67,12 +67,12 @@ class ActionScheduler_DBLogger_Test extends ActionScheduler_UnitTestCase {
 		add_action( $hook, array( $this, '_a_hook_callback_that_throws_an_exception' ) );
 		$action_id = as_schedule_single_action( time(), $hook );
 		$logger = ActionScheduler::logger();
-		$started = new ActionScheduler_LogEntry( $action_id, 'action started' );
-		$finished = new ActionScheduler_LogEntry( $action_id, 'action complete' );
-		$failed = new ActionScheduler_LogEntry( $action_id, 'action failed: Execution failed' );
+		$started = new ActionScheduler_LogEntry( $action_id, 'action started via Unit Tests' );
+		$finished = new ActionScheduler_LogEntry( $action_id, 'action complete via Unit Tests' );
+		$failed = new ActionScheduler_LogEntry( $action_id, 'action failed via Unit Tests: Execution failed' );
 
 		$runner = new ActionScheduler_QueueRunner();
-		$runner->run();
+		$runner->run( 'Unit Tests' );
 
 		// Expect 3 logs with the correct action ID.
 		$logs = $logger->get_logs( $action_id );

--- a/tests/phpunit/logging/ActionScheduler_wpCommentLogger_Test.php
+++ b/tests/phpunit/logging/ActionScheduler_wpCommentLogger_Test.php
@@ -89,11 +89,11 @@ class ActionScheduler_wpCommentLogger_Test extends ActionScheduler_UnitTestCase 
 	public function test_execution_comments() {
 		$action_id = as_schedule_single_action( time(), 'a hook' );
 		$logger = ActionScheduler::logger();
-		$started = new ActionScheduler_LogEntry( $action_id, 'action started' );
-		$finished = new ActionScheduler_LogEntry( $action_id, 'action complete' );
+		$started = new ActionScheduler_LogEntry( $action_id, 'action started via Unit Tests' );
+		$finished = new ActionScheduler_LogEntry( $action_id, 'action complete via Unit Tests' );
 
 		$runner = new ActionScheduler_QueueRunner();
-		$runner->run();
+		$runner->run( 'Unit Tests' );
 
 		$logs = $logger->get_logs( $action_id );
 		$this->assertTrue( in_array( $this->log_entry_to_array( $started ), $this->log_entry_to_array( $logs ) ) );
@@ -105,12 +105,12 @@ class ActionScheduler_wpCommentLogger_Test extends ActionScheduler_UnitTestCase 
 		add_action( $hook, array( $this, '_a_hook_callback_that_throws_an_exception' ) );
 		$action_id = as_schedule_single_action( time(), $hook );
 		$logger = ActionScheduler::logger();
-		$started = new ActionScheduler_LogEntry( $action_id, 'action started' );
-		$finished = new ActionScheduler_LogEntry( $action_id, 'action complete' );
-		$failed = new ActionScheduler_LogEntry( $action_id, 'action failed: Execution failed' );
+		$started = new ActionScheduler_LogEntry( $action_id, 'action started via Unit Tests' );
+		$finished = new ActionScheduler_LogEntry( $action_id, 'action complete via Unit Tests' );
+		$failed = new ActionScheduler_LogEntry( $action_id, 'action failed via Unit Tests: Execution failed' );
 
 		$runner = new ActionScheduler_QueueRunner();
-		$runner->run();
+		$runner->run( 'Unit Tests' );
 
 		$logs = $logger->get_logs( $action_id );
 		$this->assertTrue( in_array( $this->log_entry_to_array( $started ), $this->log_entry_to_array( $logs ) ) );

--- a/tests/phpunit/runner/ActionScheduler_QueueRunner_Test.php
+++ b/tests/phpunit/runner/ActionScheduler_QueueRunner_Test.php
@@ -108,7 +108,7 @@ class ActionScheduler_QueueRunner_Test extends ActionScheduler_UnitTestCase {
 	}
 
 	public function test_hooked_into_wp_cron() {
-		$next = wp_next_scheduled( ActionScheduler_QueueRunner::WP_CRON_HOOK );
+		$next = wp_next_scheduled( ActionScheduler_QueueRunner::WP_CRON_HOOK, array( 'WP Cron' ) );
 		$this->assertNotEmpty($next);
 	}
 


### PR DESCRIPTION
Add context to action processing / queue runners so that we can log where the action are run from, e.g. WP CLI, WP Cron the Admin List Table or the upcoming Async Runner.

Very handy for debugging issues after the fact.

Example logs entries: https://cld.wthms.co/fT0T96

Fixes #129