### PR TITLE
Add retries to Actions

### DIFF
--- a/classes/ActionScheduler_ActionFactory.php
+++ b/classes/ActionScheduler_ActionFactory.php
@@ -6,15 +6,18 @@
 class ActionScheduler_ActionFactory {
 
 	/**
+	 * Return action from store.
+	 *
 	 * @param string $status The action's status in the data store
 	 * @param string $hook The hook to trigger when this action runs
 	 * @param array $args Args to pass to callbacks when the hook is triggered
 	 * @param ActionScheduler_Schedule $schedule The action's schedule
 	 * @param string $group A group to put the action in
+	 * @param array  $retry Retry params
 	 *
 	 * @return ActionScheduler_Action An instance of the stored action
 	 */
-	public function get_stored_action( $status, $hook, array $args = array(), ActionScheduler_Schedule $schedule = null, $group = '' ) {
+	public function get_stored_action( $status, $hook, array $args = array(), ActionScheduler_Schedule $schedule = null, $group = '', $retry = array() ) {
 
 		switch ( $status ) {
 			case ActionScheduler_Store::STATUS_PENDING :
@@ -31,9 +34,9 @@ class ActionScheduler_ActionFactory {
 				break;
 		}
 
-		$action_class = apply_filters( 'action_scheduler_stored_action_class', $action_class, $status, $hook, $args, $schedule, $group );
+		$action_class = apply_filters( 'action_scheduler_stored_action_class', $action_class, $status, $hook, $args, $schedule, $group, $retry );
 
-		$action = new $action_class( $hook, $args, $schedule, $group );
+		$action = new $action_class( $hook, $args, $schedule, $group, $retry );
 
 		/**
 		 * Allow 3rd party code to change the instantiated action for a given hook, args, schedule and group.
@@ -44,7 +47,7 @@ class ActionScheduler_ActionFactory {
 		 * @param ActionScheduler_Schedule $schedule The instantiated action's schedule.
 		 * @param string $group The instantiated action's group.
 		 */
-		return apply_filters( 'action_scheduler_stored_action_instance', $action, $hook, $args, $schedule, $group );
+		return apply_filters( 'action_scheduler_stored_action_instance', $action, $hook, $args, $schedule, $group, $retry );
 	}
 
 	/**

--- a/classes/ActionScheduler_InvalidActionException.php
+++ b/classes/ActionScheduler_InvalidActionException.php
@@ -44,4 +44,22 @@ class ActionScheduler_InvalidActionException extends \InvalidArgumentException i
 
 		return new static( $message );
 	}
+
+	/**
+	 * Create a new exception when the action's retry isn't parsed.
+	 *
+	 * @param string $action_id The action ID with bad args.
+	 * @param array  $retry     Retry params.
+	 * @return static
+	 */
+	public static function from_retry( $action_id, $retry ) {
+		$message = sprintf(
+			/* translators: 1: action ID 2: retry */
+			__( 'Action [%1$s] has an invalid retry: %2$s', 'action-scheduler' ),
+			$action_id,
+			var_export( $retry, true )
+		);
+
+		return new static( $message );
+	}
 }

--- a/classes/ActionScheduler_ListTable.php
+++ b/classes/ActionScheduler_ListTable.php
@@ -100,6 +100,7 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 			'recurrence'  => __( 'Recurrence', 'action-scheduler' ),
 			'schedule'    => __( 'Scheduled Date', 'action-scheduler' ),
 			'log_entries' => __( 'Log', 'action-scheduler' ),
+			'retry'       => __( 'Retry', 'action-scheduler' ),
 		);
 
 		$this->sort_by = array(
@@ -585,6 +586,7 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 				'claim_id'    => $this->store->get_claim_id( $action_id ),
 				'recurrence'  => $this->get_recurrence( $action ),
 				'schedule'    => $action->get_schedule(),
+				'retry'       => $action->get_retry(),
 			);
 		}
 
@@ -608,5 +610,24 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 	 */
 	protected function get_search_box_button_text() {
 		return __( 'Search hook, args and claim ID', 'action-scheduler' );
+	}
+
+	/**
+	 * Serializes the argument of an action to render it in a human friendly format.
+	 *
+	 * @param array $row The array representation of the current row of the table
+	 *
+	 * @return string
+	 */
+	public function column_retry( array $row ) {
+		if ( empty( $row['retry'] ) ) {
+			return apply_filters( 'action_scheduler_list_table_column_retry', __( 'Not enabled', 'action-scheduler' ), $row );
+		}
+		$count = isset( $row['retry']['count'] ) ? $row['retry']['count'] : 5;
+		$failures = isset( $row['retry']['failures'] ) ? $row['retry']['failures'] : 0;
+		$row_html = sprintf( "<strong>%s</strong>: %s<br>", __( 'Count', 'action-scheduler' ), $count );
+		$row_html .= sprintf( "<strong>%s</strong>: %s", __( 'Failures', 'action-scheduler' ), $failures );
+
+		return apply_filters( 'action_scheduler_list_table_column_args', $row_html, $row );
 	}
 }

--- a/classes/ActionScheduler_ListTable.php
+++ b/classes/ActionScheduler_ListTable.php
@@ -623,9 +623,9 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 		if ( empty( $row['retry'] ) ) {
 			return apply_filters( 'action_scheduler_list_table_column_retry', __( 'Not enabled', 'action-scheduler' ), $row );
 		}
-		$count = isset( $row['retry']['count'] ) ? $row['retry']['count'] : 5;
-		$failures = isset( $row['retry']['failures'] ) ? $row['retry']['failures'] : 0;
-		$row_html = sprintf( "<strong>%s</strong>: %s<br>", __( 'Count', 'action-scheduler' ), $count );
+		$count = $row['retry']->get_limit();
+		$failures = $row['retry']->get_fails();
+		$row_html = sprintf( "<strong>%s</strong>: %s<br>", __( 'Retry count', 'action-scheduler' ), $count );
 		$row_html .= sprintf( "<strong>%s</strong>: %s", __( 'Failures', 'action-scheduler' ), $failures );
 
 		return apply_filters( 'action_scheduler_list_table_column_args', $row_html, $row );

--- a/classes/ActionScheduler_Retry.php
+++ b/classes/ActionScheduler_Retry.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * Class ActionScheduler_Retry
+ */
+class ActionScheduler_Retry {
+	/** @var int */
+	protected $limit;
+	/** @var int */
+	protected $fails;
+
+	/**
+	 * ActionScheduler_Retry constructor.
+	 *
+	 * @param $limit int Number of retries to attempt.
+	 * @param $fails int Track failures.
+	 */
+	public function __construct( $limit = 0, $fails = 0 ) {
+		$this->set_limit( $limit );
+		$this->set_fails( $fails );
+	}
+
+	/**
+	 * @return int
+	 */
+	public function get_limit() {
+		return $this->limit;
+	}
+
+	/**
+	 * @param int $limit
+	 */
+	public function set_limit( $limit ) {
+		$this->limit = abs( intval( $limit ) );
+	}
+
+	/**
+	 * @return int
+	 */
+	public function get_fails() {
+		return $this->fails;
+	}
+
+	/**
+	 * @param int $fails
+	 */
+	public function set_fails( $fails ) {
+		$this->fails = abs( intval( $fails ) );
+	}
+
+	/**
+	 * Increment the failures and check that the failures <= limit.
+	 * @return bool
+	 */
+	public function is_valid_after_fail() {
+		// Increment the failures.
+		$this->fails ++;
+
+		// Evaluate attempts vs. failures.
+		if ( $this->fails > $this->limit ) {
+			return false;
+		}
+		return true;
+	}
+}

--- a/classes/abstracts/ActionScheduler_Abstract_ListTable.php
+++ b/classes/abstracts/ActionScheduler_Abstract_ListTable.php
@@ -549,7 +549,7 @@ abstract class ActionScheduler_Abstract_ListTable extends WP_List_Table {
 	}
 
 	/**
-	 * Default column formatting, it will escape everythig for security.
+	 * Default column formatting, it will escape everything for security.
 	 */
 	public function column_default( $item, $column_name ) {
 		$column_html = esc_html( $item[ $column_name ] );

--- a/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php
+++ b/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php
@@ -114,7 +114,7 @@ abstract class ActionScheduler_Abstract_QueueRunner extends ActionScheduler_Abst
 		// schedule when the webhook should be retried (in seconds).  Grabbing the filter return first and using that
 		// unless it is not a number then defaulting to algorithm.
 		$backoff = apply_filters( 'action_scheduler_retry_backoff', null, $failures, $action );
-		$backoff = is_numeric( $backoff ) ? intval( $backoff ) : ( 2 ** $failures ) * 100;
+		$backoff = is_numeric( $backoff ) ? intval( $backoff ) : pow( 2, $failures ) * 100;
 		return ActionScheduler::factory()->single(
 			$action->get_hook(),
 			$action->get_args(),

--- a/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php
+++ b/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php
@@ -68,7 +68,9 @@ abstract class ActionScheduler_Abstract_QueueRunner extends ActionScheduler_Abst
 		} catch ( Exception $e ) {
 			if ( $valid_action ) {
 				$this->store->mark_failure( $action_id );
-				$this->retry_action( $action );
+				if ( isset( $action ) ) {
+					$this->retry_action( $action );
+				}
 				do_action( 'action_scheduler_failed_execution', $action_id, $e, $context );
 			} else {
 				do_action( 'action_scheduler_failed_validation', $action_id, $e, $context );
@@ -96,7 +98,7 @@ abstract class ActionScheduler_Abstract_QueueRunner extends ActionScheduler_Abst
 		if ( isset( $action ) && is_a( $action, 'ActionScheduler_Action' ) && $action->get_schedule()->is_recurring() ) {
 			return;
 		}
-		// Return when $retry is empty
+		// Return when $retry is empty.
 		$retry = $action->get_retry();
 		if ( empty( $retry ) ) {
 			return;

--- a/classes/abstracts/ActionScheduler_Store.php
+++ b/classes/abstracts/ActionScheduler_Store.php
@@ -214,20 +214,6 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 	}
 
 	/**
-	 * Validate a ActionScheduler_Action retry parameter.
-	 *
-	 * @param array $retry Retry parameters.
-	 * @param int   $action_id The action ID.
-	 *
-	 * @throws ActionScheduler_InvalidActionException When the schedule is invalid.
-	 */
-	protected function validate_retry( $retry, $action_id ) {
-		if ( ! is_array( $retry ) ) {
-			throw ActionScheduler_InvalidActionException::from_retry( $action_id, $retry );
-		}
-	}
-
-	/**
 	 * InnoDB indexes have a maximum size of 767 bytes by default, which is only 191 characters with utf8mb4.
 	 *
 	 * Previously, AS wasn't concerned about args length, as we used the (unindex) post_content column. However,

--- a/classes/abstracts/ActionScheduler_Store.php
+++ b/classes/abstracts/ActionScheduler_Store.php
@@ -214,6 +214,20 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 	}
 
 	/**
+	 * Validate a ActionScheduler_Action retry parameter.
+	 *
+	 * @param array $retry Retry parameters.
+	 * @param int   $action_id The action ID.
+	 *
+	 * @throws ActionScheduler_InvalidActionException When the schedule is invalid.
+	 */
+	protected function validate_retry( $retry, $action_id ) {
+		if ( ! is_array( $retry ) ) {
+			throw ActionScheduler_InvalidActionException::from_retry( $action_id, $retry );
+		}
+	}
+
+	/**
 	 * InnoDB indexes have a maximum size of 767 bytes by default, which is only 191 characters with utf8mb4.
 	 *
 	 * Previously, AS wasn't concerned about args length, as we used the (unindex) post_content column. However,

--- a/classes/actions/ActionScheduler_Action.php
+++ b/classes/actions/ActionScheduler_Action.php
@@ -9,8 +9,10 @@ class ActionScheduler_Action {
 	/** @var ActionScheduler_Schedule */
 	protected $schedule = NULL;
 	protected $group = '';
+	/** @var ActionScheduler_Retry */
+	protected $retry = NULL;
 
-	public function __construct( $hook, array $args = array(), ActionScheduler_Schedule $schedule = NULL, $group = '', $retry = array() ) {
+	public function __construct( $hook, array $args = array(), ActionScheduler_Schedule $schedule = NULL, $group = '', $retry = NULL ) {
 		$schedule = empty( $schedule ) ? new ActionScheduler_NullSchedule() : $schedule;
 		$this->set_hook($hook);
 		$this->set_schedule($schedule);
@@ -75,16 +77,14 @@ class ActionScheduler_Action {
 	}
 
 	/**
-	 * @param array $retry
+	 * @param ActionScheduler_Retry $retry
 	 */
 	protected function set_retry( $retry ) {
-		if ( is_array( $retry ) ) {
-			$this->retry = $retry;
-		}
+		$this->retry = $retry;
 	}
 
 	/**
-	 * @return array
+	 * @return ActionScheduler_Retry
 	 */
 	public function get_retry() {
 		return $this->retry;

--- a/classes/actions/ActionScheduler_Action.php
+++ b/classes/actions/ActionScheduler_Action.php
@@ -10,12 +10,13 @@ class ActionScheduler_Action {
 	protected $schedule = NULL;
 	protected $group = '';
 
-	public function __construct( $hook, array $args = array(), ActionScheduler_Schedule $schedule = NULL, $group = '' ) {
+	public function __construct( $hook, array $args = array(), ActionScheduler_Schedule $schedule = NULL, $group = '', $retry = array() ) {
 		$schedule = empty( $schedule ) ? new ActionScheduler_NullSchedule() : $schedule;
 		$this->set_hook($hook);
 		$this->set_schedule($schedule);
 		$this->set_args($args);
 		$this->set_group($group);
+		$this->set_retry( $retry );
 	}
 
 	public function execute() {
@@ -71,5 +72,21 @@ class ActionScheduler_Action {
 	 */
 	public function is_finished() {
 		return FALSE;
+	}
+
+	/**
+	 * @param array $retry
+	 */
+	protected function set_retry( $retry ) {
+		if ( is_array( $retry ) ) {
+			$this->retry = $retry;
+		}
+	}
+
+	/**
+	 * @return array
+	 */
+	public function get_retry() {
+		return $this->retry;
 	}
 }

--- a/classes/actions/ActionScheduler_CanceledAction.php
+++ b/classes/actions/ActionScheduler_CanceledAction.php
@@ -13,9 +13,10 @@ class ActionScheduler_CanceledAction extends ActionScheduler_FinishedAction {
 	 * @param array $args
 	 * @param ActionScheduler_Schedule $schedule
 	 * @param string $group
+	 * @param ActionScheduler_Retry $retry
 	 */
-	public function __construct( $hook, array $args = array(), ActionScheduler_Schedule $schedule = null, $group = '' ) {
-		parent::__construct( $hook, $args, $schedule, $group );
+	public function __construct( $hook, array $args = array(), ActionScheduler_Schedule $schedule = null, $group = '', $retry = null ) {
+		parent::__construct( $hook, $args, $schedule, $group, $retry );
 		if ( is_null( $schedule ) ) {
 			$this->set_schedule( new ActionScheduler_NullSchedule() );
 		}

--- a/classes/actions/ActionScheduler_NullAction.php
+++ b/classes/actions/ActionScheduler_NullAction.php
@@ -13,4 +13,3 @@ class ActionScheduler_NullAction extends ActionScheduler_Action {
 		// don't execute
 	}
 }
- 

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -142,6 +142,11 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 
 		if ( ! empty( $data->extended_args ) ) {
 			$extended_args = json_decode( $data->extended_args, true );
+			// Stored data from before the extended usage
+			if ( ! is_array( $extended_args ) ) {
+				$data->args = $data->extended_args;
+				$extended_args = array();
+			}
 			if ( array_key_exists( 'args', $extended_args ) ) {
 				$data->args = $extended_args['args'];
 			}

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -29,7 +29,7 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 	 * Save an action.
 	 *
 	 * @param ActionScheduler_Action $action Action object.
-	 * @param DateTime               $date Optional schedule date. Default null.
+	 * @param \DateTime              $date Optional schedule date. Default null.
 	 *
 	 * @return int Action ID.
 	 */
@@ -40,21 +40,7 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 
 			/** @var \wpdb $wpdb */
 			global $wpdb;
-			$data = [
-				'hook'                 => $action->get_hook(),
-				'status'               => ( $action->is_finished() ? self::STATUS_COMPLETE : self::STATUS_PENDING ),
-				'scheduled_date_gmt'   => $this->get_scheduled_date_string( $action, $date ),
-				'scheduled_date_local' => $this->get_scheduled_date_string_local( $action, $date ),
-				'schedule'             => serialize( $action->get_schedule() ),
-				'group_id'             => $this->get_group_id( $action->get_group() ),
-			];
-			$args = wp_json_encode( $action->get_args() );
-			if ( strlen( $args ) <= static::$max_index_length ) {
-				$data['args'] = $args;
-			} else {
-				$data['args']          = $this->hash_args( $args );
-				$data['extended_args'] = $args;
-			}
+			$data = $this->convert_action_to_db_format( $action, $date );
 
 			$table_name = ! empty( $wpdb->actionscheduler_actions ) ? $wpdb->actionscheduler_actions : $wpdb->prefix . 'actionscheduler_actions';
 			$wpdb->insert( $table_name, $data );
@@ -62,8 +48,7 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 
 			if ( is_wp_error( $action_id ) ) {
 				throw new RuntimeException( $action_id->get_error_message() );
-			}
-			elseif ( empty( $action_id ) ) {
+			} elseif ( empty( $action_id ) ) {
 				throw new RuntimeException( $wpdb->last_error ? $wpdb->last_error : __( 'Database error.', 'action-scheduler' ) );
 			}
 
@@ -156,7 +141,13 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 		}
 
 		if ( ! empty( $data->extended_args ) ) {
-			$data->args = $data->extended_args;
+			$extended_args = json_decode( $data->extended_args, true );
+			if ( array_key_exists( 'args', $extended_args ) ) {
+				$data->args = $extended_args['args'];
+			}
+			if ( array_key_exists( 'retry', $extended_args ) ) {
+				$data->retry = $extended_args['retry'];
+			}
 			unset( $data->extended_args );
 		}
 
@@ -191,16 +182,18 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 		$hook     = $data->hook;
 		$args     = json_decode( $data->args, true );
 		$schedule = unserialize( $data->schedule );
+		$retry    = isset( $data->retry ) ? $data->retry : array();
 
 		$this->validate_args( $args, $data->action_id );
 		$this->validate_schedule( $schedule, $data->action_id );
+		$this->validate_retry( $retry, $data->action_id );
 
 		if ( empty( $schedule ) ) {
 			$schedule = new ActionScheduler_NullSchedule();
 		}
 		$group = $data->group ? $data->group : '';
 
-		return ActionScheduler::factory()->get_stored_action( $data->status, $data->hook, $args, $schedule, $group );
+		return ActionScheduler::factory()->get_stored_action( $data->status, $data->hook, $args, $schedule, $group, $retry );
 	}
 
 	/**
@@ -841,5 +834,40 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 		} else {
 			return $status;
 		}
+	}
+
+	/**
+	 * Convert an action to an array used by $wpdb.
+	 *
+	 * @param ActionScheduler_Action $action The Action.
+	 * @param DateTime|null          $date   The date.
+	 *
+	 * @return array
+	 */
+	private function convert_action_to_db_format( ActionScheduler_Action $action, \DateTime $date = null ) {
+		$data = array(
+			'hook'                 => $action->get_hook(),
+			'status'               => ( $action->is_finished() ? self::STATUS_COMPLETE : self::STATUS_PENDING ),
+			'scheduled_date_gmt'   => $this->get_scheduled_date_string( $action, $date ),
+			'scheduled_date_local' => $this->get_scheduled_date_string_local( $action, $date ),
+			'schedule'             => serialize( $action->get_schedule() ),
+			'group_id'             => $this->get_group_id( $action->get_group() ),
+		);
+		$args = wp_json_encode( $action->get_args() );
+		if ( strlen( $args ) <= static::$max_index_length ) {
+			$data['args'] = $args;
+		} else {
+			$data['args']          = $this->hash_args( $args );
+			$data['extended_args'] = wp_json_encode(
+				array(
+					'args' => $args,
+					'retry' => $action->get_retry(),
+				)
+			);
+		}
+		if ( empty( $data['extended_args'] ) ) {
+			$data['extended_args'] = wp_json_encode( array( 'retry' => $action->get_retry() ) );
+		}
+		return $data;
 	}
 }

--- a/classes/data-stores/ActionScheduler_wpPostStore.php
+++ b/classes/data-stores/ActionScheduler_wpPostStore.php
@@ -20,11 +20,12 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 			$post_id = $this->save_post_array( $post_array );
 			$this->save_post_schedule( $post_id, $action->get_schedule() );
 			$this->save_action_group( $post_id, $action->get_group() );
-			$retry = empty( $action->get_retry() )
+			$retry = $action->get_retry();
+			$retry = empty( $retry )
 				? array()
 				: array(
-					'limit' => $action->get_retry()->get_limit(),
-					'fails' => $action->get_retry()->get_fails(),
+					'limit' => $retry->get_limit(),
+					'fails' => $retry->get_fails(),
 				);
 			$this->save_action_retry( $post_id, $retry );
 			do_action( 'action_scheduler_stored_action', $post_id );
@@ -173,7 +174,7 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 			? null
 			: new ActionScheduler_Retry(
 				isset( $retry->limit ) ? $retry->limit : 0,
-				isset( $retry->fails ) ? $retry->fails : 0,
+				isset( $retry->fails ) ? $retry->fails : 0
 			);
 
 		return ActionScheduler::factory()->get_stored_action( $this->get_action_status_by_post_status( $post->post_status ), $hook, $args, $schedule, $group, $retry );

--- a/classes/data-stores/ActionScheduler_wpPostStore.php
+++ b/classes/data-stores/ActionScheduler_wpPostStore.php
@@ -159,11 +159,11 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 		$schedule = get_post_meta( $post->ID, self::SCHEDULE_META_KEY, true );
 		$this->validate_schedule( $schedule, $post->ID );
 
-		$group = wp_get_object_terms( $post->ID, self::GROUP_TAXONOMY, array('fields' => 'names') );
-		$group = empty( $group ) ? '' : reset($group);
+		$group = wp_get_object_terms( $post->ID, self::GROUP_TAXONOMY, array( 'fields' => 'names' ) );
+		$group = empty( $group ) ? '' : reset( $group );
 
-		$retry = get_post_meta( $post->ID, self::RETRY_META_KEY, true);
-		$retry = $this->validate_retry( json_decode( $retry, true ), $post->ID );
+		$retry = json_decode( get_post_meta( $post->ID, self::RETRY_META_KEY, true ), true );
+		$this->validate_retry( $retry, $post->ID );
 
 		return ActionScheduler::factory()->get_stored_action( $this->get_action_status_by_post_status( $post->post_status ), $hook, $args, $schedule, $group, $retry );
 	}

--- a/classes/data-stores/ActionScheduler_wpPostStore.php
+++ b/classes/data-stores/ActionScheduler_wpPostStore.php
@@ -163,7 +163,7 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 		$group = empty( $group ) ? '' : reset($group);
 
 		$retry = get_post_meta( $post->ID, self::RETRY_META_KEY, true);
-		$retry = $this->validate_retry( json_decode( $retry ), $post->ID );
+		$retry = $this->validate_retry( json_decode( $retry, true ), $post->ID );
 
 		return ActionScheduler::factory()->get_stored_action( $this->get_action_status_by_post_status( $post->post_status ), $hook, $args, $schedule, $group, $retry );
 	}

--- a/classes/schema/ActionScheduler_StoreSchema.php
+++ b/classes/schema/ActionScheduler_StoreSchema.php
@@ -48,6 +48,8 @@ class ActionScheduler_StoreSchema extends ActionScheduler_Abstract_Schema {
 				        last_attempt_local datetime NOT NULL default '0000-00-00 00:00:00',
 				        claim_id bigint(20) unsigned NOT NULL default '0',
 				        extended_args varchar(8000) DEFAULT NULL,
+				        retry_limit int(11) unsigned DEFAULT NULL,
+				        retry_fails int(11) unsigned DEFAULT NULL,
 				        PRIMARY KEY  (action_id),
 				        KEY hook (hook($max_index_length)),
 				        KEY status (status),

--- a/functions.php
+++ b/functions.php
@@ -50,11 +50,11 @@ function as_schedule_single_action( $timestamp, $hook, $args = array(), $group =
  *
  * @return int The action ID.
  */
-function as_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, $args = array(), $group = '', $retry = array() ) {
+function as_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, $args = array(), $group = '' ) {
 	if ( ! ActionScheduler::is_initialized( __FUNCTION__ ) ) {
 		return 0;
 	}
-	return ActionScheduler::factory()->recurring( $hook, $args, $timestamp, $interval_in_seconds, $group, $retry );
+	return ActionScheduler::factory()->recurring( $hook, $args, $timestamp, $interval_in_seconds, $group );
 }
 
 /**

--- a/functions.php
+++ b/functions.php
@@ -10,10 +10,10 @@
  * @param string $hook The hook to trigger.
  * @param array  $args Arguments to pass when the hook triggers.
  * @param string $group The group to assign this job to.
- * @param array  $retry Handle retries in the event of failure.
+ * @param int    $retry How many retries to attempt in the event of failure.
  * @return int The action ID.
  */
-function as_enqueue_async_action( $hook, $args = array(), $group = '', $retry = array() ) {
+function as_enqueue_async_action( $hook, $args = array(), $group = '', $retry = null ) {
 	if ( ! ActionScheduler::is_initialized( __FUNCTION__ ) ) {
 		return 0;
 	}
@@ -27,11 +27,11 @@ function as_enqueue_async_action( $hook, $args = array(), $group = '', $retry = 
  * @param string $hook The hook to trigger.
  * @param array $args Arguments to pass when the hook triggers.
  * @param string $group The group to assign this job to.
- * @param array  $retry Handle retries in the event of failure.
+ * @param int $retry How many retries to attempt in the event of failure.
  *
  * @return int The action ID.
  */
-function as_schedule_single_action( $timestamp, $hook, $args = array(), $group = '', $retry = array() ) {
+function as_schedule_single_action( $timestamp, $hook, $args = array(), $group = '', $retry = null ) {
 	if ( ! ActionScheduler::is_initialized( __FUNCTION__ ) ) {
 		return 0;
 	}
@@ -46,7 +46,6 @@ function as_schedule_single_action( $timestamp, $hook, $args = array(), $group =
  * @param string $hook The hook to trigger.
  * @param array $args Arguments to pass when the hook triggers.
  * @param string $group The group to assign this job to.
- * @param array  $retry Handle retries in the event of failure.
  *
  * @return int The action ID.
  */
@@ -77,15 +76,14 @@ function as_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, 
  * @param string $hook The hook to trigger.
  * @param array $args Arguments to pass when the hook triggers.
  * @param string $group The group to assign this job to.
- * @param array  $retry Handle retries in the event of failure.
  *
  * @return int The action ID.
  */
-function as_schedule_cron_action( $timestamp, $schedule, $hook, $args = array(), $group = '', $retry = array() ) {
+function as_schedule_cron_action( $timestamp, $schedule, $hook, $args = array(), $group = '' ) {
 	if ( ! ActionScheduler::is_initialized( __FUNCTION__ ) ) {
 		return 0;
 	}
-	return ActionScheduler::factory()->cron( $hook, $args, $timestamp, $schedule, $group, $retry );
+	return ActionScheduler::factory()->cron( $hook, $args, $timestamp, $schedule, $group );
 }
 
 /**

--- a/functions.php
+++ b/functions.php
@@ -10,13 +10,14 @@
  * @param string $hook The hook to trigger.
  * @param array  $args Arguments to pass when the hook triggers.
  * @param string $group The group to assign this job to.
+ * @param array  $retry Handle retries in the event of failure.
  * @return int The action ID.
  */
-function as_enqueue_async_action( $hook, $args = array(), $group = '' ) {
+function as_enqueue_async_action( $hook, $args = array(), $group = '', $retry = array() ) {
 	if ( ! ActionScheduler::is_initialized( __FUNCTION__ ) ) {
 		return 0;
 	}
-	return ActionScheduler::factory()->async( $hook, $args, $group );
+	return ActionScheduler::factory()->async( $hook, $args, $group, $retry );
 }
 
 /**
@@ -26,14 +27,15 @@ function as_enqueue_async_action( $hook, $args = array(), $group = '' ) {
  * @param string $hook The hook to trigger.
  * @param array $args Arguments to pass when the hook triggers.
  * @param string $group The group to assign this job to.
+ * @param array  $retry Handle retries in the event of failure.
  *
  * @return int The action ID.
  */
-function as_schedule_single_action( $timestamp, $hook, $args = array(), $group = '' ) {
+function as_schedule_single_action( $timestamp, $hook, $args = array(), $group = '', $retry = array() ) {
 	if ( ! ActionScheduler::is_initialized( __FUNCTION__ ) ) {
 		return 0;
 	}
-	return ActionScheduler::factory()->single( $hook, $args, $timestamp, $group );
+	return ActionScheduler::factory()->single( $hook, $args, $timestamp, $group, $retry );
 }
 
 /**
@@ -44,14 +46,15 @@ function as_schedule_single_action( $timestamp, $hook, $args = array(), $group =
  * @param string $hook The hook to trigger.
  * @param array $args Arguments to pass when the hook triggers.
  * @param string $group The group to assign this job to.
+ * @param array  $retry Handle retries in the event of failure.
  *
  * @return int The action ID.
  */
-function as_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, $args = array(), $group = '' ) {
+function as_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, $args = array(), $group = '', $retry = array() ) {
 	if ( ! ActionScheduler::is_initialized( __FUNCTION__ ) ) {
 		return 0;
 	}
-	return ActionScheduler::factory()->recurring( $hook, $args, $timestamp, $interval_in_seconds, $group );
+	return ActionScheduler::factory()->recurring( $hook, $args, $timestamp, $interval_in_seconds, $group, $retry );
 }
 
 /**
@@ -74,14 +77,15 @@ function as_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, 
  * @param string $hook The hook to trigger.
  * @param array $args Arguments to pass when the hook triggers.
  * @param string $group The group to assign this job to.
+ * @param array  $retry Handle retries in the event of failure.
  *
  * @return int The action ID.
  */
-function as_schedule_cron_action( $timestamp, $schedule, $hook, $args = array(), $group = '' ) {
+function as_schedule_cron_action( $timestamp, $schedule, $hook, $args = array(), $group = '', $retry = array() ) {
 	if ( ! ActionScheduler::is_initialized( __FUNCTION__ ) ) {
 		return 0;
 	}
-	return ActionScheduler::factory()->cron( $hook, $args, $timestamp, $schedule, $group );
+	return ActionScheduler::factory()->cron( $hook, $args, $timestamp, $schedule, $group, $retry );
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "action-scheduler",
-  "version": "3.0.0",
+  "version": "3.1.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/tests/phpunit/jobstore/ActionScheduler_DBStore_Test.php
+++ b/tests/phpunit/jobstore/ActionScheduler_DBStore_Test.php
@@ -29,7 +29,8 @@ class ActionScheduler_DBStore_Test extends ActionScheduler_UnitTestCase {
 	public function test_retrieve_action() {
 		$time      = as_get_datetime_object();
 		$schedule  = new ActionScheduler_SimpleSchedule( $time );
-		$action    = new ActionScheduler_Action( 'my_hook', [], $schedule, 'my_group' );
+		$retry     = array( 'count' => 1 );
+		$action    = new ActionScheduler_Action( 'my_hook', [], $schedule, 'my_group', $retry );
 		$store     = new ActionScheduler_DBStore();
 		$action_id = $store->save_action( $action );
 
@@ -38,6 +39,7 @@ class ActionScheduler_DBStore_Test extends ActionScheduler_UnitTestCase {
 		$this->assertEqualSets( $action->get_args(), $retrieved->get_args() );
 		$this->assertEquals( $action->get_schedule()->get_date()->format( 'U' ), $retrieved->get_schedule()->get_date()->format( 'U' ) );
 		$this->assertEquals( $action->get_group(), $retrieved->get_group() );
+		$this->assertEquals( $action->get_retry(), $retrieved->get_retry() );
 	}
 
 	public function test_cancel_action() {

--- a/tests/phpunit/jobstore/ActionScheduler_DBStore_Test.php
+++ b/tests/phpunit/jobstore/ActionScheduler_DBStore_Test.php
@@ -29,7 +29,7 @@ class ActionScheduler_DBStore_Test extends ActionScheduler_UnitTestCase {
 	public function test_retrieve_action() {
 		$time      = as_get_datetime_object();
 		$schedule  = new ActionScheduler_SimpleSchedule( $time );
-		$retry     = array( 'count' => 1 );
+		$retry     = new ActionScheduler_Retry( 1 );
 		$action    = new ActionScheduler_Action( 'my_hook', [], $schedule, 'my_group', $retry );
 		$store     = new ActionScheduler_DBStore();
 		$action_id = $store->save_action( $action );
@@ -39,7 +39,8 @@ class ActionScheduler_DBStore_Test extends ActionScheduler_UnitTestCase {
 		$this->assertEqualSets( $action->get_args(), $retrieved->get_args() );
 		$this->assertEquals( $action->get_schedule()->get_date()->format( 'U' ), $retrieved->get_schedule()->get_date()->format( 'U' ) );
 		$this->assertEquals( $action->get_group(), $retrieved->get_group() );
-		$this->assertEquals( $action->get_retry(), $retrieved->get_retry() );
+		$this->assertEquals( $action->get_retry()->get_limit(), $retrieved->get_retry()->get_limit() );
+		$this->assertEquals( $action->get_retry()->get_fails(), $retrieved->get_retry()->get_fails() );
 	}
 
 	public function test_cancel_action() {

--- a/tests/phpunit/jobstore/ActionScheduler_wpPostStore_Test.php
+++ b/tests/phpunit/jobstore/ActionScheduler_wpPostStore_Test.php
@@ -28,17 +28,19 @@ class ActionScheduler_wpPostStore_Test extends ActionScheduler_UnitTestCase {
 	}
 
 	public function test_retrieve_action() {
-		$time = as_get_datetime_object();
-		$schedule = new ActionScheduler_SimpleSchedule($time);
-		$action = new ActionScheduler_Action('my_hook', array(), $schedule, 'my_group');
-		$store = new ActionScheduler_wpPostStore();
-		$action_id = $store->save_action($action);
+		$time      = as_get_datetime_object();
+		$schedule  = new ActionScheduler_SimpleSchedule( $time );
+		$retry     = array( 'count' => 1 );
+		$action    = new ActionScheduler_Action( 'my_hook', array(), $schedule, 'my_group', $retry );
+		$store     = new ActionScheduler_wpPostStore();
+		$action_id = $store->save_action( $action );
 
-		$retrieved = $store->fetch_action($action_id);
-		$this->assertEquals($action->get_hook(), $retrieved->get_hook());
-		$this->assertEqualSets($action->get_args(), $retrieved->get_args());
+		$retrieved = $store->fetch_action( $action_id );
+		$this->assertEquals( $action->get_hook(), $retrieved->get_hook() );
+		$this->assertEqualSets( $action->get_args(), $retrieved->get_args() );
 		$this->assertEquals( $action->get_schedule()->get_date()->getTimestamp(), $retrieved->get_schedule()->get_date()->getTimestamp() );
-		$this->assertEquals($action->get_group(), $retrieved->get_group());
+		$this->assertEquals( $action->get_group(), $retrieved->get_group() );
+		$this->assertEquals( $action->get_retry(), $retrieved->get_retry() );
 	}
 
 	/**

--- a/tests/phpunit/jobstore/ActionScheduler_wpPostStore_Test.php
+++ b/tests/phpunit/jobstore/ActionScheduler_wpPostStore_Test.php
@@ -30,7 +30,7 @@ class ActionScheduler_wpPostStore_Test extends ActionScheduler_UnitTestCase {
 	public function test_retrieve_action() {
 		$time      = as_get_datetime_object();
 		$schedule  = new ActionScheduler_SimpleSchedule( $time );
-		$retry     = array( 'count' => 1 );
+		$retry     = new ActionScheduler_Retry( 1 );
 		$action    = new ActionScheduler_Action( 'my_hook', array(), $schedule, 'my_group', $retry );
 		$store     = new ActionScheduler_wpPostStore();
 		$action_id = $store->save_action( $action );
@@ -40,7 +40,8 @@ class ActionScheduler_wpPostStore_Test extends ActionScheduler_UnitTestCase {
 		$this->assertEqualSets( $action->get_args(), $retrieved->get_args() );
 		$this->assertEquals( $action->get_schedule()->get_date()->getTimestamp(), $retrieved->get_schedule()->get_date()->getTimestamp() );
 		$this->assertEquals( $action->get_group(), $retrieved->get_group() );
-		$this->assertEquals( $action->get_retry(), $retrieved->get_retry() );
+		$this->assertEquals( $action->get_retry()->get_limit(), $retrieved->get_retry()->get_limit() );
+		$this->assertEquals( $action->get_retry()->get_fails(), $retrieved->get_retry()->get_fails() );
 	}
 
 	/**

--- a/tests/phpunit/runner/ActionScheduler_QueueRunner_Test.php
+++ b/tests/phpunit/runner/ActionScheduler_QueueRunner_Test.php
@@ -355,12 +355,11 @@ class ActionScheduler_QueueRunner_Test extends ActionScheduler_UnitTestCase {
 			->getMock();
 		$mock->expects( $this->once() )
 			->method( 'backoff' )
-			->with( null, 1, $this->anything() )
+			->with(  200, $this->anything() )
 			->willReturn( 1 );
-		add_action( 'action_scheduler_retry_backoff', array( $mock, 'backoff' ), 10, 3 );
+		add_action( 'action_scheduler_retry_backoff', array( $mock, 'backoff' ), 10, 2 );
 		$schedule = new ActionScheduler_SimpleSchedule( as_get_datetime_object( '1 day ago' ) );
-
-		$retry = array( 'count' => 1 );
+		$retry = new ActionScheduler_Retry( 1 );
 		$action = new ActionScheduler_Action( $random, array( $random ), $schedule, '', $retry );
 		$store->save_action( $action );
 


### PR DESCRIPTION
Adds an optional field to the ActionScheduler API for a retry parameter.  (For non-recurring actions).

```php
// For example, this tries `do_work` 1 time (if it fails the first time).
as_enqueue_async_action( 'do_work', [], '', 1 );
```

Exceptions thrown by an Action schedule a new Action (with the same hook and args) on an exponential backoff algorithm.

Tests included.

- [x] Update the API
- [x] Update store
   - wpPostStore
      - [x] `save_action()`
      - [x] `fetch_action()`
   - DBStore
      - [x] `save_action()`
      - [x] `fetch_action()`
- [x] Implement retries in QueueRunner
- [x] Update UI
- [x] Ensure backwards compatibility
- [x] Add tests