### PR TITLE
make add_help_tabs static

### DIFF
--- a/classes/ActionScheduler_AdminHelp.php
+++ b/classes/ActionScheduler_AdminHelp.php
@@ -7,7 +7,7 @@
 class ActionScheduler_AdminHelp {
 	const SCREEN_ID = 'tools_page_action-scheduler';
 
-	public function add_help_tabs() {
+	public static function add_help_tabs() {
 		$screen = get_current_screen();
 
 		if ( ! $screen || self::SCREEN_ID != $screen->id ) {


### PR DESCRIPTION
Closes #334 

This is a follow up PR #316 to fix the warning for the function missing the static declaration.