### PR TITLE
Fix php 7 deprecated notice for non static method called statically f…

### DIFF
--- a/classes/ActionScheduler_AdminHelp.php
+++ b/classes/ActionScheduler_AdminHelp.php
@@ -7,7 +7,7 @@
 class ActionScheduler_AdminHelp {
 	const SCREEN_ID = 'tools_page_action-scheduler';
 
-	public function add_help_tabs() {
+	public static function add_help_tabs() {
 		$screen = get_current_screen();
 
 		if ( ! $screen || self::SCREEN_ID != $screen->id ) {


### PR DESCRIPTION
In php 7+ calling a method statically results in a php notice. WordPress calls the current screen help tabs statically so the help tab calls should be a static function to avoid this notice:

```
Deprecated: Non-static method ActionScheduler_AdminHelp::add_help_tabs() should not be called statically in /var/www/html/wp-includes/class-wp-hook.php on line 286
```
Thanks!