### PR TITLE
Add "no ordering" option to as_next_scheduled_action()

### DIFF
--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -358,27 +358,29 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 		}
 
 		if ( 'select' === $select_or_count ) {
-			switch ( $query['orderby'] ) {
-				case 'hook':
-					$orderby = 'a.hook';
-					break;
-				case 'group':
-					$orderby = 'g.slug';
-					break;
-				case 'modified':
-					$orderby = 'a.last_attempt_gmt';
-					break;
-				case 'date':
-				default:
-					$orderby = 'a.scheduled_date_gmt';
-					break;
-			}
 			if ( strtoupper( $query[ 'order' ] ) == 'ASC' ) {
 				$order = 'ASC';
 			} else {
 				$order = 'DESC';
 			}
-			$sql .= " ORDER BY $orderby $order";
+			switch ( $query['orderby'] ) {
+				case 'hook':
+					$sql .= " ORDER BY a.hook $order";
+					break;
+				case 'group':
+					$sql .= " ORDER BY g.slug $order";
+					break;
+				case 'modified':
+					$sql .= " ORDER BY a.last_attempt_gmt $order";
+					break;
+				case 'none':
+					break;
+				case 'date':
+				default:
+					$sql .= " ORDER BY a.scheduled_date_gmt $order";
+					break;
+			}
+
 			if ( $query[ 'per_page' ] > 0 ) {
 				$sql          .= " LIMIT %d, %d";
 				$sql_params[] = $query[ 'offset' ];

--- a/functions.php
+++ b/functions.php
@@ -209,7 +209,7 @@ function as_next_scheduled_action( $hook, $args = NULL, $group = '' ) {
  *        'claimed' => NULL - TRUE to find claimed actions, FALSE to find unclaimed actions, a string to find a specific claim ID
  *        'per_page' => 5 - Number of results to return
  *        'offset' => 0
- *        'orderby' => 'date' - accepted values are 'hook', 'group', 'modified', or 'date'
+ *        'orderby' => 'date' - accepted values are 'hook', 'group', 'modified', 'date' or 'none'
  *        'order' => 'ASC'
  *
  * @param string $return_format OBJECT, ARRAY_A, or ids.


### PR DESCRIPTION
Occasionally an extension may want to check if an action has already been scheduled. Currently, the easiest way to do that is to run something like this:

```php
$pending = as_get_scheduled_actions(
	[
		'hook'     => 'my_hook',
		'args'     => ['my_args'],
		'status'   => \ActionScheduler_Store::STATUS_PENDING,
	],
	'ids'
);
// Check whether $pending is empty or not.
```

For the DB Store, the resulting SQL looks like this:
```sql
SELECT a.action_id FROM wp_actionscheduler_actions a WHERE 1=1 AND a.hook='my_hook' AND a.args='[\"my_args\"]' AND a.status='pending' ORDER BY a.scheduled_date_gmt ASC LIMIT 0, 5
```

Notice that the query includes an `ORDER BY` clause which is unnecessary in this use case.

The SQL EXPLAIN for this query, looks like this:
```
explain SELECT a.action_id FROM wc_actionscheduler_actions a WHERE 1=1 AND a.hook='my_hook' AND a.args='[\"my_args\"]' AND a.status='pending' ORDER BY a.scheduled_date_gmt ASC LIMIT 0, 5
    -> ;
+----+-------------+-------+------------+------+------------------+------+---------+-------+------+----------+----------------------------------------------------+
| id | select_type | table | partitions | type | possible_keys    | key  | key_len | ref   | rows | filtered | Extra                                              |
+----+-------------+-------+------------+------+------------------+------+---------+-------+------+----------+----------------------------------------------------+
|  1 | SIMPLE      | a     | NULL       | ref  | hook,status,args | hook | 766     | const |    1 |     5.00 | Using index condition; Using where; Using filesort |
+----+-------------+-------+------------+------+------------------+------+---------+-------+------+----------+----------------------------------------------------+
```

The addition of the ordering adds an additional filesort step to the query execution. While this isn't likely to be significant for small queries, it is unnecessary for some use cases, and could be avoided. 

This pull request allows a caller to specify that they do not want ordering of the results, by passing `'orderby' => 'none'` in the query args, e.g.
```php
$pending = as_get_scheduled_actions(
	[
		'hook'     => 'my_hook',
		'args'     => ['my_args'],
		'status'   => \ActionScheduler_Store::STATUS_PENDING,
                'orderby'  => 'none',
	],
	'ids'
);
// Check whether $pending is empty or not.
```

The resulting query, and `EXPLAIN` looks like this (note the filesort is no longer required):
```sql
> explain SELECT a.action_id FROM wc_actionscheduler_actions a WHERE 1=1 AND a.hook='my_hook' AND a.args='[\"my_args\"]' AND a.status='pending'  LIMIT 0, 5;
+----+-------------+-------+------------+-------------+------------------+-------------+---------+------+------+----------+-------------------------------------------+
| id | select_type | table | partitions | type        | possible_keys    | key         | key_len | ref  | rows | filtered | Extra                                     |
+----+-------------+-------+------------+-------------+------------------+-------------+---------+------+------+----------+-------------------------------------------+
|  1 | SIMPLE      | a     | NULL       | index_merge | hook,status,args | args,status | 767,82  | NULL |    1 |    14.42 | Using intersect(args,status); Using where |
+----+-------------+-------+------------+-------------+------------------+-------------+---------+------+------+----------+-------------------------------------------+
```

**Note:**
- This change is backwards compatible (callers not supplying an orderby will still get date-ordered results)
- I've only implemented this in the `ActionScheduler_DBStore`, not the Hybrid, or post stores since my understanding is that they are legacy and deprecated. Let me know if you want me to expand the PR to include them
