### PR TITLE
Speed up clean up and batch selects.

### DIFF
--- a/classes/ActionScheduler_QueueCleaner.php
+++ b/classes/ActionScheduler_QueueCleaner.php
@@ -44,6 +44,7 @@ class ActionScheduler_QueueCleaner {
 				'modified'         => $cutoff,
 				'modified_compare' => '<=',
 				'per_page'         => $this->get_batch_size(),
+				'orderby'          => 'none',
 			) );
 
 			foreach ( $actions_to_delete as $action_id ) {
@@ -90,6 +91,7 @@ class ActionScheduler_QueueCleaner {
 			'modified_compare' => '<=',
 			'claimed'          => true,
 			'per_page'         => $this->get_batch_size(),
+			'orderby'          => 'none',
 		) );
 
 		foreach ( $actions_to_reset as $action_id ) {
@@ -118,6 +120,7 @@ class ActionScheduler_QueueCleaner {
 			'modified'         => $cutoff,
 			'modified_compare' => '<=',
 			'per_page'         => $this->get_batch_size(),
+			'orderby'          => 'none',
 		) );
 
 		foreach ( $actions_to_reset as $action_id ) {

--- a/classes/abstracts/ActionScheduler_Store.php
+++ b/classes/abstracts/ActionScheduler_Store.php
@@ -242,9 +242,10 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 		while ( ! empty( $action_ids ) ) {
 			$action_ids = $this->query_actions(
 				array(
-					'hook' => $hook,
-					'status' => self::STATUS_PENDING,
+					'hook'     => $hook,
+					'status'   => self::STATUS_PENDING,
 					'per_page' => 1000,
+					'orderby'  => 'action_id',
 				)
 			);
 
@@ -266,9 +267,10 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 		while ( ! empty( $action_ids ) ) {
 			$action_ids = $this->query_actions(
 				array(
-					'group' => $group,
-					'status' => self::STATUS_PENDING,
+					'group'    => $group,
+					'status'   => self::STATUS_PENDING,
 					'per_page' => 1000,
+					'orderby'  => 'action_id',
 				)
 			);
 

--- a/classes/abstracts/ActionScheduler_Store.php
+++ b/classes/abstracts/ActionScheduler_Store.php
@@ -315,8 +315,9 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 	 */
 	public function has_pending_actions_due() {
 		$pending_actions = $this->query_actions( array(
-			'date'   => as_get_datetime_object(),
-			'status' => ActionScheduler_Store::STATUS_PENDING,
+			'date'    => as_get_datetime_object(),
+			'status'  => ActionScheduler_Store::STATUS_PENDING,
+			'orderby' => 'none',
 		) );
 
 		return ! empty( $pending_actions );

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -368,7 +368,7 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 		}
 
 		if ( 'select' === $select_or_count ) {
-			if ( strtoupper( $query[ 'order' ] ) == 'ASC' ) {
+			if ( 'ASC' === strtoupper( $query['order'] ) ) {
 				$order = 'ASC';
 			} else {
 				$order = 'DESC';
@@ -384,6 +384,9 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 					$sql .= " ORDER BY a.last_attempt_gmt $order";
 					break;
 				case 'none':
+					break;
+				case 'action_id':
+					$sql .= " ORDER BY a.action_id $order";
 					break;
 				case 'date':
 				default:
@@ -521,7 +524,8 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 			$query_args,
 			[
 				'per_page' => 1000,
-				'status' => self::STATUS_PENDING,
+				'status'   => self::STATUS_PENDING,
+				'orderby'  => 'action_id',
 			]
 		);
 


### PR DESCRIPTION
TL;DR is that SELECT queries on the actions table are by default ordering the result by date_scheduled_gmt, which was orders of magnitude slower than non-sorted query variant. Thus, I've updated the places where I think the order doesn't play any role, and where it potentially plays tiny role, I've changed it to sort by action_id, which is the primary key, and theoretically the data thus should already be ordered by it. 

After the fact I implemented this, I noticed that @leewillis77 already noticed this and added their fix in #651, but this hopefully provides a bigger jump in overall performance, since the cleanup runs on each `ActionScheduler_QueueRunner::run`.

For further details from the research and comparison, please see my comments on #530. 

Closes #530 together with #680.

Testing instructions are the same as for #680.