### PR TITLE
Maintain property names for serialized schedules

### DIFF
--- a/classes/abstracts/ActionScheduler_Abstract_RecurringSchedule.php
+++ b/classes/abstracts/ActionScheduler_Abstract_RecurringSchedule.php
@@ -81,6 +81,16 @@ abstract class ActionScheduler_Abstract_RecurringSchedule extends ActionSchedule
 		) );
 	}
 
+	/**
+	 * Unserialize recurring schedules serialized/stored prior to AS 3.0.0
+	 *
+	 * Prior to Action Scheduler 3.0.0, schedules used different property names to refer
+	 * to equivalent data. For example, ActionScheduler_IntervalSchedule::start_timestamp
+	 * was the same as ActionScheduler_SimpleSchedule::timestamp. This was addressed in
+	 * Action Scheduler 3.0.0, where properties and property names were aligned for better
+	 * inheritance. To maintain backward compatibility with scheduled serialized and stored
+	 * prior to 3.0, we need to correctly map the old property names.
+	 */
 	public function __wakeup() {
 		parent::__wakeup();
 		if ( $this->first_timestamp > 0 ) {

--- a/classes/schedules/ActionScheduler_CronSchedule.php
+++ b/classes/schedules/ActionScheduler_CronSchedule.php
@@ -56,14 +56,9 @@ class ActionScheduler_CronSchedule extends ActionScheduler_Abstract_RecurringSch
 	}
 
 	/**
-	 * Unserialize recurring schedules serialized/stored prior to AS 3.0.0
+	 * Unserialize cron schedules serialized/stored prior to AS 3.0.0
 	 *
-	 * Prior to Action Scheduler 3.0.0, schedules used different property names to refer
-	 * to equivalent data. For example, ActionScheduler_IntervalSchedule::start_timestamp
-	 * was the same as ActionScheduler_SimpleSchedule::timestamp. This was addressed in
-	 * Action Scheduler 3.0.0, where properties and property names were aligned for better
-	 * inheritance. To maintain backward compatibility with scheduled serialized and stored
-	 * prior to 3.0, we need to correctly map the old property names.
+	 * For more background, @see ActionScheduler_Abstract_RecurringSchedule::__wakeup().
 	 */
 	public function __wakeup() {
 		if ( ! is_null( $this->start_timestamp ) ) {

--- a/classes/schedules/ActionScheduler_CronSchedule.php
+++ b/classes/schedules/ActionScheduler_CronSchedule.php
@@ -56,18 +56,45 @@ class ActionScheduler_CronSchedule extends ActionScheduler_Abstract_RecurringSch
 	}
 
 	/**
+	 * Serialize cron schedules with data required prior to AS 3.0.0
+	 *
+	 * Prior to Action Scheduler 3.0.0, reccuring schedules used different property names to
+	 * refer to equivalent data. For example, ActionScheduler_IntervalSchedule::start_timestamp
+	 * was the same as ActionScheduler_SimpleSchedule::timestamp. Action Scheduler 3.0.0
+	 * aligned properties and property names for better inheritance. To guard against the
+	 * possibility of infinite loops if downgrading to Action Scheduler < 3.0.0, we need to
+	 * also store the data with the old property names so if it's unserialized in AS < 3.0,
+	 * the schedule doesn't end up with a null recurrence.
+	 *
+	 * @return array
+	 */
+	public function __sleep() {
+
+		$sleep_params = parent::__sleep();
+
+		$this->start_timestamp = $this->scheduled_timestamp;
+		$this->cron            = $this->recurrence;
+
+		return array_merge( $sleep_params, array(
+			'start_timestamp',
+			'cron'
+		) );
+	}
+
+	/**
 	 * Unserialize cron schedules serialized/stored prior to AS 3.0.0
 	 *
 	 * For more background, @see ActionScheduler_Abstract_RecurringSchedule::__wakeup().
 	 */
 	public function __wakeup() {
-		if ( ! is_null( $this->start_timestamp ) ) {
+		if ( is_null( $this->scheduled_timestamp ) && ! is_null( $this->start_timestamp ) ) {
 			$this->scheduled_timestamp = $this->start_timestamp;
 			unset( $this->start_timestamp );
 		}
 
-		if ( ! is_null( $this->cron ) ) {
+		if ( is_null( $this->recurrence ) && ! is_null( $this->cron ) ) {
 			$this->recurrence = $this->cron;
+			unset( $this->cron );
 		}
 		parent::__wakeup();
 	}

--- a/classes/schedules/ActionScheduler_CronSchedule.php
+++ b/classes/schedules/ActionScheduler_CronSchedule.php
@@ -19,7 +19,7 @@ class ActionScheduler_CronSchedule extends ActionScheduler_Abstract_RecurringSch
 	 * Wrapper for parent constructor to accept a cron expression string and map it to a CronExpression for this
 	 * objects $recurrence property.
 	 *
-	 * @param DateTime $start The date & time to run the action.
+	 * @param DateTime $start The date & time to run the action at or after. If $start aligns with the CronSchedule passed via $recurrence, it will be used. If it does not align, the first matching date after it will be used.
 	 * @param CronExpression|string $recurrence The CronExpression used to calculate the schedule's next instance.
 	 * @param DateTime|null $first (Optional) The date & time the first instance of this interval schedule ran. Default null, meaning this is the first instance.
 	 */

--- a/classes/schedules/ActionScheduler_IntervalSchedule.php
+++ b/classes/schedules/ActionScheduler_IntervalSchedule.php
@@ -36,17 +36,43 @@ class ActionScheduler_IntervalSchedule extends ActionScheduler_Abstract_Recurrin
 	}
 
 	/**
+	 * Serialize interval schedules with data required prior to AS 3.0.0
+	 *
+	 * Prior to Action Scheduler 3.0.0, reccuring schedules used different property names to
+	 * refer to equivalent data. For example, ActionScheduler_IntervalSchedule::start_timestamp
+	 * was the same as ActionScheduler_SimpleSchedule::timestamp. Action Scheduler 3.0.0
+	 * aligned properties and property names for better inheritance. To guard against the
+	 * possibility of infinite loops if downgrading to Action Scheduler < 3.0.0, we need to
+	 * also store the data with the old property names so if it's unserialized in AS < 3.0,
+	 * the schedule doesn't end up with a null/false/0 recurrence.
+	 *
+	 * @return array
+	 */
+	public function __sleep() {
+
+		$sleep_params = parent::__sleep();
+
+		$this->start_timestamp     = $this->scheduled_timestamp;
+		$this->interval_in_seconds = $this->recurrence;
+
+		return array_merge( $sleep_params, array(
+			'start_timestamp',
+			'interval_in_seconds'
+		) );
+	}
+
+	/**
 	 * Unserialize interval schedules serialized/stored prior to AS 3.0.0
 	 *
 	 * For more background, @see ActionScheduler_Abstract_RecurringSchedule::__wakeup().
 	 */
 	public function __wakeup() {
-		if ( ! is_null( $this->start_timestamp ) ) {
+		if ( is_null( $this->scheduled_timestamp ) && ! is_null( $this->start_timestamp ) ) {
 			$this->scheduled_timestamp = $this->start_timestamp;
 			unset( $this->start_timestamp );
 		}
 
-		if ( ! is_null( $this->interval_in_seconds ) ) {
+		if ( is_null( $this->recurrence ) && ! is_null( $this->interval_in_seconds ) ) {
 			$this->recurrence = $this->interval_in_seconds;
 			unset( $this->interval_in_seconds );
 		}

--- a/classes/schedules/ActionScheduler_IntervalSchedule.php
+++ b/classes/schedules/ActionScheduler_IntervalSchedule.php
@@ -36,14 +36,9 @@ class ActionScheduler_IntervalSchedule extends ActionScheduler_Abstract_Recurrin
 	}
 
 	/**
-	 * Unserialize recurring schedules serialized/stored prior to AS 3.0.0
+	 * Unserialize interval schedules serialized/stored prior to AS 3.0.0
 	 *
-	 * Prior to Action Scheduler 3.0.0, schedules used different property names to refer
-	 * to equivalent data. For example, ActionScheduler_IntervalSchedule::start_timestamp
-	 * was the same as ActionScheduler_SimpleSchedule::timestamp. Action Scheduler 3.0.0
-	 * aligned properties and property names for better inheritance. To maintain backward
-	 * compatibility with schedules serialized and stored prior to 3.0, we need to correctly
-	 * map the old property names with matching visibility.
+	 * For more background, @see ActionScheduler_Abstract_RecurringSchedule::__wakeup().
 	 */
 	public function __wakeup() {
 		if ( ! is_null( $this->start_timestamp ) ) {


### PR DESCRIPTION
Prior to #333, recurring schedules used different property names to refer to equivalent data. For example, `IntervalSchedule::start_timestamp` was the same as `SimpleSchedule::timestamp`.

PR #333 aligned properties and property names for better inheritance. However, in doing so, it also broke backward compatibility with schedule data serialized and stored prior to AS 3.0.0.

While that was a known issue, what wasn't realised at the time is that sites may downgrade to AS < 3.0.0. In some cases, they may do this completely unintentionally or unaware. For example, because they deactivate a plugin with AS >= 3.0.0 and another plugin is still running AS < 3.0.0.

For most cases, this won't be a major issue. Their data will have been migrated to a custom data store when upgrading to AS 3.0.0, so when downgrading, AS < 3.0.0 won't select and attempt to continue running with any data stored with AS >= 3.0.0.

However, there is the case of a site which has the custom tables plugin installed. Those sites will continue to claim the data in the new format, even though AS will be looking for properties on schedules in the old format.

This creates the infinite loops mentioned in #340.

To guard against the possibility of infinite loops if downgrading to Action Scheduler < 3.0.0, we need to also store the data with the old property names so if it's unserialized in AS < 3.0, the schedule doesn't end up with a 0 recurrence.

This PR handles that.

It also sneaks in a couple of commits to tweak docblocks added in #333.

Fixes #340.