### PR TITLE
Allow 3rd-party code to enable asnyc runner requests outside of the admin context

### DIFF
--- a/classes/ActionScheduler_QueueRunner.php
+++ b/classes/ActionScheduler_QueueRunner.php
@@ -87,13 +87,15 @@ class ActionScheduler_QueueRunner extends ActionScheduler_Abstract_QueueRunner {
 	 * This method is attached to 'shutdown', so is called frequently. To avoid slowing down
 	 * the site, it mitigates the work performed in each request by:
 	 * 1. checking if it's in the admin context and then
-	 * 2. haven't run on the 'shutdown' hook within the lock time (60 seconds by default)
-	 * 3. haven't exceeded the number of allowed batches.
+	 * 2. if not in admin context check whether non-admin async runner requests should be allowed via a filter
+	 * 3. haven't run on the 'shutdown' hook within the lock time (60 seconds by default)
+	 * 4. haven't exceeded the number of allowed batches.
 	 *
 	 * The order of these checks is important, because they run from a check on a value:
 	 * 1. in memory - is_admin() maps to $GLOBALS or the WP_ADMIN constant
-	 * 2. in memory - transients use autoloaded options by default
-	 * 3. from a database query - has_maximum_concurrent_batches() run the query
+	 * 2. filter - 'action_scheduler_allow_non_admin_async_runner_request' value
+	 * 3. in memory - transients use autoloaded options by default
+	 * 4. from a database query - has_maximum_concurrent_batches() run the query
 	 *    $this->store->get_claim_count() to find the current number of claims in the DB.
 	 *
 	 * If all of these conditions are met, then we request an async runner check whether it

--- a/classes/ActionScheduler_QueueRunner.php
+++ b/classes/ActionScheduler_QueueRunner.php
@@ -121,7 +121,7 @@ class ActionScheduler_QueueRunner extends ActionScheduler_Abstract_QueueRunner {
 	 */
 	protected function allow_non_admin_async_request() {
 		/**
-		 * This filter allows custom code to allow a non-admin async runner request.
+		 * Filter whether an async runner request is allowed outside of the admin context.
 		 *
 		 * Non-admin async runner requests are disabled by default.
 		 *


### PR DESCRIPTION
Adds a filter (`action_scheduler_allow_non_admin_async_runner_request`) that can be used by 3rd-party code to allow an async runner request to be dispatched outside the admin context.

I deliberately prevented the filter from disabling async runner requests in the admin area to prevent this from accidentally happening if the filter is misused. 

@rrennick @thenbrent as discussed we agreed this would be the best solution to enable AutomateWoo to completely switch to use ActionScheduler.

I've added this to the 3.2.0 milestone but would love to get this in as soon as possible.

cc @woocommerce/ventures  