### PR TITLE
Fix recurring schedules, e.g. Cron and Interval schedules

### DIFF
--- a/classes/ActionScheduler_ActionFactory.php
+++ b/classes/ActionScheduler_ActionFactory.php
@@ -22,6 +22,9 @@ class ActionScheduler_ActionFactory {
 				break;
 			case ActionScheduler_Store::STATUS_CANCELED :
 				$action_class = 'ActionScheduler_CanceledAction';
+				if ( ! is_null( $schedule ) && ! is_a( $schedule, 'ActionScheduler_CanceledSchedule' ) ) {
+					$schedule = new ActionScheduler_CanceledSchedule( $schedule->get_date() );
+				}
 				break;
 			default :
 				$action_class = 'ActionScheduler_FinishedAction';

--- a/classes/ActionScheduler_ActionFactory.php
+++ b/classes/ActionScheduler_ActionFactory.php
@@ -107,17 +107,19 @@ class ActionScheduler_ActionFactory {
 	 *
 	 * @param string $hook The hook to trigger when this action runs
 	 * @param array $args Args to pass when the hook is triggered
-	 * @param int $first Unix timestamp for the first run
+	 * @param int $base_timestamp The first instance of the action will be scheduled
+	 *        to run at a time calculated after this timestamp matching the cron
+	 *        expression. This can be used to delay the first instance of the action.
 	 * @param int $schedule A cron definition string
 	 * @param string $group A group to put the action in
 	 *
 	 * @return string The ID of the stored action
 	 */
-	public function cron( $hook, $args = array(), $first = null, $schedule = null, $group = '' ) {
+	public function cron( $hook, $args = array(), $base_timestamp = null, $schedule = null, $group = '' ) {
 		if ( empty($schedule) ) {
-			return $this->single( $hook, $args, $first, $group );
+			return $this->single( $hook, $args, $base_timestamp, $group );
 		}
-		$date = as_get_datetime_object( $first );
+		$date = as_get_datetime_object( $base_timestamp );
 		$cron = CronExpression::factory( $schedule );
 		$schedule = new ActionScheduler_CronSchedule( $date, $cron );
 		$action = new ActionScheduler_Action( $hook, $args, $schedule, $group );

--- a/classes/ActionScheduler_ActionFactory.php
+++ b/classes/ActionScheduler_ActionFactory.php
@@ -82,6 +82,8 @@ class ActionScheduler_ActionFactory {
 	}
 
 	/**
+	 * Create the first instance of an action recurring on a given interval.
+	 *
 	 * @param string $hook The hook to trigger when this action runs
 	 * @param array $args Args to pass when the hook is triggered
 	 * @param int $first Unix timestamp for the first run
@@ -100,8 +102,9 @@ class ActionScheduler_ActionFactory {
 		return $this->store( $action );
 	}
 
-
 	/**
+	 * Create the first instance of an action recurring on a Cron schedule.
+	 *
 	 * @param string $hook The hook to trigger when this action runs
 	 * @param array $args Args to pass when the hook is triggered
 	 * @param int $first Unix timestamp for the first run
@@ -119,6 +122,44 @@ class ActionScheduler_ActionFactory {
 		$schedule = new ActionScheduler_CronSchedule( $date, $cron );
 		$action = new ActionScheduler_Action( $hook, $args, $schedule, $group );
 		return $this->store( $action );
+	}
+
+	/**
+	 * Create a successive instance of a recurring or cron action.
+	 *
+	 * Importantly, the action will be rescheduled to run based on the current date/time.
+	 * That means when the action is scheduled to run in the past, the next scheduled date
+	 * will be pushed forward. For example, if a recurring action set to run every hour
+	 * was scheduled to run 5 seconds ago, it will be next scheduled for 1 hour in the
+	 * future, which is 1 hour and 5 seconds from when it was last scheduled to run.
+	 *
+	 * Alternatively, if the action is scheduled to run in the future, and is run early,
+	 * likely via manual intervention, then its schedule will change based on the time now.
+	 * For example, if a recurring action set to run every day, and is run 12 hours early,
+	 * it will run again in 24 hours, not 36 hours.
+	 *
+	 * This slippage is less of an issue with Cron actions, as the specific run time can
+	 * be set for them to run, e.g. 1am each day. In those cases, and entire period would
+	 * need to be missed before there was any change is scheduled, e.g. in the case of an
+	 * action scheduled for 1am each day, the action would need to run an entire day late.
+	 *
+	 * @param ActionScheduler_Action $action The existing action.
+	 *
+	 * @return string The ID of the stored action
+	 * @throws InvalidArgumentException If $action is not a recurring action.
+	 */
+	public function repeat( $action ) {
+		$schedule = $action->get_schedule();
+		$next     = $schedule->get_next( as_get_datetime_object() );
+
+		if ( is_null( $next ) || ! $schedule->is_recurring() ) {
+			throw new InvalidArgumentException( __( 'Invalid action - must be a recurring action.', 'action-scheduler' ) );
+		}
+
+		$schedule_class = get_class( $schedule );
+		$new_schedule = new $schedule( $next, $schedule->get_recurrence(), $schedule->get_first_date() );
+		$new_action = new ActionScheduler_Action( $action->get_hook(), $action->get_args(), $new_schedule, $action->get_group() );
+		return $this->store( $new_action );
 	}
 
 	/**

--- a/classes/ActionScheduler_ListTable.php
+++ b/classes/ActionScheduler_ListTable.php
@@ -395,13 +395,13 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 
 		$schedule_display_string = '';
 
-		if ( ! $schedule->next() ) {
+		if ( ! $schedule->get_start() ) {
 			return '0000-00-00 00:00:00';
 		}
 
-		$next_timestamp = $schedule->next()->getTimestamp();
+		$next_timestamp = $schedule->get_start()->getTimestamp();
 
-		$schedule_display_string .= $schedule->next()->format( 'Y-m-d H:i:s O' );
+		$schedule_display_string .= $schedule->get_start()->format( 'Y-m-d H:i:s O' );
 		$schedule_display_string .= '<br/>';
 
 		if ( gmdate( 'U' ) > $next_timestamp ) {

--- a/classes/ActionScheduler_ListTable.php
+++ b/classes/ActionScheduler_ListTable.php
@@ -221,14 +221,14 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 	 * @return string
 	 */
 	protected function get_recurrence( $action ) {
-		$recurrence = $action->get_schedule();
-		if ( $recurrence->is_recurring() ) {
-			if ( method_exists( $recurrence, 'interval_in_seconds' ) ) {
-				return sprintf( __( 'Every %s', 'action-scheduler' ), self::human_interval( $recurrence->interval_in_seconds() ) );
-			}
+		$schedule = $action->get_schedule();
+		if ( $schedule->is_recurring() ) {
+			$recurrence = $schedule->get_recurrence();
 
-			if ( method_exists( $recurrence, 'get_recurrence' ) ) {
-				return sprintf( __( 'Cron %s', 'action-scheduler' ), $recurrence->get_recurrence() );
+			if ( is_numeric( $recurrence ) ) {
+				return sprintf( __( 'Every %s', 'action-scheduler' ), self::human_interval( $recurrence ) );
+			} else {
+				return sprintf( __( '%s', 'action-scheduler' ), $recurrence );
 			}
 		}
 
@@ -395,13 +395,13 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 
 		$schedule_display_string = '';
 
-		if ( ! $schedule->get_start() ) {
+		if ( ! $schedule->get_date() ) {
 			return '0000-00-00 00:00:00';
 		}
 
-		$next_timestamp = $schedule->get_start()->getTimestamp();
+		$next_timestamp = $schedule->get_date()->getTimestamp();
 
-		$schedule_display_string .= $schedule->get_start()->format( 'Y-m-d H:i:s O' );
+		$schedule_display_string .= $schedule->get_date()->format( 'Y-m-d H:i:s O' );
 		$schedule_display_string .= '<br/>';
 
 		if ( gmdate( 'U' ) > $next_timestamp ) {

--- a/classes/abstracts/ActionScheduler.php
+++ b/classes/abstracts/ActionScheduler.php
@@ -173,14 +173,16 @@ abstract class ActionScheduler {
 	 */
 	protected static function is_class_abstract( $class ) {
 		static $abstracts = array(
-			'ActionScheduler'                      => true,
-			'ActionScheduler_Abstract_ListTable'   => true,
-			'ActionScheduler_Abstract_QueueRunner' => true,
-			'ActionScheduler_Lock'                 => true,
-			'ActionScheduler_Logger'               => true,
-			'ActionScheduler_Abstract_Schema'      => true,
-			'ActionScheduler_Store'                => true,
-			'ActionScheduler_TimezoneHelper'       => true,
+			'ActionScheduler'                            => true,
+			'ActionScheduler_Abstract_ListTable'         => true,
+			'ActionScheduler_Abstract_QueueRunner'       => true,
+			'ActionScheduler_Abstract_Schedule'          => true,
+			'ActionScheduler_Abstract_RecurringSchedule' => true,
+			'ActionScheduler_Lock'                       => true,
+			'ActionScheduler_Logger'                     => true,
+			'ActionScheduler_Abstract_Schema'            => true,
+			'ActionScheduler_Store'                      => true,
+			'ActionScheduler_TimezoneHelper'             => true,
 		);
 
 		return isset( $abstracts[ $class ] ) && $abstracts[ $class ];

--- a/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php
+++ b/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php
@@ -77,12 +77,9 @@ abstract class ActionScheduler_Abstract_QueueRunner extends ActionScheduler_Abst
 	 * @param ActionScheduler_Action $action
 	 */
 	protected function schedule_next_instance( ActionScheduler_Action $action ) {
-		$schedule = $action->get_schedule();
-		$next     = $schedule->next( as_get_datetime_object() );
-
-		if ( ! is_null( $next ) && $schedule->is_recurring() ) {
-			$schedule->set_next( $next );
-			$this->store->save_action( $action, $next );
+		try {
+			ActionScheduler::factory()->repeat( $action );
+		} catch ( Exception $e ) {
 		}
 	}
 

--- a/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php
+++ b/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php
@@ -66,7 +66,7 @@ abstract class ActionScheduler_Abstract_QueueRunner extends ActionScheduler_Abst
 			do_action( 'action_scheduler_failed_execution', $action_id, $e, $context );
 		}
 
-		if ( isset( $action ) && is_a( $action, 'ActionScheduler_Action' ) ) {
+		if ( isset( $action ) && is_a( $action, 'ActionScheduler_Action' ) && $action->get_schedule()->is_recurring() ) {
 			$this->schedule_next_instance( $action );
 		}
 	}

--- a/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php
+++ b/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php
@@ -81,6 +81,7 @@ abstract class ActionScheduler_Abstract_QueueRunner extends ActionScheduler_Abst
 		$next     = $schedule->next( as_get_datetime_object() );
 
 		if ( ! is_null( $next ) && $schedule->is_recurring() ) {
+			$schedule->set_next( $next );
 			$this->store->save_action( $action, $next );
 		}
 	}

--- a/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php
+++ b/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php
@@ -67,7 +67,7 @@ abstract class ActionScheduler_Abstract_QueueRunner extends ActionScheduler_Abst
 		}
 
 		if ( isset( $action ) && is_a( $action, 'ActionScheduler_Action' ) && $action->get_schedule()->is_recurring() ) {
-			$this->schedule_next_instance( $action );
+			$this->schedule_next_instance( $action, $action_id );
 		}
 	}
 
@@ -75,11 +75,13 @@ abstract class ActionScheduler_Abstract_QueueRunner extends ActionScheduler_Abst
 	 * Schedule the next instance of the action if necessary.
 	 *
 	 * @param ActionScheduler_Action $action
+	 * @param int $action_id
 	 */
-	protected function schedule_next_instance( ActionScheduler_Action $action ) {
+	protected function schedule_next_instance( ActionScheduler_Action $action, $action_id ) {
 		try {
 			ActionScheduler::factory()->repeat( $action );
 		} catch ( Exception $e ) {
+			do_action( 'action_scheduler_failed_to_schedule_next_instance', $action_id, $e, $action );
 		}
 	}
 

--- a/classes/abstracts/ActionScheduler_Abstract_RecurringSchedule.php
+++ b/classes/abstracts/ActionScheduler_Abstract_RecurringSchedule.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * Class ActionScheduler_Abstract_RecurringSchedule
+ */
+abstract class ActionScheduler_Abstract_RecurringSchedule extends ActionScheduler_Abstract_Schedule {
+
+	/**
+	 * The date & time the first instance of this schedule was setup to run (which may not be this instance).
+	 *
+	 * Schedule objects are attached to an action object. Each schedule stores the run date for that
+	 * object as the start date - @see $this->start - and logic to calculate the next run date after
+	 * that - @see $this->calculate_next(). The $first_date property also keeps a record of when the very
+	 * first instance of this chain of schedules ran.
+	 *
+	 * @var DateTime
+	 */
+	private $first_date = NULL;
+
+	/**
+	 * Timestamp equivalent of @see $this->first_date
+	 *
+	 * @var int
+	 */
+	protected $first_timestamp = 0;
+
+	/**
+	 * The recurrance between each time an action is run using this schedule.
+	 * Used to calculate the start date & time. Can be a number of seconds, in the
+	 * case of ActionScheduler_IntervalSchedule, or a cron expression, as in the
+	 * case of ActionScheduler_CronSchedule. Or something else.
+	 *
+	 * @var mixed
+	 */
+	protected $recurrence;
+
+	/**
+	 * @param DateTime $date The date & time to run the action.
+	 * @param mixed $recurrence The data used to determine the schedule's recurrance.
+	 * @param DateTime|null $first (Optional) The date & time the first instance of this interval schedule ran. Default null, meaning this is the first instance.
+	 */
+	public function __construct( DateTime $date, $recurrence, DateTime $first = null ) {
+		parent::__construct( $date );
+		$this->first_date = empty( $first ) ? $date : $first;
+		$this->recurrence = $recurrence;
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function is_recurring() {
+		return true;
+	}
+
+	/**
+	 * Get the date & time of the first schedule in this recurring series.
+	 *
+	 * @return DateTime|null
+	 */
+	public function get_first_date() {
+		return clone $this->first_date;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function get_recurrence() {
+		return $this->recurrence;
+	}
+
+	/**
+	 * For PHP 5.2 compat, since DateTime objects can't be serialized
+	 * @return array
+	 */
+	public function __sleep() {
+		$sleep_params = parent::__sleep();
+		$this->first_timestamp = $this->first_date->getTimestamp();
+		return array_merge( $sleep_params, array(
+			'first_timestamp',
+			'recurrence'
+		) );
+	}
+
+	public function __wakeup() {
+		parent::__wakeup();
+		if ( $this->first_timestamp > 0 ) {
+			$this->first_date = as_get_datetime_object( $this->first_timestamp );
+		} else {
+			$this->first_date = $this->get_date();
+		}
+	}
+}

--- a/classes/abstracts/ActionScheduler_Abstract_Schedule.php
+++ b/classes/abstracts/ActionScheduler_Abstract_Schedule.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * Class ActionScheduler_Abstract_Schedule
+ */
+abstract class ActionScheduler_Abstract_Schedule extends ActionScheduler_Schedule_Deprecated {
+
+	/**
+	 * The date & time the schedule is set to run.
+	 *
+	 * @var DateTime
+	 */
+	private $scheduled_date = NULL;
+
+	/**
+	 * Timestamp equivalent of @see $this->scheduled_date
+	 *
+	 * @var int
+	 */
+	protected $scheduled_timestamp = 0;
+
+	/**
+	 * @param DateTime $date The date & time to run the action.
+	 */
+	public function __construct( DateTime $date ) {
+		$this->scheduled_date = $date;
+	}
+
+	/**
+	 * Check if a schedule should recur.
+	 *
+	 * @return bool
+	 */
+	abstract public function is_recurring();
+
+	/**
+	 * Calculate when the next instance of this schedule would run based on a given date & time.
+	 *
+	 * @param DateTime $after
+	 * @return DateTime
+	 */
+	abstract protected function calculate_next( DateTime $after );
+
+	/**
+	 * Get the next date & time when this schedule should run after a given date & time.
+	 *
+	 * @param DateTime $after
+	 * @return DateTime|null
+	 */
+	public function get_next( DateTime $after ) {
+		$after = clone $after;
+		if ( $after > $this->scheduled_date ) {
+			$after = $this->calculate_next( $after );
+			return $after;
+		}
+		return clone $this->scheduled_date;
+	}
+
+	/**
+	 * Get the date & time the schedule is set to run.
+	 *
+	 * @return DateTime|null
+	 */
+	public function get_date() {
+		return $this->scheduled_date;
+	}
+
+	/**
+	 * For PHP 5.2 compat, since DateTime objects can't be serialized
+	 * @return array
+	 */
+	public function __sleep() {
+		$this->scheduled_timestamp = $this->scheduled_date->getTimestamp();
+		return array(
+			'scheduled_timestamp',
+		);
+	}
+
+	public function __wakeup() {
+		$this->scheduled_date = as_get_datetime_object( $this->scheduled_timestamp );
+	}
+}

--- a/classes/abstracts/ActionScheduler_Logger.php
+++ b/classes/abstracts/ActionScheduler_Logger.php
@@ -56,6 +56,7 @@ abstract class ActionScheduler_Logger {
 		add_action( 'action_scheduler_reset_action', array( $this, 'log_reset_action' ), 10, 1 );
 		add_action( 'action_scheduler_execution_ignored', array( $this, 'log_ignored_action' ), 10, 2 );
 		add_action( 'action_scheduler_failed_fetch_action', array( $this, 'log_failed_fetch_action' ), 10, 2 );
+		add_action( 'action_scheduler_failed_to_schedule_next_instance', array( $this, 'log_failed_schedule_next_instance' ), 10, 2 );
 	}
 
 	public function hook_stored_action() {
@@ -139,5 +140,9 @@ abstract class ActionScheduler_Logger {
 		}
 
 		$this->log( $action_id, $log_message );
+	}
+
+	public function log_failed_schedule_next_instance( $action_id, Exception $exception ) {
+		$this->log( $action_id, sprintf( __( 'There was a failure scheduling the next instance of this action: %s', 'action-scheduler' ), $exception->getMessage() ) );
 	}
 }

--- a/classes/abstracts/ActionScheduler_Store.php
+++ b/classes/abstracts/ActionScheduler_Store.php
@@ -148,7 +148,7 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 	 * @return string
 	 */
 	protected function get_scheduled_date_string( ActionScheduler_Action $action, DateTime $scheduled_date = NULL ) {
-		$next = null === $scheduled_date ? $action->get_schedule()->next() : $scheduled_date;
+		$next = null === $scheduled_date ? $action->get_schedule()->get_date() : $scheduled_date;
 		if ( ! $next ) {
 			return '0000-00-00 00:00:00';
 		}
@@ -165,7 +165,7 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 	 * @return string
 	 */
 	protected function get_scheduled_date_string_local( ActionScheduler_Action $action, DateTime $scheduled_date = NULL ) {
-		$next = null === $scheduled_date ? $action->get_schedule()->next() : $scheduled_date;
+		$next = null === $scheduled_date ? $action->get_schedule()->get_date() : $scheduled_date;
 		if ( ! $next ) {
 			return '0000-00-00 00:00:00';
 		}

--- a/classes/actions/ActionScheduler_CanceledAction.php
+++ b/classes/actions/ActionScheduler_CanceledAction.php
@@ -16,6 +16,8 @@ class ActionScheduler_CanceledAction extends ActionScheduler_FinishedAction {
 	 */
 	public function __construct( $hook, array $args = array(), ActionScheduler_Schedule $schedule = null, $group = '' ) {
 		parent::__construct( $hook, $args, $schedule, $group );
-		$this->set_schedule( new ActionScheduler_NullSchedule() );
+		if ( is_null( $schedule ) ) {
+			$this->set_schedule( new ActionScheduler_NullSchedule() );
+		}
 	}
 }

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -153,15 +153,8 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 			$schedule = new ActionScheduler_NullSchedule();
 		}
 		$group = $data->group ? $data->group : '';
-		if ( $data->status == self::STATUS_PENDING ) {
-			$action = new ActionScheduler_Action( $hook, $args, $schedule, $group );
-		} elseif ( $data->status == self::STATUS_CANCELED ) {
-			$action = new ActionScheduler_CanceledAction( $hook, $args, $schedule, $group );
-		} else {
-			$action = new ActionScheduler_FinishedAction( $hook, $args, $schedule, $group );
-		}
 
-		return $action;
+		return ActionScheduler::factory()->get_stored_action( $data->status, $data->hook, $args, $schedule, $group );
 	}
 
 	/**

--- a/classes/data-stores/ActionScheduler_wpPostStore.php
+++ b/classes/data-stores/ActionScheduler_wpPostStore.php
@@ -21,10 +21,6 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 			$post_id = $this->save_post_array( $post_array );
 			$schedule = $action->get_schedule();
 
-			if ( ! is_null( $scheduled_date ) && $schedule->is_recurring() ) {
-				$schedule = new ActionScheduler_IntervalSchedule( $scheduled_date, $schedule->interval_in_seconds() );
-			}
-
 			$this->save_post_schedule( $post_id, $schedule );
 			$this->save_action_group( $post_id, $action->get_group() );
 			do_action( 'action_scheduler_stored_action', $post_id );

--- a/classes/migration/ActionMigrator.php
+++ b/classes/migration/ActionMigrator.php
@@ -51,7 +51,7 @@ class ActionMigrator {
 			$status = '';
 		}
 
-		if ( empty( $status ) || ! $action->get_schedule()->next() ) {
+		if ( empty( $status ) || ! $action->get_schedule()->get_date() ) {
 			// empty status means the action didn't exist
 			// null schedule means it's missing vital data
 			// delete it and move on

--- a/classes/migration/ActionMigrator.php
+++ b/classes/migration/ActionMigrator.php
@@ -77,10 +77,14 @@ class ActionMigrator {
 			return 0; // could not save the action in the new store
 		}
 
-
 		try {
-			if ( $status === \ActionScheduler_Store::STATUS_FAILED ) {
-				$this->destination->mark_failure( $destination_action_id );
+			switch ( $status ) {
+				case \ActionScheduler_Store::STATUS_FAILED :
+					$this->destination->mark_failure( $destination_action_id );
+					break;
+				case \ActionScheduler_Store::STATUS_CANCELED :
+					$this->destination->cancel_action( $destination_action_id );
+					break;
 			}
 
 			$this->log_migrator->migrate( $source_action_id, $destination_action_id );

--- a/classes/schedules/ActionScheduler_CanceledSchedule.php
+++ b/classes/schedules/ActionScheduler_CanceledSchedule.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * Class ActionScheduler_SimpleSchedule
+ */
+class ActionScheduler_CanceledSchedule extends ActionScheduler_SimpleSchedule {
+
+	/**
+	 * Deprecated property @see $this->__wakeup() for details.
+	 **/
+	private $timestamp = NULL;
+
+	/**
+	 * @param DateTime $after
+	 *
+	 * @return DateTime|null
+	 */
+	public function calculate_next( DateTime $after ) {
+		return null;
+	}
+
+	/**
+	 * Cancelled actions should never have a next schedule, even if get_next()
+	 * is called with $after < $this->scheduled_date.
+	 *
+	 * @param DateTime $after
+	 * @return DateTime|null
+	 */
+	public function get_next( DateTime $after ) {
+		return null;
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function is_recurring() {
+		return false;
+	}
+
+	/**
+	 * Unserialize recurring schedules serialized/stored prior to AS 3.0.0
+	 *
+	 * Prior to Action Scheduler 3.0.0, schedules used different property names to refer
+	 * to equivalent data. For example, ActionScheduler_IntervalSchedule::start_timestamp
+	 * was the same as ActionScheduler_SimpleSchedule::timestamp. Action Scheduler 3.0.0
+	 * aligned properties and property names for better inheritance. To maintain backward
+	 * compatibility with schedules serialized and stored prior to 3.0, we need to correctly
+	 * map the old property names with matching visibility.
+	 */
+	public function __wakeup() {
+		if ( ! is_null( $this->timestamp ) ) {
+			$this->scheduled_timestamp = $this->timestamp;
+			unset( $this->timestamp );
+		}
+		parent::__wakeup();
+	}
+}

--- a/classes/schedules/ActionScheduler_CronSchedule.php
+++ b/classes/schedules/ActionScheduler_CronSchedule.php
@@ -28,8 +28,8 @@ class ActionScheduler_CronSchedule extends ActionScheduler_Abstract_RecurringSch
 			$recurrence = CronExpression::factory( $recurrence );
 		}
 
-		// For backward compatibility, we need to make sure the date is set to the first matching cron date, not just the date passed in. This was previously handled in the now deprecated next() method.
-		$date = $recurrence->getNextRunDate( $start, 0, false );
+		// For backward compatibility, we need to make sure the date is set to the first matching cron date, not whatever date is passed in. Importantly, by passing true as the 3rd param, if $start matches the cron expression, then it will be used. This was previously handled in the now deprecated next() method.
+		$date = $recurrence->getNextRunDate( $start, 0, true );
 
 		// parent::__construct() will set this to $date by default, but that may be different to $start now.
 		$first = empty( $first ) ? $start : $first;

--- a/classes/schedules/ActionScheduler_CronSchedule.php
+++ b/classes/schedules/ActionScheduler_CronSchedule.php
@@ -27,7 +27,14 @@ class ActionScheduler_CronSchedule extends ActionScheduler_Abstract_RecurringSch
 		if ( ! is_a( $recurrence, 'CronExpression' ) ) {
 			$recurrence = CronExpression::factory( $recurrence );
 		}
-		parent::__construct( $start, $recurrence, $first );
+
+		// For backward compatibility, we need to make sure the date is set to the first matching cron date, not just the date passed in. This was previously handled in the now deprecated next() method.
+		$date = $recurrence->getNextRunDate( $start, 0, false );
+
+		// parent::__construct() will set this to $date by default, but that may be different to $start now.
+		$first = empty( $first ) ? $start : $first;
+
+		parent::__construct( $date, $recurrence, $first );
 	}
 
 	/**

--- a/classes/schedules/ActionScheduler_CronSchedule.php
+++ b/classes/schedules/ActionScheduler_CronSchedule.php
@@ -3,55 +3,71 @@
 /**
  * Class ActionScheduler_CronSchedule
  */
-class ActionScheduler_CronSchedule implements ActionScheduler_Schedule {
-	/** @var DateTime */
-	private $start = NULL;
-	private $start_timestamp = 0;
-	/** @var CronExpression */
+class ActionScheduler_CronSchedule extends ActionScheduler_Abstract_RecurringSchedule implements ActionScheduler_Schedule {
+
+	/**
+	 * Deprecated property @see $this->__wakeup() for details.
+	 **/
+	private $start_timestamp = NULL;
+
+	/**
+	 * Deprecated property @see $this->__wakeup() for details.
+	 **/
 	private $cron = NULL;
 
-	public function __construct( DateTime $start, CronExpression $cron ) {
-		$this->start = $start;
-		$this->cron = $cron;
+	/**
+	 * Wrapper for parent constructor to accept a cron expression string and map it to a CronExpression for this
+	 * objects $recurrence property.
+	 *
+	 * @param DateTime $start The date & time to run the action.
+	 * @param CronExpression|string $recurrence The CronExpression used to calculate the schedule's next instance.
+	 * @param DateTime|null $first (Optional) The date & time the first instance of this interval schedule ran. Default null, meaning this is the first instance.
+	 */
+	public function __construct( DateTime $start, $recurrence, DateTime $first = null ) {
+		if ( ! is_a( $recurrence, 'CronExpression' ) ) {
+			$recurrence = CronExpression::factory( $recurrence );
+		}
+		parent::__construct( $start, $recurrence, $first );
 	}
 
 	/**
+	 * Calculate when an instance of this schedule would start based on a given
+	 * date & time using its the CronExpression.
+	 *
 	 * @param DateTime $after
-	 * @return DateTime|null
+	 * @return DateTime
 	 */
-	public function next( DateTime $after = NULL ) {
-		$after = empty($after) ? clone $this->start : clone $after;
-		return $this->cron->getNextRunDate($after, 0, false);
-	}
-
-	/**
-	 * @return bool
-	 */
-	public function is_recurring() {
-		return true;
+	protected function calculate_next( DateTime $after ) {
+		return $this->recurrence->getNextRunDate( $after, 0, false );
 	}
 
 	/**
 	 * @return string
 	 */
 	public function get_recurrence() {
-		return strval($this->cron);
+		return strval( $this->recurrence );
 	}
 
 	/**
-	 * For PHP 5.2 compat, since DateTime objects can't be serialized
-	 * @return array
+	 * Unserialize recurring schedules serialized/stored prior to AS 3.0.0
+	 *
+	 * Prior to Action Scheduler 3.0.0, schedules used different property names to refer
+	 * to equivalent data. For example, ActionScheduler_IntervalSchedule::start_timestamp
+	 * was the same as ActionScheduler_SimpleSchedule::timestamp. This was addressed in
+	 * Action Scheduler 3.0.0, where properties and property names were aligned for better
+	 * inheritance. To maintain backward compatibility with scheduled serialized and stored
+	 * prior to 3.0, we need to correctly map the old property names.
 	 */
-	public function __sleep() {
-		$this->start_timestamp = $this->start->getTimestamp();
-		return array(
-			'start_timestamp',
-			'cron'
-		);
-	}
-
 	public function __wakeup() {
-		$this->start = as_get_datetime_object($this->start_timestamp);
+		if ( ! is_null( $this->start_timestamp ) ) {
+			$this->scheduled_timestamp = $this->start_timestamp;
+			unset( $this->start_timestamp );
+		}
+
+		if ( ! is_null( $this->cron ) ) {
+			$this->recurrence = $this->cron;
+		}
+		parent::__wakeup();
 	}
 }
 

--- a/classes/schedules/ActionScheduler_IntervalSchedule.php
+++ b/classes/schedules/ActionScheduler_IntervalSchedule.php
@@ -5,12 +5,15 @@
  */
 class ActionScheduler_IntervalSchedule implements ActionScheduler_Schedule {
 	/** @var DateTime */
+	private $first = NULL;
 	private $start = NULL;
+	private $first_timestamp = 0;
 	private $start_timestamp = 0;
 	private $interval_in_seconds = 0;
 
-	public function __construct( DateTime $start, $interval ) {
-		$this->start = $start;
+	public function __construct( DateTime $first, $interval ) {
+		$this->first = $first;
+		$this->start = $first;
 		$this->interval_in_seconds = (int)$interval;
 	}
 
@@ -21,11 +24,25 @@ class ActionScheduler_IntervalSchedule implements ActionScheduler_Schedule {
 	 */
 	public function next( DateTime $after = NULL ) {
 		$after = empty($after) ? as_get_datetime_object('@0') : clone $after;
-		if ( $after > $this->start ) {
+		if ( $after > $this->first ) {
 			$after->modify('+'.$this->interval_in_seconds.' seconds');
 			return $after;
 		}
-		return clone $this->start;
+		return clone $this->first;
+	}
+
+	/**
+	 * @return DateTime
+	 */
+	public function get_start() {
+		return $this->start;
+	}
+
+	/**
+	 * @param DateTime $next
+	 */
+	public function set_next( DateTime $next ) {
+		$this->start = $next;
 	}
 
 	/**
@@ -47,14 +64,17 @@ class ActionScheduler_IntervalSchedule implements ActionScheduler_Schedule {
 	 * @return array
 	 */
 	public function __sleep() {
+		$this->first_timestamp = $this->first->getTimestamp();
 		$this->start_timestamp = $this->start->getTimestamp();
 		return array(
+			'first_timestamp',
 			'start_timestamp',
 			'interval_in_seconds'
 		);
 	}
 
 	public function __wakeup() {
+		$this->first = as_get_datetime_object($this->first_timestamp);
 		$this->start = as_get_datetime_object($this->start_timestamp);
 	}
 }

--- a/classes/schedules/ActionScheduler_NullSchedule.php
+++ b/classes/schedules/ActionScheduler_NullSchedule.php
@@ -3,17 +3,26 @@
 /**
  * Class ActionScheduler_NullSchedule
  */
-class ActionScheduler_NullSchedule implements ActionScheduler_Schedule {
+class ActionScheduler_NullSchedule extends ActionScheduler_SimpleSchedule {
 
-	public function next( DateTime $after = NULL ) {
-		return NULL;
+	/**
+	 * Make the $date param optional and default to null.
+	 *
+	 * @param null $date The date & time to run the action.
+	 */
+	public function __construct( DateTime $date = null ) {
+		$this->scheduled_date = null;
 	}
 
 	/**
-	 * @return bool
+	 * This schedule has no scheduled DateTime, so we need to override the parent __sleep()
+	 * @return array
 	 */
-	public function is_recurring() {
-		return false;
+	public function __sleep() {
+		return array();
+	}
+
+	public function __wakeup() {
+		$this->scheduled_date = null;
 	}
 }
- 

--- a/classes/schedules/ActionScheduler_SimpleSchedule.php
+++ b/classes/schedules/ActionScheduler_SimpleSchedule.php
@@ -3,21 +3,20 @@
 /**
  * Class ActionScheduler_SimpleSchedule
  */
-class ActionScheduler_SimpleSchedule implements ActionScheduler_Schedule {
-	private $date = NULL;
-	private $timestamp = 0;
-	public function __construct( DateTime $date ) {
-		$this->date = clone $date;
-	}
+class ActionScheduler_SimpleSchedule extends ActionScheduler_Abstract_Schedule {
+
+	/**
+	 * Deprecated property @see $this->__wakeup() for details.
+	 **/
+	private $timestamp = NULL;
 
 	/**
 	 * @param DateTime $after
 	 *
 	 * @return DateTime|null
 	 */
-	public function next( DateTime $after = NULL ) {
-		$after = empty($after) ? as_get_datetime_object('@0') : $after;
-		return ( $after > $this->date ) ? NULL : clone $this->date;
+	public function calculate_next( DateTime $after ) {
+		return null;
 	}
 
 	/**
@@ -28,17 +27,20 @@ class ActionScheduler_SimpleSchedule implements ActionScheduler_Schedule {
 	}
 
 	/**
-	 * For PHP 5.2 compat, since DateTime objects can't be serialized
-	 * @return array
+	 * Unserialize recurring schedules serialized/stored prior to AS 3.0.0
+	 *
+	 * Prior to Action Scheduler 3.0.0, schedules used different property names to refer
+	 * to equivalent data. For example, ActionScheduler_IntervalSchedule::start_timestamp
+	 * was the same as ActionScheduler_SimpleSchedule::timestamp. Action Scheduler 3.0.0
+	 * aligned properties and property names for better inheritance. To maintain backward
+	 * compatibility with schedules serialized and stored prior to 3.0, we need to correctly
+	 * map the old property names with matching visibility.
 	 */
-	public function __sleep() {
-		$this->timestamp = $this->date->getTimestamp();
-		return array(
-			'timestamp',
-		);
-	}
-
 	public function __wakeup() {
-		$this->date = as_get_datetime_object($this->timestamp);
+		if ( ! is_null( $this->timestamp ) ) {
+			$this->scheduled_timestamp = $this->timestamp;
+			unset( $this->timestamp );
+		}
+		parent::__wakeup();
 	}
 }

--- a/deprecated/ActionScheduler_Schedule_Deprecated.php
+++ b/deprecated/ActionScheduler_Schedule_Deprecated.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * Class ActionScheduler_Abstract_Schedule
+ */
+abstract class ActionScheduler_Schedule_Deprecated implements ActionScheduler_Schedule {
+
+	/**
+	 * Get the date & time this schedule was created to run, or calculate when it should be run
+	 * after a given date & time.
+	 *
+	 * @param DateTime $after
+	 *
+	 * @return DateTime|null
+	 */
+	public function next( DateTime $after = NULL ) {
+		if ( empty( $after ) ) {
+			$return_value       = $this->get_date();
+			$replacement_method = 'get_date()';
+		} else {
+			$return_value       = $this->get_next( $after );
+			$replacement_method = 'get_next( $after )';
+		}
+
+		_deprecated_function( __METHOD__, '3.0.0', __CLASS__ . '::' . $replacement_method );
+
+		return $return_value;
+	}
+}

--- a/functions.php
+++ b/functions.php
@@ -48,7 +48,9 @@ function as_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, 
 /**
  * Schedule an action that recurs on a cron-like schedule.
  *
- * @param int $timestamp The schedule will start on or after this time
+ * @param int $base_timestamp The first instance of the action will be scheduled
+ *        to run at a time calculated after this timestamp matching the cron
+ *        expression. This can be used to delay the first instance of the action.
  * @param string $schedule A cron-link schedule string
  * @see http://en.wikipedia.org/wiki/Cron
  *   *    *    *    *    *    *

--- a/functions.php
+++ b/functions.php
@@ -138,10 +138,10 @@ function as_next_scheduled_action( $hook, $args = NULL, $group = '' ) {
 		return false;
 	}
 	$job = ActionScheduler::store()->fetch_action( $job_id );
-	$next = $job->get_schedule()->next();
-	if ( $next ) {
-		return (int)($next->format('U'));
-	} elseif ( NULL === $next ) { // pending async action with NullSchedule
+	$scheduled_date = $job->get_schedule()->get_date();
+	if ( $scheduled_date ) {
+		return (int) $scheduled_date->format( 'U' );
+	} elseif ( NULL === $scheduled_date ) { // pending async action with NullSchedule
 		return true;
 	}
 	return false;

--- a/tests/phpunit/jobs/ActionScheduler_NullAction_Test.php
+++ b/tests/phpunit/jobs/ActionScheduler_NullAction_Test.php
@@ -10,7 +10,7 @@ class ActionScheduler_NullAction_Test extends ActionScheduler_UnitTestCase {
 
 		$this->assertEmpty($action->get_hook());
 		$this->assertEmpty($action->get_args());
-		$this->assertNull($action->get_schedule()->next());
+		$this->assertNull( $action->get_schedule()->get_date() );
 	}
 }
  

--- a/tests/phpunit/jobstore/ActionScheduler_DBStore_Test.php
+++ b/tests/phpunit/jobstore/ActionScheduler_DBStore_Test.php
@@ -36,7 +36,7 @@ class ActionScheduler_DBStore_Test extends ActionScheduler_UnitTestCase {
 		$retrieved = $store->fetch_action( $action_id );
 		$this->assertEquals( $action->get_hook(), $retrieved->get_hook() );
 		$this->assertEqualSets( $action->get_args(), $retrieved->get_args() );
-		$this->assertEquals( $action->get_schedule()->next()->format( 'U' ), $retrieved->get_schedule()->next()->format( 'U' ) );
+		$this->assertEquals( $action->get_schedule()->get_date()->format( 'U' ), $retrieved->get_schedule()->get_date()->format( 'U' ) );
 		$this->assertEquals( $action->get_group(), $retrieved->get_group() );
 	}
 
@@ -334,7 +334,7 @@ class ActionScheduler_DBStore_Test extends ActionScheduler_UnitTestCase {
 
 		$this->assertEquals( $now->format( 'U' ), $store->get_date( $action_id )->format( 'U' ) );
 
-		$next          = $action->get_schedule()->next( $now );
+		$next          = $action->get_schedule()->get_next( $now );
 		$new_action_id = $store->save_action( $action, $next );
 
 		$this->assertEquals( (int) ( $now->format( 'U' ) ) + HOUR_IN_SECONDS, $store->get_date( $new_action_id )->format( 'U' ) );

--- a/tests/phpunit/jobstore/ActionScheduler_wpPostStore_Test.php
+++ b/tests/phpunit/jobstore/ActionScheduler_wpPostStore_Test.php
@@ -37,7 +37,7 @@ class ActionScheduler_wpPostStore_Test extends ActionScheduler_UnitTestCase {
 		$retrieved = $store->fetch_action($action_id);
 		$this->assertEquals($action->get_hook(), $retrieved->get_hook());
 		$this->assertEqualSets($action->get_args(), $retrieved->get_args());
-		$this->assertEquals($action->get_schedule()->next()->getTimestamp(), $retrieved->get_schedule()->next()->getTimestamp());
+		$this->assertEquals( $action->get_schedule()->get_date()->getTimestamp(), $retrieved->get_schedule()->get_date()->getTimestamp() );
 		$this->assertEquals($action->get_group(), $retrieved->get_group());
 	}
 
@@ -225,7 +225,7 @@ class ActionScheduler_wpPostStore_Test extends ActionScheduler_UnitTestCase {
 		$action->execute();
 		$store->mark_complete( $action_id );
 
-		$next = $action->get_schedule()->next( as_get_datetime_object() );
+		$next = $action->get_schedule()->get_next( as_get_datetime_object() );
 		$new_action_id = $store->save_action( $action, $next );
 
 		$this->assertEquals('publish', get_post_status($action_id));
@@ -248,7 +248,7 @@ class ActionScheduler_wpPostStore_Test extends ActionScheduler_UnitTestCase {
 
 		$this->assertEquals( $store->get_date( $action_id )->getTimestamp(), $now->getTimestamp(), '', 1 ); // allow timestamp to be 1 second off for older versions of PHP
 
-		$next = $action->get_schedule()->next( $now );
+		$next = $action->get_schedule()->get_next( $now );
 		$new_action_id = $store->save_action( $action, $next );
 
 		$this->assertEquals( (int)($now->getTimestamp()) + HOUR_IN_SECONDS, $store->get_date($new_action_id)->getTimestamp() );

--- a/tests/phpunit/logging/ActionScheduler_wpCommentLogger_Test.php
+++ b/tests/phpunit/logging/ActionScheduler_wpCommentLogger_Test.php
@@ -118,6 +118,21 @@ class ActionScheduler_wpCommentLogger_Test extends ActionScheduler_UnitTestCase 
 		$this->assertTrue( in_array( $this->log_entry_to_array( $failed ), $this->log_entry_to_array( $logs ) ) );
 	}
 
+	public function test_failed_schedule_next_instance_comments() {
+		$action_id = rand();
+		$logger    = ActionScheduler::logger();
+		$log_entry = new ActionScheduler_LogEntry( $action_id, 'There was a failure scheduling the next instance of this action: Execution failed' );
+
+		try {
+			$this->_a_hook_callback_that_throws_an_exception();
+		} catch ( Exception $e ) {
+			do_action( 'action_scheduler_failed_to_schedule_next_instance', $action_id, $e, new ActionScheduler_Action('my_hook') );
+		}
+
+		$logs = $logger->get_logs( $action_id );
+		$this->assertTrue( in_array( $this->log_entry_to_array( $log_entry ), $this->log_entry_to_array( $logs ) ) );
+	}
+
 	public function test_fatal_error_comments() {
 		$hook = md5(rand());
 		$action_id = as_schedule_single_action( time(), $hook );

--- a/tests/phpunit/migration/ActionMigrator_Test.php
+++ b/tests/phpunit/migration/ActionMigrator_Test.php
@@ -33,7 +33,7 @@ class ActionMigrator_Test extends ActionScheduler_UnitTestCase {
 		$retrieved = $destination->fetch_action( $new_id );
 		$this->assertEquals( $action->get_hook(), $retrieved->get_hook() );
 		$this->assertEqualSets( $action->get_args(), $retrieved->get_args() );
-		$this->assertEquals( $action->get_schedule()->next()->format( 'U' ), $retrieved->get_schedule()->next()->format( 'U' ) );
+		$this->assertEquals( $action->get_schedule()->get_date()->format( 'U' ), $retrieved->get_schedule()->get_date()->format( 'U' ) );
 		$this->assertEquals( $action->get_group(), $retrieved->get_group() );
 		$this->assertEquals( \ActionScheduler_Store::STATUS_PENDING, $destination->get_status( $new_id ) );
 
@@ -75,7 +75,7 @@ class ActionMigrator_Test extends ActionScheduler_UnitTestCase {
 		$retrieved = $destination->fetch_action( $new_id );
 		$this->assertEquals( $action->get_hook(), $retrieved->get_hook() );
 		$this->assertEqualSets( $action->get_args(), $retrieved->get_args() );
-		$this->assertEquals( $action->get_schedule()->next()->format( 'U' ), $retrieved->get_schedule()->next()->format( 'U' ) );
+		$this->assertEquals( $action->get_schedule()->get_date()->format( 'U' ), $retrieved->get_schedule()->get_date()->format( 'U' ) );
 		$this->assertEquals( $action->get_group(), $retrieved->get_group() );
 		$this->assertTrue( $retrieved->is_finished() );
 		$this->assertEquals( \ActionScheduler_Store::STATUS_COMPLETE, $destination->get_status( $new_id ) );
@@ -102,7 +102,7 @@ class ActionMigrator_Test extends ActionScheduler_UnitTestCase {
 		$retrieved = $destination->fetch_action( $new_id );
 		$this->assertEquals( $action->get_hook(), $retrieved->get_hook() );
 		$this->assertEqualSets( $action->get_args(), $retrieved->get_args() );
-		$this->assertEquals( $action->get_schedule()->next()->format( 'U' ), $retrieved->get_schedule()->next()->format( 'U' ) );
+		$this->assertEquals( $action->get_schedule()->get_date()->format( 'U' ), $retrieved->get_schedule()->get_date()->format( 'U' ) );
 		$this->assertEquals( $action->get_group(), $retrieved->get_group() );
 		$this->assertTrue( $retrieved->is_finished() );
 		$this->assertEquals( \ActionScheduler_Store::STATUS_FAILED, $destination->get_status( $new_id ) );

--- a/tests/phpunit/migration/ActionMigrator_Test.php
+++ b/tests/phpunit/migration/ActionMigrator_Test.php
@@ -112,7 +112,7 @@ class ActionMigrator_Test extends ActionScheduler_UnitTestCase {
 		$this->assertInstanceOf( 'ActionScheduler_NullAction', $old_action );
 	}
 
-	public function test_does_not_migrate_canceled_action_from_wpPost_to_db() {
+	public function test_migrate_canceled_action_from_wpPost_to_db() {
 		$source = new ActionScheduler_wpPostStore();
 		$destination = new ActionScheduler_DBStore();
 		$migrator = new ActionMigrator( $source, $destination, $this->get_log_migrator() );
@@ -125,7 +125,14 @@ class ActionMigrator_Test extends ActionScheduler_UnitTestCase {
 
 		$new_id = $migrator->migrate( $action_id );
 
-		$this->assertEquals( 0, $new_id );
+		// ensure we get the same record out of the new store as we stored in the old
+		$retrieved = $destination->fetch_action( $new_id );
+		$this->assertEquals( $action->get_hook(), $retrieved->get_hook() );
+		$this->assertEqualSets( $action->get_args(), $retrieved->get_args() );
+		$this->assertEquals( $action->get_schedule()->get_date()->format( 'U' ), $retrieved->get_schedule()->get_date()->format( 'U' ) );
+		$this->assertEquals( $action->get_group(), $retrieved->get_group() );
+		$this->assertTrue( $retrieved->is_finished() );
+		$this->assertEquals( \ActionScheduler_Store::STATUS_CANCELED, $destination->get_status( $new_id ) );
 
 		// ensure that the record in the old store does not exist
 		$old_action = $source->fetch_action( $action_id );

--- a/tests/phpunit/procedural_api/procedural_api_Test.php
+++ b/tests/phpunit/procedural_api/procedural_api_Test.php
@@ -12,7 +12,7 @@ class procedural_api_Test extends ActionScheduler_UnitTestCase {
 
 		$store = ActionScheduler::store();
 		$action = $store->fetch_action($action_id);
-		$this->assertEquals( $time, $action->get_schedule()->next()->getTimestamp() );
+		$this->assertEquals( $time, $action->get_schedule()->get_date()->getTimestamp() );
 		$this->assertEquals( $hook, $action->get_hook() );
 	}
 
@@ -23,8 +23,8 @@ class procedural_api_Test extends ActionScheduler_UnitTestCase {
 
 		$store = ActionScheduler::store();
 		$action = $store->fetch_action($action_id);
-		$this->assertEquals( $time, $action->get_schedule()->next()->getTimestamp() );
-		$this->assertEquals( $time + HOUR_IN_SECONDS + 2, $action->get_schedule()->next(as_get_datetime_object($time + 2))->getTimestamp());
+		$this->assertEquals( $time, $action->get_schedule()->get_date()->getTimestamp() );
+		$this->assertEquals( $time + HOUR_IN_SECONDS + 2, $action->get_schedule()->get_next(as_get_datetime_object($time + 2))->getTimestamp());
 		$this->assertEquals( $hook, $action->get_hook() );
 	}
 
@@ -36,7 +36,7 @@ class procedural_api_Test extends ActionScheduler_UnitTestCase {
 		$store = ActionScheduler::store();
 		$action = $store->fetch_action($action_id);
 		$expected_date = as_get_datetime_object('2014-10-10');
-		$this->assertEquals( $expected_date->getTimestamp(), $action->get_schedule()->next()->getTimestamp() );
+		$this->assertEquals( $expected_date->getTimestamp(), $action->get_schedule()->get_date()->getTimestamp() );
 		$this->assertEquals( $hook, $action->get_hook() );
 	}
 
@@ -137,13 +137,13 @@ class procedural_api_Test extends ActionScheduler_UnitTestCase {
 
 		// Make sure the next scheduled action is unscheduled
 		$this->assertEquals( $hook, $unscheduled_action->get_hook() );
-		$this->assertNull( $unscheduled_action->get_schedule()->next() );
+		$this->assertNull( $unscheduled_action->get_schedule()->get_date() );
 
 		// Make sure other scheduled actions are not unscheduled
 		$scheduled_action = $store->fetch_action( $action_id_scheduled );
 
 		$this->assertEquals( $hook, $scheduled_action->get_hook() );
-		$this->assertEquals( $action_scheduled_time, $scheduled_action->get_schedule()->next()->getTimestamp() );
+		$this->assertEquals( $action_scheduled_time, $scheduled_action->get_schedule()->get_date()->getTimestamp() );
 	}
 
 	/**
@@ -168,7 +168,7 @@ class procedural_api_Test extends ActionScheduler_UnitTestCase {
 		foreach ( $action_ids as $action_id ) {
 			$action = $store->fetch_action($action_id);
 
-			$this->assertNull($action->get_schedule()->next());
+			$this->assertNull($action->get_schedule()->get_date());
 			$this->assertEquals($hook, $action->get_hook() );
 		}
 	}

--- a/tests/phpunit/procedural_api/procedural_api_Test.php
+++ b/tests/phpunit/procedural_api/procedural_api_Test.php
@@ -140,9 +140,12 @@ class procedural_api_Test extends ActionScheduler_UnitTestCase {
 
 		// Make sure the next scheduled action is unscheduled
 		$this->assertEquals( $hook, $unscheduled_action->get_hook() );
-		$this->assertNull( $unscheduled_action->get_schedule()->get_date() );
+		$this->assertEquals( as_get_datetime_object($time), $unscheduled_action->get_schedule()->get_date() );
+		$this->assertEquals( ActionScheduler_Store::STATUS_CANCELED, $store->get_status( $action_id_unscheduled ) );
+		$this->assertNull( $unscheduled_action->get_schedule()->get_next( as_get_datetime_object() ) );
 
 		// Make sure other scheduled actions are not unscheduled
+		$this->assertEquals( ActionScheduler_Store::STATUS_PENDING, $store->get_status( $action_id_scheduled ) );
 		$scheduled_action = $store->fetch_action( $action_id_scheduled );
 
 		$this->assertEquals( $hook, $scheduled_action->get_hook() );
@@ -166,13 +169,18 @@ class procedural_api_Test extends ActionScheduler_UnitTestCase {
 		$next = as_next_scheduled_action( $hook );
 		$this->assertFalse($next);
 
+		$after = as_get_datetime_object( $time );
+		$after->modify( '+1 minute' );
+
 		$store = ActionScheduler::store();
 
 		foreach ( $action_ids as $action_id ) {
 			$action = $store->fetch_action($action_id);
 
-			$this->assertNull($action->get_schedule()->get_date());
-			$this->assertEquals($hook, $action->get_hook() );
+			$this->assertEquals( $hook, $action->get_hook() );
+			$this->assertEquals( as_get_datetime_object( $time ), $action->get_schedule()->get_date() );
+			$this->assertEquals( ActionScheduler_Store::STATUS_CANCELED, $store->get_status( $action_id ) );
+			$this->assertNull( $action->get_schedule()->get_next( $after ) );
 		}
 	}
 

--- a/tests/phpunit/procedural_api/procedural_api_Test.php
+++ b/tests/phpunit/procedural_api/procedural_api_Test.php
@@ -38,6 +38,9 @@ class procedural_api_Test extends ActionScheduler_UnitTestCase {
 		$expected_date = as_get_datetime_object('2014-10-10');
 		$this->assertEquals( $expected_date->getTimestamp(), $action->get_schedule()->get_date()->getTimestamp() );
 		$this->assertEquals( $hook, $action->get_hook() );
+
+		$expected_date = as_get_datetime_object( '2015-10-10' );
+		$this->assertEquals( $expected_date->getTimestamp(), $action->get_schedule()->get_next( as_get_datetime_object( '2015-01-02' ) )->getTimestamp() );
 	}
 
 	public function test_get_next() {

--- a/tests/phpunit/runner/ActionScheduler_QueueRunner_Test.php
+++ b/tests/phpunit/runner/ActionScheduler_QueueRunner_Test.php
@@ -125,31 +125,59 @@ class ActionScheduler_QueueRunner_Test extends ActionScheduler_UnitTestCase {
 		$this->assertEquals( $date->getTimestamp(), $fetched_action->get_schedule()->get_date()->getTimestamp(), '', 1 );
 	}
 
-	public function test_next_instance_of_action() {
-		$store = ActionScheduler::store();
-		$runner = new ActionScheduler_QueueRunner( $store );
+	public function test_next_instance_of_interval_action() {
+		// Create an action to recur every 24 hours, with the first instance scheduled to run 12 hours ago
+		$random    = md5( rand() );
+		$date      = as_get_datetime_object( '12 hours ago' );
+		$action_id = ActionScheduler::factory()->recurring( $random, array(), $date->getTimestamp(), DAY_IN_SECONDS );
+		$store     = ActionScheduler::store();
+		$runner    = new ActionScheduler_QueueRunner( $store );
 
-		$random = md5(rand());
-		$schedule = new ActionScheduler_IntervalSchedule(as_get_datetime_object('12 hours ago'), DAY_IN_SECONDS);
+		// Make sure the 1st instance of the action is scheduled to occur 12 hours ago
+		$claim = $store->stake_claim( 10, $date );
+		$actions = $claim->get_actions();
+		$this->assertCount( 1, $actions );
 
-		$action = new ActionScheduler_Action( $random, array(), $schedule );
-		$store->save_action( $action );
+		$fetched_action_id = reset( $actions );
+		$fetched_action    = $store->fetch_action( $fetched_action_id );
 
+		$this->assertEquals( $fetched_action_id, $action_id );
+		$this->assertEquals( $random, $fetched_action->get_hook() );
+		$this->assertEquals( $date->getTimestamp(), $fetched_action->get_schedule()->get_date()->getTimestamp(), '', 1 );
+
+		$store->release_claim( $claim );
+
+		// Make sure after the queue is run, the 2nd instance of the action is scheduled to occur in 24 hours
 		$runner->run();
 
-		$claim = $store->stake_claim(10, as_get_datetime_object((DAY_IN_SECONDS - 60).' seconds'));
-		$this->assertCount(0, $claim->get_actions());
-
-		$claim = $store->stake_claim(10, as_get_datetime_object(DAY_IN_SECONDS.' seconds'));
+		$date = as_get_datetime_object( '+1 day' );
+		$claim = $store->stake_claim( 10, $date );
 		$actions = $claim->get_actions();
-		$this->assertCount(1, $actions);
+		$this->assertCount( 1, $actions );
 
-		$action_id = reset($actions);
-		$new_action = $store->fetch_action($action_id);
+		$fetched_action_id = reset( $actions );
+		$fetched_action    = $store->fetch_action( $fetched_action_id );
 
+		$this->assertNotEquals( $fetched_action_id, $action_id );
+		$this->assertEquals( $random, $fetched_action->get_hook() );
+		$this->assertEquals( $date->getTimestamp(), $fetched_action->get_schedule()->get_date()->getTimestamp(), '', 1 );
 
-		$this->assertEquals( $random, $new_action->get_hook() );
-		$this->assertEquals( $schedule->get_next( as_get_datetime_object() )->getTimestamp(), $new_action->get_schedule()->get_next( as_get_datetime_object() )->getTimestamp(), '', 1 );
+		$store->release_claim( $claim );
+
+		// Make sure the 3rd instance of the cron action is scheduled for 24 hours from now, as the action was run early, ahead of schedule
+		$runner->process_action( $action_id );
+		$date = as_get_datetime_object( '+1 day' );
+
+		$claim = $store->stake_claim( 10, $date );
+		$actions = $claim->get_actions();
+		$this->assertCount( 1, $actions );
+
+		$fetched_action_id = reset( $actions );
+		$fetched_action    = $store->fetch_action( $fetched_action_id );
+
+		$this->assertNotEquals( $fetched_action_id, $action_id );
+		$this->assertEquals( $random, $fetched_action->get_hook() );
+		$this->assertEquals( $date->getTimestamp(), $fetched_action->get_schedule()->get_date()->getTimestamp(), '', 1 );
 	}
 
 	public function test_hooked_into_wp_cron() {

--- a/tests/phpunit/runner/ActionScheduler_QueueRunner_Test.php
+++ b/tests/phpunit/runner/ActionScheduler_QueueRunner_Test.php
@@ -104,7 +104,7 @@ class ActionScheduler_QueueRunner_Test extends ActionScheduler_UnitTestCase {
 
 
 		$this->assertEquals( $random, $new_action->get_hook() );
-		$this->assertEquals( $schedule->next( as_get_datetime_object() )->getTimestamp(), $new_action->get_schedule()->next( as_get_datetime_object() )->getTimestamp(), '', 1 );
+		$this->assertEquals( $schedule->get_next( as_get_datetime_object() )->getTimestamp(), $new_action->get_schedule()->get_next( as_get_datetime_object() )->getTimestamp(), '', 1 );
 	}
 
 	public function test_hooked_into_wp_cron() {

--- a/tests/phpunit/schedules/ActionScheduler_CronSchedule_Test.php
+++ b/tests/phpunit/schedules/ActionScheduler_CronSchedule_Test.php
@@ -8,15 +8,46 @@ class ActionScheduler_CronSchedule_Test extends ActionScheduler_UnitTestCase {
 	public function test_creation() {
 		$time = as_get_datetime_object('tomorrow');
 		$cron = CronExpression::factory('@daily');
-		$schedule = new ActionScheduler_CronSchedule(as_get_datetime_object(), $cron);
-		$this->assertEquals( $time, $schedule->next() );
+		$start = clone $time;
+		$start->modify( '-1 hour' );
+		$schedule = new ActionScheduler_CronSchedule( $start, $cron );
+		$this->assertEquals( $time, $schedule->get_date() );
+		$this->assertEquals( $start, $schedule->get_first_date() );
+
+		// Test delaying for a future start date
+		$start->modify( '+1 week' );
+		$time->modify( '+1 week' );
+
+		$schedule = new ActionScheduler_CronSchedule( $start, $cron );
+		$this->assertEquals( $time, $schedule->get_date() );
+		$this->assertEquals( $start, $schedule->get_first_date() );
+	}
+
+	public function test_creation_with_first_date() {
+		$time = as_get_datetime_object( 'tomorrow' );
+		$cron = CronExpression::factory( '@daily' );
+		$start = clone $time;
+		$start->modify( '-1 hour' );
+		$schedule = new ActionScheduler_CronSchedule( $start, $cron );
+		$this->assertEquals( $time, $schedule->get_date() );
+		$this->assertEquals( $start, $schedule->get_first_date() );
+
+		// Test delaying for a future start date
+		$first = clone $time;
+		$first->modify( '-1 day' );
+		$start->modify( '+1 week' );
+		$time->modify( '+1 week' );
+
+		$schedule = new ActionScheduler_CronSchedule( $start, $cron, $first );
+		$this->assertEquals( $time, $schedule->get_date() );
+		$this->assertEquals( $first, $schedule->get_first_date() );
 	}
 
 	public function test_next() {
 		$time = as_get_datetime_object('2013-06-14');
 		$cron = CronExpression::factory('@daily');
 		$schedule = new ActionScheduler_CronSchedule($time, $cron);
-		$this->assertEquals( as_get_datetime_object('tomorrow'), $schedule->next( as_get_datetime_object() ) );
+		$this->assertEquals( as_get_datetime_object('tomorrow'), $schedule->get_next( as_get_datetime_object() ) );
 	}
 
 	public function test_is_recurring() {
@@ -28,18 +59,18 @@ class ActionScheduler_CronSchedule_Test extends ActionScheduler_UnitTestCase {
 		$time = as_get_datetime_object('2014-01-01');
 		$cron = CronExpression::factory('0 0 10 10 *');
 		$schedule = new ActionScheduler_CronSchedule($time, $cron);
-		$this->assertEquals( as_get_datetime_object('2014-10-10'), $schedule->next() );
+		$this->assertEquals( as_get_datetime_object('2014-10-10'), $schedule->get_date() );
 
 		$cron = CronExpression::factory('0 0 L 1/2 *');
 		$schedule = new ActionScheduler_CronSchedule($time, $cron);
-		$this->assertEquals( as_get_datetime_object('2014-01-31'), $schedule->next() );
-		$this->assertEquals( as_get_datetime_object('2014-07-31'), $schedule->next( as_get_datetime_object('2014-06-01') ) );
-		$this->assertEquals( as_get_datetime_object('2028-11-30'), $schedule->next( as_get_datetime_object('2028-11-01') ) );
+		$this->assertEquals( as_get_datetime_object('2014-01-31'), $schedule->get_date() );
+		$this->assertEquals( as_get_datetime_object('2014-07-31'), $schedule->get_next( as_get_datetime_object('2014-06-01') ) );
+		$this->assertEquals( as_get_datetime_object('2028-11-30'), $schedule->get_next( as_get_datetime_object('2028-11-01') ) );
 
 		$cron = CronExpression::factory('30 14 * * MON#3 *');
 		$schedule = new ActionScheduler_CronSchedule($time, $cron);
-		$this->assertEquals( as_get_datetime_object('2014-01-20 14:30:00'), $schedule->next() );
-		$this->assertEquals( as_get_datetime_object('2014-05-19 14:30:00'), $schedule->next( as_get_datetime_object('2014-05-01') ) );
+		$this->assertEquals( as_get_datetime_object('2014-01-20 14:30:00'), $schedule->get_date() );
+		$this->assertEquals( as_get_datetime_object('2014-05-19 14:30:00'), $schedule->get_next( as_get_datetime_object('2014-05-01') ) );
 	}
 }
  

--- a/tests/phpunit/schedules/ActionScheduler_IntervalSchedule_Test.php
+++ b/tests/phpunit/schedules/ActionScheduler_IntervalSchedule_Test.php
@@ -8,16 +8,25 @@ class ActionScheduler_IntervalSchedule_Test extends ActionScheduler_UnitTestCase
 	public function test_creation() {
 		$time = as_get_datetime_object();
 		$schedule = new ActionScheduler_IntervalSchedule($time, HOUR_IN_SECONDS);
-		$this->assertEquals( $time, $schedule->next() );
+		$this->assertEquals( $time, $schedule->get_date() );
+		$this->assertEquals( $time, $schedule->get_first_date() );
+	}
+
+	public function test_creation_with_first_date() {
+		$first = as_get_datetime_object();
+		$time  = as_get_datetime_object( '+12 hours' );
+		$schedule = new ActionScheduler_IntervalSchedule( $time, HOUR_IN_SECONDS, $first );
+		$this->assertEquals( $time, $schedule->get_date() );
+		$this->assertEquals( $first, $schedule->get_first_date() );
 	}
 
 	public function test_next() {
 		$now = time();
 		$start = $now - 30;
 		$schedule = new ActionScheduler_IntervalSchedule( as_get_datetime_object("@$start"), MINUTE_IN_SECONDS );
-		$this->assertEquals( $start, $schedule->next()->getTimestamp() );
-		$this->assertEquals( $now + MINUTE_IN_SECONDS, $schedule->next(as_get_datetime_object())->getTimestamp() );
-		$this->assertEquals( $start, $schedule->next(as_get_datetime_object("@$start"))->getTimestamp() );
+		$this->assertEquals( $start, $schedule->get_date()->getTimestamp() );
+		$this->assertEquals( $now + MINUTE_IN_SECONDS, $schedule->get_next(as_get_datetime_object())->getTimestamp() );
+		$this->assertEquals( $start, $schedule->get_next( as_get_datetime_object( "@$start" ) )->getTimestamp() );
 	}
 
 	public function test_is_recurring() {

--- a/tests/phpunit/schedules/ActionScheduler_NullSchedule_Test.php
+++ b/tests/phpunit/schedules/ActionScheduler_NullSchedule_Test.php
@@ -7,7 +7,7 @@
 class ActionScheduler_NullSchedule_Test extends ActionScheduler_UnitTestCase {
 	public function test_null_schedule() {
 		$schedule = new ActionScheduler_NullSchedule();
-		$this->assertNull( $schedule->next() );
+		$this->assertNull( $schedule->get_date() );
 	}
 
 	public function test_is_recurring() {

--- a/tests/phpunit/schedules/ActionScheduler_SimpleSchedule_Test.php
+++ b/tests/phpunit/schedules/ActionScheduler_SimpleSchedule_Test.php
@@ -8,25 +8,25 @@ class ActionScheduler_SimpleSchedule_Test extends ActionScheduler_UnitTestCase {
 	public function test_creation() {
 		$time = as_get_datetime_object();
 		$schedule = new ActionScheduler_SimpleSchedule($time);
-		$this->assertEquals( $time, $schedule->next() );
+		$this->assertEquals( $time, $schedule->get_date() );
 	}
 
 	public function test_past_date() {
 		$time = as_get_datetime_object('-1 day');
 		$schedule = new ActionScheduler_SimpleSchedule($time);
-		$this->assertEquals( $time, $schedule->next() );
+		$this->assertEquals( $time, $schedule->get_date() );
 	}
 
 	public function test_future_date() {
 		$time = as_get_datetime_object('+1 day');
 		$schedule = new ActionScheduler_SimpleSchedule($time);
-		$this->assertEquals( $time, $schedule->next() );
+		$this->assertEquals( $time, $schedule->get_date() );
 	}
 
 	public function test_grace_period_for_next() {
 		$time = as_get_datetime_object('3 seconds ago');
 		$schedule = new ActionScheduler_SimpleSchedule($time);
-		$this->assertEquals( $time, $schedule->next() );
+		$this->assertEquals( $time, $schedule->get_date() );
 	}
 
 	public function test_is_recurring() {


### PR DESCRIPTION
This is a monster, late stage PR for 3.0.0. However, because there are breaking changes, and it resolves a number of discrepancies and gotchas in the recurring and cron actions & schedules, I think it's worth including in 3.0.0 instead of waiting for a 4.0.0, or shipping in a 3.x.x version.

---

Fixes #330 and associated issues - #256, #258, #291, #293 and #296.

---

As outlined in #330, there are a number of issues with recurring action that use either a Cron or Interval schedule.

This PR fixes recurring schedules, and in the process, refactors all schedules to avoid duplicate code and ambiguity of properties and parameters.

This patch introduces two important new base classes:

 * `ActionScheduler_Abstract_Schedule` and
 * `ActionScheduler_Abstract_RecurringSchedule`

These are then used to implement all other schedule types - cron, recurring/interval and simple. This helps unify the data on each schedule. For example, schedules used to have different property names referring to equivalent data like `ActionScheduler_IntervalSchedule::start_timestamp` and `ActionScheduler_SimpleSchedule::timestamp`.

Both of these timestamps actually referring to the date the action was scheduled, but due to ambiguity in naming, like "_start_" or "_date_" or "_first_", the data was sometimes used to refer to the scheduled date, and sometimes the first instance of a recurring schedule. While unifying the properties, their nomenclature has also been changed to avoid ambiguity.

While working on this, I also took the opportunity to:

* harden safeguards when next instances are scheduled to make only recurring action are ever rescheduled
* introduce a new `ActionScheduler_CanceledSchedule` class which takes advantage of the separation of scheduled / next dates on a schedule so that a cancelled action's scheduled date can be derived (and displayed in the admin)
* improve docblocks to better record any gotchas, like time slippage when rescheduling an instance of a recurring action
* add more unit tests, particularly to test cases of 2...n instances of a recurring action
* log issues rescheduling a recurring action