### PR TITLE
Do not mark action complete in Migration\Scheduler

### DIFF
--- a/classes/migration/Runner.php
+++ b/classes/migration/Runner.php
@@ -132,18 +132,4 @@ class Runner {
 		$this->destination_store->init();
 		$this->destination_logger->init();
 	}
-
-	/**
-	 * Get destination store.
-	 */
-	public function get_destination_store() {
-		return $this->destination_store;
-	}
-
-	/**
-	 * Get destination logger.
-	 */
-	public function get_destination_logger() {
-		return $this->destination_logger;
-	}
 }

--- a/classes/migration/Scheduler.php
+++ b/classes/migration/Scheduler.php
@@ -51,16 +51,6 @@ class Scheduler {
 	 * Mark the migration complete.
 	 */
 	public function mark_complete() {
-		$migration_runner   = $this->get_migration_runner();
-		$destination_store  = $migration_runner->get_destination_store();
-		$destination_logger = $migration_runner->get_destination_logger();
-
-		$action_id = $destination_store->find_action( self::HOOK );
-		if ( $action_id ) {
-			$destination_logger->hook_stored_action();
-			$destination_store->mark_complete( $action_id );
-		}
-
 		$this->unschedule_migration();
 
 		\ActionScheduler_DataController::mark_migration_complete();


### PR DESCRIPTION
Do not mark action complete in `Migration\Scheduler` because when the migration is run via the `Scheduler`, the action will be marked as complete by the `QueueRunner` and when the migration is run via `Migration_Command::migrate()`, the scheduled action should not be marked `'complete'`, because the action is not actually run (or completed). It should instead simply be unscheduled so that no migration is run in future via the Migration Scheduler once the WP CLI command has completed the migration.

This minor bug was introduced with a few other changes in SHA: d74bf96a as part of #259.