### PR TITLE
Remove the NOT NULL from date fields

### DIFF
--- a/classes/abstracts/ActionScheduler_Abstract_Schema.php
+++ b/classes/abstracts/ActionScheduler_Abstract_Schema.php
@@ -18,6 +18,11 @@ abstract class ActionScheduler_Abstract_Schema {
 	protected $schema_version = 1;
 
 	/**
+	 * @var string Schema version stored in database.
+	 */
+	protected $db_version;
+
+	/**
 	 * @var array Names of tables that will be registered by this class.
 	 */
 	protected $tables = [];
@@ -42,6 +47,13 @@ abstract class ActionScheduler_Abstract_Schema {
 		// create the tables
 		if ( $this->schema_update_required() || $force_update ) {
 			foreach ( $this->tables as $table ) {
+				/**
+				 * Allow custom processing before updating a table schema.
+				 *
+				 * @param string $table Name of table being updated.
+				 * @param string $db_version Existing version of the table being updated.
+				 */
+				do_action( 'action_scheduler_before_schema_update', $table, $this->db_version );
 				$this->update_table( $table );
 			}
 			$this->mark_schema_update_complete();
@@ -63,11 +75,11 @@ abstract class ActionScheduler_Abstract_Schema {
 	 * @return bool
 	 */
 	private function schema_update_required() {
-		$option_name         = 'schema-' . static::class;
-		$version_found_in_db = get_option( $option_name, 0 );
+		$option_name      = 'schema-' . static::class;
+		$this->db_version = get_option( $option_name, 0 );
 
 		// Check for schema option stored by the Action Scheduler Custom Tables plugin in case site has migrated from that plugin with an older schema
-		if ( 0 === $version_found_in_db ) {
+		if ( 0 === $this->db_version ) {
 
 			$plugin_option_name = 'schema-';
 
@@ -80,12 +92,12 @@ abstract class ActionScheduler_Abstract_Schema {
 					break;
 			}
 
-			$version_found_in_db = get_option( $plugin_option_name, 0 );
+			$this->db_version = get_option( $plugin_option_name, 0 );
 
 			delete_option( $plugin_option_name );
 		}
 
-		return version_compare( $version_found_in_db, $this->schema_version, '<' );
+		return version_compare( $this->db_version, $this->schema_version, '<' );
 	}
 
 	/**

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -161,6 +161,19 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 			unset( $data->extended_args );
 		}
 
+		// Convert NULL dates to zero dates.
+		$date_fields = [
+			'scheduled_date_gmt',
+			'scheduled_date_local',
+			'last_attempt_gmt',
+			'last_attempt_gmt'
+		];
+		foreach( $date_fields as $date_field ) {
+			if ( is_null( $data->$date_field ) ) {
+				$data->$date_field = ActionScheduler_StoreSchema::DEFAULT_DATE;
+			}
+		}
+
 		try {
 			$action = $this->make_action_from_db_record( $data );
 		} catch ( ActionScheduler_InvalidActionException $exception ) {
@@ -579,16 +592,17 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 		}
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		$table_name = $wpdb->prefix . 'actionscheduler_actions';
-		$table_list = $wpdb->get_col( "SHOW TABLES LIKE '{$table_name}'" );
+		$table_name   = $wpdb->prefix . 'actionscheduler_actions';
+		$table_list   = $wpdb->get_col( "SHOW TABLES LIKE '${table_name}'" );
+		$default_date = ActionScheduler_StoreSchema::DEFAULT_DATE;
 		if ( ! empty( $table_list ) ) {
-			$query = "ALTER TABLE
-				MODIFY COLUMN scheduled_date_gmt datetime NULL default '0000-00-00 00:00:00',
-				MODIFY COLUMN scheduled_date_local datetime NULL default '0000-00-00 00:00:00',
-				MODIFY COLUMN last_attempt_gmt datetime NULL default '0000-00-00 00:00:00',
-				MODIFY COLUMN last_attempt_local datetime NULL default '0000-00-00 00:00:00'
+			$query = "ALTER TABLE ${table_name}
+				MODIFY COLUMN scheduled_date_gmt datetime NULL default '${default_date}',
+				MODIFY COLUMN scheduled_date_local datetime NULL default '${default_date}',
+				MODIFY COLUMN last_attempt_gmt datetime NULL default '${default_date}',
+				MODIFY COLUMN last_attempt_local datetime NULL default '${default_date}'
 			";
-			$wpdb->query($query);
+			$wpdb->query( $query );
 		}
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 	}

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -21,6 +21,7 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 	 * @codeCoverageIgnore
 	 */
 	public function init() {
+		add_action( 'action_scheduler_before_schema_update', array( $this, 'update_actions_schema_4_0' ), 10, 2 );
 		$table_maker = new ActionScheduler_StoreSchema();
 		$table_maker->register_tables();
 	}
@@ -562,6 +563,34 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 		$date = $this->get_date_gmt( $action_id );
 		ActionScheduler_TimezoneHelper::set_local_timezone( $date );
 		return $date;
+	}
+
+	/**
+	 * Update the actions table schema to allow the datetime fields to be NULL.
+	 * The NOT NULL causes a conflict with some versions of MySQL configured with sql_mode=NO_ZERO_DATE.
+	 *
+	 * @param string $table Name of table being updated.
+	 * @param string $db_version The existing schema version of the table.
+	 */
+	public function update_actions_schema_4_0( $table, $db_version ) {
+		global $wpdb;
+		if ( 'actionscheduler_actions' !== $table || version_compare( $db_version, '4', '>=' ) ) {
+			return;
+		}
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$table_name = $wpdb->prefix . 'actionscheduler_actions';
+		$table_list = $wpdb->get_col( "SHOW TABLES LIKE '{$table_name}'" );
+		if ( ! empty( $table_list ) ) {
+			$query = "ALTER TABLE
+				MODIFY COLUMN scheduled_date_gmt datetime NULL default '0000-00-00 00:00:00',
+				MODIFY COLUMN scheduled_date_local datetime NULL default '0000-00-00 00:00:00',
+				MODIFY COLUMN last_attempt_gmt datetime NULL default '0000-00-00 00:00:00',
+				MODIFY COLUMN last_attempt_local datetime NULL default '0000-00-00 00:00:00'
+			";
+			$wpdb->query($query);
+		}
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 	}
 
 	/**

--- a/classes/schema/ActionScheduler_LoggerSchema.php
+++ b/classes/schema/ActionScheduler_LoggerSchema.php
@@ -13,7 +13,7 @@ class ActionScheduler_LoggerSchema extends ActionScheduler_Abstract_Schema {
 	/**
 	 * @var int Increment this value to trigger a schema update.
 	 */
-	protected $schema_version = 2;
+	protected $schema_version = 3;
 
 	public function __construct() {
 		$this->tables = [
@@ -29,12 +29,13 @@ class ActionScheduler_LoggerSchema extends ActionScheduler_Abstract_Schema {
 
 			case self::LOG_TABLE:
 
+				$default_date = ActionScheduler_StoreSchema::DEFAULT_DATE;
 				return "CREATE TABLE {$table_name} (
 				        log_id bigint(20) unsigned NOT NULL auto_increment,
 				        action_id bigint(20) unsigned NOT NULL,
 				        message text NOT NULL,
-				        log_date_gmt datetime NOT NULL default '0000-00-00 00:00:00',
-				        log_date_local datetime NOT NULL default '0000-00-00 00:00:00',
+				        log_date_gmt datetime NULL default '${default_date}',
+				        log_date_local datetime NULL default '${default_date}',
 				        PRIMARY KEY  (log_id),
 				        KEY action_id (action_id),
 				        KEY log_date_gmt (log_date_gmt)

--- a/classes/schema/ActionScheduler_StoreSchema.php
+++ b/classes/schema/ActionScheduler_StoreSchema.php
@@ -11,6 +11,7 @@ class ActionScheduler_StoreSchema extends ActionScheduler_Abstract_Schema {
 	const ACTIONS_TABLE = 'actionscheduler_actions';
 	const CLAIMS_TABLE  = 'actionscheduler_claims';
 	const GROUPS_TABLE  = 'actionscheduler_groups';
+	const DEFAULT_DATE  = '0000-00-00 00:00:00';
 
 	/**
 	 * @var int Increment this value to trigger a schema update.
@@ -30,6 +31,7 @@ class ActionScheduler_StoreSchema extends ActionScheduler_Abstract_Schema {
 		$table_name       = $wpdb->$table;
 		$charset_collate  = $wpdb->get_charset_collate();
 		$max_index_length = 191; // @see wp_get_db_schema()
+		$default_date     = self::DEFAULT_DATE;
 		switch ( $table ) {
 
 			case self::ACTIONS_TABLE:
@@ -38,14 +40,14 @@ class ActionScheduler_StoreSchema extends ActionScheduler_Abstract_Schema {
 				        action_id bigint(20) unsigned NOT NULL auto_increment,
 				        hook varchar(191) NOT NULL,
 				        status varchar(20) NOT NULL,
-				        scheduled_date_gmt datetime NULL default '0000-00-00 00:00:00',
-				        scheduled_date_local datetime NULL default '0000-00-00 00:00:00',
+				        scheduled_date_gmt datetime NULL default '${default_date}',
+				        scheduled_date_local datetime NULL default '${default_date}',
 				        args varchar($max_index_length),
 				        schedule longtext,
 				        group_id bigint(20) unsigned NOT NULL default '0',
 				        attempts int(11) NOT NULL default '0',
-				        last_attempt_gmt datetime NULL default '0000-00-00 00:00:00',
-				        last_attempt_local datetime NULL default '0000-00-00 00:00:00',
+				        last_attempt_gmt datetime NULL default '${default_date}',
+				        last_attempt_local datetime NULL default '${default_date}',
 				        claim_id bigint(20) unsigned NOT NULL default '0',
 				        extended_args varchar(8000) DEFAULT NULL,
 				        PRIMARY KEY  (action_id),
@@ -62,7 +64,7 @@ class ActionScheduler_StoreSchema extends ActionScheduler_Abstract_Schema {
 
 				return "CREATE TABLE {$table_name} (
 				        claim_id bigint(20) unsigned NOT NULL auto_increment,
-				        date_created_gmt datetime NOT NULL default '0000-00-00 00:00:00',
+				        date_created_gmt datetime NULL default '${default_date}',
 				        PRIMARY KEY  (claim_id),
 				        KEY date_created_gmt (date_created_gmt)
 				        ) $charset_collate";

--- a/classes/schema/ActionScheduler_StoreSchema.php
+++ b/classes/schema/ActionScheduler_StoreSchema.php
@@ -15,7 +15,7 @@ class ActionScheduler_StoreSchema extends ActionScheduler_Abstract_Schema {
 	/**
 	 * @var int Increment this value to trigger a schema update.
 	 */
-	protected $schema_version = 3;
+	protected $schema_version = 4;
 
 	public function __construct() {
 		$this->tables = [
@@ -38,14 +38,14 @@ class ActionScheduler_StoreSchema extends ActionScheduler_Abstract_Schema {
 				        action_id bigint(20) unsigned NOT NULL auto_increment,
 				        hook varchar(191) NOT NULL,
 				        status varchar(20) NOT NULL,
-				        scheduled_date_gmt datetime NOT NULL default '0000-00-00 00:00:00',
-				        scheduled_date_local datetime NOT NULL default '0000-00-00 00:00:00',
+				        scheduled_date_gmt datetime NULL default '0000-00-00 00:00:00',
+				        scheduled_date_local datetime NULL default '0000-00-00 00:00:00',
 				        args varchar($max_index_length),
 				        schedule longtext,
 				        group_id bigint(20) unsigned NOT NULL default '0',
 				        attempts int(11) NOT NULL default '0',
-				        last_attempt_gmt datetime NOT NULL default '0000-00-00 00:00:00',
-				        last_attempt_local datetime NOT NULL default '0000-00-00 00:00:00',
+				        last_attempt_gmt datetime NULL default '0000-00-00 00:00:00',
+				        last_attempt_local datetime NULL default '0000-00-00 00:00:00',
 				        claim_id bigint(20) unsigned NOT NULL default '0',
 				        extended_args varchar(8000) DEFAULT NULL,
 				        PRIMARY KEY  (action_id),


### PR DESCRIPTION
Closes #587 

This PR
- updates the table schemas to remove the `NOT NULL` on `datetime` fields
- adds an update routine to remove the `NOT NULL` from `datetime` fields in existing installs

The update routine is necessary because `dbDelta()` fails on the tables with `NOT NULL default '0000-00-00 00:00:00` column definitions in MySQL 5.7 configured with `sql_mode=STRICT_TRANS_TABLES,NO_ZERO_DATE`.

### Testing

- Load the Tools -> Scheduled Actions screen
- In MySQL
```
> SHOW CREATE TABLE wp_actionscheduler_actions;
wp_actionscheduler_actions | CREATE TABLE `wp_actionscheduler_actions` (
  `action_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
  `hook` varchar(191) COLLATE utf8mb4_unicode_520_ci NOT NULL,
  `status` varchar(20) COLLATE utf8mb4_unicode_520_ci NOT NULL,
  `scheduled_date_gmt` datetime DEFAULT '0000-00-00 00:00:00',
  `scheduled_date_local` datetime DEFAULT '0000-00-00 00:00:00',
  `args` varchar(191) COLLATE utf8mb4_unicode_520_ci DEFAULT NULL,
  `schedule` longtext COLLATE utf8mb4_unicode_520_ci,
  `group_id` bigint(20) unsigned NOT NULL DEFAULT '0',
  `attempts` int(11) NOT NULL DEFAULT '0',
  `last_attempt_gmt` datetime DEFAULT '0000-00-00 00:00:00',
  `last_attempt_local` datetime DEFAULT '0000-00-00 00:00:00',
  `claim_id` bigint(20) unsigned NOT NULL DEFAULT '0',
  `extended_args` varchar(8000) COLLATE utf8mb4_unicode_520_ci DEFAULT NULL,
  PRIMARY KEY (`action_id`),
  KEY `hook` (`hook`),
  KEY `status` (`status`),
  KEY `scheduled_date_gmt` (`scheduled_date_gmt`),
  KEY `args` (`args`),
  KEY `group_id` (`group_id`),
  KEY `last_attempt_gmt` (`last_attempt_gmt`),
  KEY `claim_id` (`claim_id`)
) ENGINE=InnoDB AUTO_INCREMENT=18003 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci

> SHOW CREATE TABLE wp_actionscheduler_logs;
wp_actionscheduler_logs | CREATE TABLE `wp_actionscheduler_logs` (
  `log_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
  `action_id` bigint(20) unsigned NOT NULL,
  `message` text COLLATE utf8mb4_unicode_520_ci NOT NULL,
  `log_date_gmt` datetime DEFAULT '0000-00-00 00:00:00',
  `log_date_local` datetime DEFAULT '0000-00-00 00:00:00',
  PRIMARY KEY (`log_id`),
  KEY `action_id` (`action_id`),
  KEY `log_date_gmt` (`log_date_gmt`)
) ENGINE=InnoDB AUTO_INCREMENT=7 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci
```