### PR TITLE
'Headers Already Sent' warning and failure of 'wp_redirect()'

### DIFF
--- a/classes/ActionScheduler_Abstract_ListTable.php
+++ b/classes/ActionScheduler_Abstract_ListTable.php
@@ -634,6 +634,21 @@ abstract class ActionScheduler_Abstract_ListTable extends WP_List_Table {
 	}
 
 	/**
+	 * Process any pending actions.
+	 */
+	public function process_actions() {
+		$this->process_bulk_action();
+
+		$this->process_row_actions();
+
+		if ( ! empty( $_REQUEST['_wp_http_referer'] ) ) {
+			// _wp_http_referer is used only on bulk actions, we remove it to keep the $_GET shorter
+			wp_redirect( remove_query_arg( array( '_wp_http_referer', '_wpnonce' ), wp_unslash( $_SERVER['REQUEST_URI'] ) ) );
+			exit;
+		}
+	}
+
+	/**
 	 * Render the list table page, including header, notices, status filters and table.
 	 */
 	public function display_page() {

--- a/classes/ActionScheduler_AdminView.php
+++ b/classes/ActionScheduler_AdminView.php
@@ -63,7 +63,7 @@ class ActionScheduler_AdminView extends ActionScheduler_AdminView_Deprecated {
 	 * System Status page, and for sites where WooCommerce isn't active.
 	 */
 	public function register_menu() {
-		add_submenu_page(
+		$hook_suffix = add_submenu_page(
 			'tools.php',
 			__( 'Scheduled Actions', 'action-scheduler' ),
 			__( 'Scheduled Actions', 'action-scheduler' ),
@@ -71,6 +71,15 @@ class ActionScheduler_AdminView extends ActionScheduler_AdminView_Deprecated {
 			'action-scheduler',
 			array( $this, 'render_admin_ui' )
 		);
+		add_action( 'load-' . $hook_suffix , array( $this, 'process_admin_ui' ) );
+	}
+
+	/**
+	 * Triggers processing of any pending actions.
+	 */
+	public function process_admin_ui() {
+		$table = new ActionScheduler_ListTable( ActionScheduler::store(), ActionScheduler::logger(), ActionScheduler::runner() );
+		$table->process_actions();
 	}
 
 	/**

--- a/classes/ActionScheduler_ListTable.php
+++ b/classes/ActionScheduler_ListTable.php
@@ -462,16 +462,6 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 	 * {@inheritDoc}
 	 */
 	public function prepare_items() {
-		$this->process_bulk_action();
-
-		$this->process_row_actions();
-
-		if ( ! empty( $_REQUEST['_wp_http_referer'] ) ) {
-			// _wp_http_referer is used only on bulk actions, we remove it to keep the $_GET shorter
-			wp_redirect( remove_query_arg( array( '_wp_http_referer', '_wpnonce' ), wp_unslash( $_SERVER['REQUEST_URI'] ) ) );
-			exit;
-		}
-
 		$this->prepare_column_headers();
 
 		$per_page = $this->get_items_per_page( $this->package . '_items_per_page', $this->items_per_page );


### PR DESCRIPTION
The methods `process_bulk_action()` and `process_row_actions()` are being called after WordPress admin UI is already partially rendered as they are triggered as a callback from `add_submenu_page()`. Callbacks from `add_submenu_page()` are called after headers are already sent, so `wp_redirect()` calls here fail to actually redirect ([more info](https://wordpress.stackexchange.com/a/233769)).

Solution: process any pending actions prior to WordPress admin UI render, [using the recommended `load-*` action](https://codex.wordpress.org/Administration_Menus#Page_Hook_Suffix).