### PR TITLE
add bulk cancel by hook/group to table store

### DIFF
--- a/classes/abstracts/ActionScheduler_Logger.php
+++ b/classes/abstracts/ActionScheduler_Logger.php
@@ -57,6 +57,7 @@ abstract class ActionScheduler_Logger {
 		add_action( 'action_scheduler_execution_ignored', array( $this, 'log_ignored_action' ), 10, 2 );
 		add_action( 'action_scheduler_failed_fetch_action', array( $this, 'log_failed_fetch_action' ), 10, 2 );
 		add_action( 'action_scheduler_failed_to_schedule_next_instance', array( $this, 'log_failed_schedule_next_instance' ), 10, 2 );
+		add_action( 'action_scheduler_bulk_cancel_actions', array( $this, 'bulk_log_cancel_actions' ), 10, 1 );
 	}
 
 	public function hook_stored_action() {
@@ -144,5 +145,23 @@ abstract class ActionScheduler_Logger {
 
 	public function log_failed_schedule_next_instance( $action_id, Exception $exception ) {
 		$this->log( $action_id, sprintf( __( 'There was a failure scheduling the next instance of this action: %s', 'action-scheduler' ), $exception->getMessage() ) );
+	}
+
+	/**
+	 * Bulk add cancel action log entries.
+	 *
+	 * Implemented here for backward compatibility. Should be implemented in parent loggers
+	 * for more performant bulk logging.
+	 *
+	 * @param array $action_ids List of action ID.
+	 */
+	public function bulk_log_cancel_actions( $action_ids ) {
+		if ( empty( $action_ids ) ) {
+			return;
+		}
+
+		foreach ( $action_ids as $action_id ) {
+			$this->log_canceled_action( $action_id );
+		}
 	}
 }

--- a/classes/abstracts/ActionScheduler_Store.php
+++ b/classes/abstracts/ActionScheduler_Store.php
@@ -33,16 +33,17 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 	abstract public function fetch_action( $action_id );
 
 	/**
-	 * @param string $hook
-	 * @param array $params
-	 * @return string ID of the next action matching the criteria
+	 * @param string $hook Hook name/slug.
+	 * @param array  $params Hook arguments.
+	 * @return string ID of the next action matching the criteria.
 	 */
 	abstract public function find_action( $hook, $params = array() );
 
 	/**
-	 * @param array $query
+	 * @param array  $query Query parameters.
 	 * @param string $query_type Whether to select or count the results. Default, select.
-	 * @return array The IDs of actions matching the query
+	 *
+	 * @return array|int The IDs of or count of actions matching the query.
 	 */
 	abstract public function query_actions( $query = array(), $query_type = 'select' );
 
@@ -206,6 +207,58 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 	protected function validate_schedule( $schedule, $action_id ) {
 		if ( empty( $schedule ) || ! is_a( $schedule, 'ActionScheduler_Schedule' ) ) {
 			throw ActionScheduler_InvalidActionException::from_schedule( $action_id, $schedule );
+		}
+	}
+
+	/**
+	 * Cancel pending actions by hook.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param string $hook Hook name.
+	 *
+	 * @return void
+	 */
+	public function cancel_actions_by_hook( $hook ) {
+		$action_ids = true;
+		while ( ! empty( $action_ids ) ) {
+			$action_ids = $this->query_actions(
+				array(
+					'hook' => $hook,
+					'status' => self::STATUS_PENDING,
+					'per_page' => 1000,
+				)
+			);
+
+			foreach ( $action_ids as $action_id ) {
+				$this->cancel_action( $action_id );
+			}
+		}
+	}
+
+	/**
+	 * Cancel pending actions by group.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param string $group Group slug.
+	 *
+	 * @return void
+	 */
+	public function cancel_actions_by_group( $hook ) {
+		$action_ids = true;
+		while ( ! empty( $action_ids ) ) {
+			$action_ids = $this->query_actions(
+				array(
+					'group' => $group,
+					'status' => self::STATUS_PENDING,
+					'per_page' => 1000,
+				)
+			);
+
+			foreach ( $action_ids as $action_id ) {
+				$this->cancel_action( $action_id );
+			}
 		}
 	}
 

--- a/classes/abstracts/ActionScheduler_Store.php
+++ b/classes/abstracts/ActionScheduler_Store.php
@@ -245,7 +245,7 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 	 *
 	 * @return void
 	 */
-	public function cancel_actions_by_group( $hook ) {
+	public function cancel_actions_by_group( $group ) {
 		$action_ids = true;
 		while ( ! empty( $action_ids ) ) {
 			$action_ids = $this->query_actions(

--- a/classes/abstracts/ActionScheduler_Store.php
+++ b/classes/abstracts/ActionScheduler_Store.php
@@ -230,9 +230,7 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 				)
 			);
 
-			foreach ( $action_ids as $action_id ) {
-				$this->cancel_action( $action_id );
-			}
+			$this->bulk_cancel_actions( $action_ids );
 		}
 	}
 
@@ -256,10 +254,25 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 				)
 			);
 
-			foreach ( $action_ids as $action_id ) {
-				$this->cancel_action( $action_id );
-			}
+			$this->bulk_cancel_actions( $action_ids );
 		}
+	}
+
+	/**
+	 * Cancel a set of action IDs.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param array $action_ids List of action IDs.
+	 *
+	 * @return void
+	 */
+	private function bulk_cancel_actions( $action_ids ) {
+		foreach ( $action_ids as $action_id ) {
+			$this->cancel_action( $action_id );
+		}
+
+		do_action( 'action_scheduler_bulk_cancel_actions', $action_ids );
 	}
 
 	/**

--- a/classes/data-stores/ActionScheduler_DBLogger.php
+++ b/classes/data-stores/ActionScheduler_DBLogger.php
@@ -102,7 +102,6 @@ class ActionScheduler_DBLogger extends ActionScheduler_Logger {
 		parent::init();
 
 		add_action( 'action_scheduler_deleted_action', [ $this, 'clear_deleted_action_logs' ], 10, 1 );
-		add_action( 'action_scheduler_bulk_cancel_actions', [ $this, 'bulk_log_cancel_actions' ], 10, 1 );
 	}
 
 	/**

--- a/classes/data-stores/ActionScheduler_DBLogger.php
+++ b/classes/data-stores/ActionScheduler_DBLogger.php
@@ -102,6 +102,7 @@ class ActionScheduler_DBLogger extends ActionScheduler_Logger {
 		parent::init();
 
 		add_action( 'action_scheduler_deleted_action', [ $this, 'clear_deleted_action_logs' ], 10, 1 );
+		add_action( 'action_scheduler_bulk_cancel_actions', [ $this, 'bulk_log_cancel_actions' ], 10, 1 );
 	}
 
 	/**
@@ -113,5 +114,34 @@ class ActionScheduler_DBLogger extends ActionScheduler_Logger {
 		/** @var \wpdb $wpdb */
 		global $wpdb;
 		$wpdb->delete( $wpdb->actionscheduler_logs, [ 'action_id' => $action_id, ], [ '%d' ] );
+	}
+
+	/**
+	 * Bulk add cancel action log entries.
+	 *
+	 * @param array $action_ids List of action ID.
+	 */
+	public function bulk_log_cancel_actions( $action_ids ) {
+		if ( empty( $action_ids ) ) {
+			return;
+		}
+
+		/** @var \wpdb $wpdb */
+		global $wpdb;
+		$date     = as_get_datetime_object();
+		$date_gmt = $date->format( 'Y-m-d H:i:s' );
+		ActionScheduler_TimezoneHelper::set_local_timezone( $date );
+		$date_local = $date->format( 'Y-m-d H:i:s' );
+		$message    = __( 'action canceled', 'action-scheduler' );
+		$format     = '(%d, ' . $wpdb->prepare( '%s, %s, %s', $message, $date_gmt, $date_local ) . ')';
+		$sql_query  = "INSERT {$wpdb->actionscheduler_logs} (action_id, message, log_date_gmt, log_date_local) VALUES ";
+		$value_rows = [];
+
+		foreach ( $action_ids as $action_id ) {
+			$value_rows[] = $wpdb->prepare( $format, $action_id );
+		}
+		$sql_query .= implode( ',', $value_rows );
+
+		$wpdb->query( $sql_query );
 	}
 }

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -410,6 +410,8 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 	/**
 	 * Cancel pending actions by hook.
 	 *
+	 * @since 3.0.0
+	 *
 	 * @param string $hook Hook name.
 	 *
 	 * @return void

--- a/functions.php
+++ b/functions.php
@@ -113,6 +113,16 @@ function as_unschedule_action( $hook, $args = array(), $group = '' ) {
  * @param string $group
  */
 function as_unschedule_all_actions( $hook, $args = array(), $group = '' ) {
+	if ( empty( $args ) ) {
+		if ( ! empty( $hook ) && empty( $group ) ) {
+			ActionScheduler_Store::instance()->cancel_actions_by_hook( $hook );
+			return;
+		}
+		if ( ! empty( $group ) && empty( $hook ) ) {
+			ActionScheduler_Store::instance()->cancel_actions_by_group( $group );
+			return;
+		}
+	}
 	do {
 		$unscheduled_action = as_unschedule_action( $hook, $args, $group );
 	} while ( ! empty( $unscheduled_action ) );

--- a/tests/phpunit/jobstore/ActionScheduler_DBStore_Test.php
+++ b/tests/phpunit/jobstore/ActionScheduler_DBStore_Test.php
@@ -52,6 +52,44 @@ class ActionScheduler_DBStore_Test extends ActionScheduler_UnitTestCase {
 		$this->assertInstanceOf( 'ActionScheduler_CanceledAction', $fetched );
 	}
 
+	public function test_cancel_actions_by_hook() {
+		$store   = new ActionScheduler_DBStore();
+		$actions = [];
+		$hook    = 'by_hook_test';
+		for ( $day = 1; $day <= 3; $day++ ) {
+			$delta     = sprintf( '+%d day', $day );
+			$time      = as_get_datetime_object( $delta );
+			$schedule  = new ActionScheduler_SimpleSchedule( $time );
+			$action    = new ActionScheduler_Action( $hook, [], $schedule, 'my_group' );
+			$actions[] = $store->save_action( $action );
+		}
+		$store->cancel_actions_by_hook( $hook );
+
+		foreach ( $actions as $action_id ) {
+			$fetched = $store->fetch_action( $action_id );
+			$this->assertInstanceOf( 'ActionScheduler_CanceledAction', $fetched );
+		}
+	}
+
+	public function test_cancel_actions_by_group() {
+		$store   = new ActionScheduler_DBStore();
+		$actions = [];
+		$group   = 'by_group_test';
+		for ( $day = 1; $day <= 3; $day++ ) {
+			$delta     = sprintf( '+%d day', $day );
+			$time      = as_get_datetime_object( $delta );
+			$schedule  = new ActionScheduler_SimpleSchedule( $time );
+			$action    = new ActionScheduler_Action( 'my_hook', [], $schedule, $group );
+			$actions[] = $store->save_action( $action );
+		}
+		$store->cancel_actions_by_group( $group );
+
+		foreach ( $actions as $action_id ) {
+			$fetched = $store->fetch_action( $action_id );
+			$this->assertInstanceOf( 'ActionScheduler_CanceledAction', $fetched );
+		}
+	}
+
 	public function test_claim_actions() {
 		$created_actions = [];
 		$store           = new ActionScheduler_DBStore();

--- a/tests/phpunit/jobstore/ActionScheduler_wpPostStore_Test.php
+++ b/tests/phpunit/jobstore/ActionScheduler_wpPostStore_Test.php
@@ -76,6 +76,44 @@ class ActionScheduler_wpPostStore_Test extends ActionScheduler_UnitTestCase {
 		$this->assertInstanceOf( 'ActionScheduler_CanceledAction', $fetched );
 	}
 
+	public function test_cancel_actions_by_hook() {
+		$store   = new ActionScheduler_wpPostStore();
+		$actions = [];
+		$hook    = 'by_hook_test';
+		for ( $day = 1; $day <= 3; $day++ ) {
+			$delta     = sprintf( '+%d day', $day );
+			$time      = as_get_datetime_object( $delta );
+			$schedule  = new ActionScheduler_SimpleSchedule( $time );
+			$action    = new ActionScheduler_Action( $hook, [], $schedule, 'my_group' );
+			$actions[] = $store->save_action( $action );
+		}
+		$store->cancel_actions_by_hook( $hook );
+
+		foreach ( $actions as $action_id ) {
+			$fetched = $store->fetch_action( $action_id );
+			$this->assertInstanceOf( 'ActionScheduler_CanceledAction', $fetched );
+		}
+	}
+
+	public function test_cancel_actions_by_group() {
+		$store   = new ActionScheduler_wpPostStore();
+		$actions = [];
+		$group   = 'by_group_test';
+		for ( $day = 1; $day <= 3; $day++ ) {
+			$delta     = sprintf( '+%d day', $day );
+			$time      = as_get_datetime_object( $delta );
+			$schedule  = new ActionScheduler_SimpleSchedule( $time );
+			$action    = new ActionScheduler_Action( 'my_hook', [], $schedule, $group );
+			$actions[] = $store->save_action( $action );
+		}
+		$store->cancel_actions_by_group( $group );
+
+		foreach ( $actions as $action_id ) {
+			$fetched = $store->fetch_action( $action_id );
+			$this->assertInstanceOf( 'ActionScheduler_CanceledAction', $fetched );
+		}
+	}
+
 	public function test_claim_actions() {
 		$created_actions = array();
 		$store = new ActionScheduler_wpPostStore();

--- a/tests/phpunit/jobstore/ActionScheduler_wpPostStore_Test.php
+++ b/tests/phpunit/jobstore/ActionScheduler_wpPostStore_Test.php
@@ -99,6 +99,7 @@ class ActionScheduler_wpPostStore_Test extends ActionScheduler_UnitTestCase {
 		$store   = new ActionScheduler_wpPostStore();
 		$actions = [];
 		$group   = 'by_group_test';
+
 		for ( $day = 1; $day <= 3; $day++ ) {
 			$delta     = sprintf( '+%d day', $day );
 			$time      = as_get_datetime_object( $delta );

--- a/tests/phpunit/jobstore/ActionScheduler_wpPostStore_Test.php
+++ b/tests/phpunit/jobstore/ActionScheduler_wpPostStore_Test.php
@@ -78,13 +78,13 @@ class ActionScheduler_wpPostStore_Test extends ActionScheduler_UnitTestCase {
 
 	public function test_cancel_actions_by_hook() {
 		$store   = new ActionScheduler_wpPostStore();
-		$actions = [];
+		$actions = array();
 		$hook    = 'by_hook_test';
 		for ( $day = 1; $day <= 3; $day++ ) {
 			$delta     = sprintf( '+%d day', $day );
 			$time      = as_get_datetime_object( $delta );
 			$schedule  = new ActionScheduler_SimpleSchedule( $time );
-			$action    = new ActionScheduler_Action( $hook, [], $schedule, 'my_group' );
+			$action    = new ActionScheduler_Action( $hook, array(), $schedule, 'my_group' );
 			$actions[] = $store->save_action( $action );
 		}
 		$store->cancel_actions_by_hook( $hook );
@@ -97,14 +97,14 @@ class ActionScheduler_wpPostStore_Test extends ActionScheduler_UnitTestCase {
 
 	public function test_cancel_actions_by_group() {
 		$store   = new ActionScheduler_wpPostStore();
-		$actions = [];
+		$actions = array();
 		$group   = 'by_group_test';
 
 		for ( $day = 1; $day <= 3; $day++ ) {
 			$delta     = sprintf( '+%d day', $day );
 			$time      = as_get_datetime_object( $delta );
 			$schedule  = new ActionScheduler_SimpleSchedule( $time );
-			$action    = new ActionScheduler_Action( 'my_hook', [], $schedule, $group );
+			$action    = new ActionScheduler_Action( 'my_hook', array(), $schedule, $group );
 			$actions[] = $store->save_action( $action );
 		}
 		$store->cancel_actions_by_group( $group );


### PR DESCRIPTION
This PR adds two bulk cancel functions to the table data store with a unit test for each function

- `cancel_actions_by_group( $group_slug )` cancels pending actions by group
- `cancel_actions_by_hook( $hook_name )` cancels pending actions by hook

This is a prerequisite for https://github.com/woocommerce/woocommerce-admin/issues/2766 to allow bulk cancelation of pending actions.

In future, other plugins using AS will also be able to take advantage of these function to cancel their pending actions on de-activation.
