### PR TITLE
make migration config a singleton

### DIFF
--- a/classes/migration/Config.php
+++ b/classes/migration/Config.php
@@ -17,6 +17,9 @@ use ActionScheduler_Store as Store;
  * A config builder for the ActionScheduler\Migration\Runner class
  */
 class Config {
+	/** @var Config */
+	private static $instance;
+
 	/** @var ActionScheduler_Store */
 	private $source_store;
 
@@ -38,7 +41,7 @@ class Config {
 	/**
 	 * Config constructor.
 	 */
-	public function __construct() {
+	private function __construct() {
 
 	}
 
@@ -105,7 +108,9 @@ class Config {
 	 * @param ActionScheduler_Store $store
 	 */
 	public function set_destination_store( Store $store ) {
-		$this->destination_store = $store;
+		if ( null === $this->destination_store ) {
+			$this->destination_store = $store;
+		}
 	}
 
 	/**
@@ -127,7 +132,9 @@ class Config {
 	 * @param ActionScheduler_Logger $logger
 	 */
 	public function set_destination_logger( Logger $logger ) {
-		$this->destination_logger = $logger;
+		if ( null === $this->destination_logger ) {
+			$this->destination_logger = $logger;
+		}
 	}
 
 	/**
@@ -164,5 +171,18 @@ class Config {
 	 */
 	public function set_progress_bar( ProgressBar $progress_bar ) {
 		$this->progress_bar = $progress_bar;
+	}
+
+	/**
+	 * Get the singleton Config object.
+	 *
+	 * @return Config
+	 */
+	public static function instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new Config();
+		}
+
+		return self::$instance;
 	}
 }

--- a/classes/migration/Controller.php
+++ b/classes/migration/Controller.php
@@ -108,7 +108,7 @@ class Controller {
 		$source_store  = $this->store_classname ? new $this->store_classname() : new \ActionScheduler_wpPostStore();
 		$source_logger = $this->logger_classname ? new $this->logger_classname() : new \ActionScheduler_wpCommentLogger();
 
-		$config = new Config();
+		$config = Config::instance();
 		$config->set_source_store( $source_store );
 		$config->set_source_logger( $source_logger );
 		$config->set_destination_store( new \ActionScheduler_DBStoreMigrator() );

--- a/tests/phpunit/jobstore/ActionScheduler_HybridStore_Test.php
+++ b/tests/phpunit/jobstore/ActionScheduler_HybridStore_Test.php
@@ -42,7 +42,7 @@ class ActionScheduler_HybridStore_Test extends ActionScheduler_UnitTestCase {
 		$source_logger      = new CommentLogger();
 		$destination_logger = new ActionScheduler_DBLogger();
 
-		$config = new Config();
+		$config = Config::instance();
 		$config->set_source_store( $source_store );
 		$config->set_source_logger( $source_logger );
 		$config->set_destination_store( $destination_store );
@@ -71,7 +71,7 @@ class ActionScheduler_HybridStore_Test extends ActionScheduler_UnitTestCase {
 		$source_logger      = new CommentLogger();
 		$destination_logger = new ActionScheduler_DBLogger();
 
-		$config = new Config();
+		$config = Config::instance();
 		$config->set_source_store( $source_store );
 		$config->set_source_logger( $source_logger );
 		$config->set_destination_store( $destination_store );
@@ -130,7 +130,7 @@ class ActionScheduler_HybridStore_Test extends ActionScheduler_UnitTestCase {
 		$source_logger      = new CommentLogger();
 		$destination_logger = new ActionScheduler_DBLogger();
 
-		$config = new Config();
+		$config = Config::instance();
 		$config->set_source_store( $source_store );
 		$config->set_source_logger( $source_logger );
 		$config->set_destination_store( $destination_store );
@@ -184,7 +184,7 @@ class ActionScheduler_HybridStore_Test extends ActionScheduler_UnitTestCase {
 		$source_logger      = new CommentLogger();
 		$destination_logger = new ActionScheduler_DBLogger();
 
-		$config = new Config();
+		$config = Config::instance();
 		$config->set_source_store( $source_store );
 		$config->set_source_logger( $source_logger );
 		$config->set_destination_store( $destination_store );
@@ -230,7 +230,7 @@ class ActionScheduler_HybridStore_Test extends ActionScheduler_UnitTestCase {
 		$source_logger      = new CommentLogger();
 		$destination_logger = new ActionScheduler_DBLogger();
 
-		$config = new Config();
+		$config = Config::instance();
 		$config->set_source_store( $source_store );
 		$config->set_source_logger( $source_logger );
 		$config->set_destination_store( $destination_store );

--- a/tests/phpunit/migration/Config_Test.php
+++ b/tests/phpunit/migration/Config_Test.php
@@ -8,25 +8,25 @@ use Action_Scheduler\Migration\Config;
  */
 class Config_Test extends ActionScheduler_UnitTestCase {
 	public function test_source_store_required() {
-		$config = new Config();
+		$config = Config::instance();
 		$this->expectException( \RuntimeException::class );
 		$config->get_source_store();
 	}
 
 	public function test_source_logger_required() {
-		$config = new Config();
+		$config = Config::instance();
 		$this->expectException( \RuntimeException::class );
 		$config->get_source_logger();
 	}
 
 	public function test_destination_store_required() {
-		$config = new Config();
+		$config = Config::instance();
 		$this->expectException( \RuntimeException::class );
 		$config->get_destination_store();
 	}
 
 	public function test_destination_logger_required() {
-		$config = new Config();
+		$config = Config::instance();
 		$this->expectException( \RuntimeException::class );
 		$config->get_destination_logger();
 	}

--- a/tests/phpunit/migration/Runner_Test.php
+++ b/tests/phpunit/migration/Runner_Test.php
@@ -26,7 +26,7 @@ class Runner_Test extends ActionScheduler_UnitTestCase {
 		$source_logger      = new CommentLogger();
 		$destination_logger = new ActionScheduler_DBLogger();
 
-		$config = new Config();
+		$config = Config::instance();
 		$config->set_source_store( $source_store );
 		$config->set_source_logger( $source_logger );
 		$config->set_destination_store( $destination_store );


### PR DESCRIPTION
Closes #360 

This PR makes the migration `Config` class a singleton object. It ensures that the first assigned store and logger objects are used when multiple actions are being migrated in the same thread.

### Testing

- Activate WC & WCS
- Deactivate AS
- Create a webhook for order created
- use `wc-smooth-generator` to generate 100 orders
- activate AS
- allow migration to complete
- check migrated actions