### PR TITLE
Don't re-hook the destination logger function which logs action created

### DIFF
--- a/classes/migration/Runner.php
+++ b/classes/migration/Runner.php
@@ -120,7 +120,6 @@ class Runner {
 		}
 
 		\ActionScheduler::logger()->hook_stored_action();
-		$this->destination_logger->hook_stored_action();
 
 		do_action( 'action_scheduler/migration_batch_complete', $action_ids );
 	}


### PR DESCRIPTION
This PR fixes the issue where subsequent migration actions are getting two `action created` logs.

<img width="858" alt="Screen Shot 2019-10-01 at 10 21 11 am" src="https://user-images.githubusercontent.com/8490476/65925734-58756900-e435-11e9-8119-d5ac1c5a3ba0.png">

_You can ignore the 000..., those are just some troubleshooting things I added locally_.

As I mentioned in https://github.com/Prospress/action-scheduler/pull/364#issuecomment-536807719, this was happening because when the next scheduled migration action is created, there is still the migrator and `$destination_logger` hooked in and so both the global logger (`\ActionScheduler::logger()`) and `$destination_logger` log the created event.

To fix that, I've removed the line that rehooks the destination logger after migration.

**This raises a question though. Isn't the purpose of the destination logger object to just migrate the existing action's logs? and if so should we be initialising the logger [here](https://github.com/Prospress/action-scheduler/blob/fix_duplicate_logs/classes/migration/Runner.php#L132)?** Put in another way should it be used to write any new logs based on events?

Looking at all the actions that are attached in the database logger init function (see below), I don't think any of them should be attached on the destination logger instance. 

https://github.com/Prospress/action-scheduler/blob/a913b85b33335a777f4dbdc7151fde29edd5b0fb/classes/abstracts/ActionScheduler_Logger.php#L48-L61