### PR TITLE
New index on the actions table (reduce potential for deadlocks)

### DIFF
--- a/classes/schema/ActionScheduler_StoreSchema.php
+++ b/classes/schema/ActionScheduler_StoreSchema.php
@@ -56,7 +56,7 @@ class ActionScheduler_StoreSchema extends ActionScheduler_Abstract_Schema {
 				        KEY group_id (group_id),
 				        KEY last_attempt_gmt (last_attempt_gmt),
 				        KEY claim_id (claim_id),
-						KEY `claim_id, status, scheduled_date_gmt` (`claim_id`, `status`, `scheduled_date_gmt`)
+				        KEY `claim_id_status_scheduled_date_gmt` (`claim_id`, `status`, `scheduled_date_gmt`)
 				        ) $charset_collate";
 
 			case self::CLAIMS_TABLE:

--- a/classes/schema/ActionScheduler_StoreSchema.php
+++ b/classes/schema/ActionScheduler_StoreSchema.php
@@ -15,7 +15,7 @@ class ActionScheduler_StoreSchema extends ActionScheduler_Abstract_Schema {
 	/**
 	 * @var int Increment this value to trigger a schema update.
 	 */
-	protected $schema_version = 3;
+	protected $schema_version = 4;
 
 	public function __construct() {
 		$this->tables = [
@@ -55,7 +55,8 @@ class ActionScheduler_StoreSchema extends ActionScheduler_Abstract_Schema {
 				        KEY args (args($max_index_length)),
 				        KEY group_id (group_id),
 				        KEY last_attempt_gmt (last_attempt_gmt),
-				        KEY claim_id (claim_id)
+				        KEY claim_id (claim_id),
+						KEY `claim_id, status, scheduled_date_gmt` (`claim_id`, `status`, `scheduled_date_gmt`)
 				        ) $charset_collate";
 
 			case self::CLAIMS_TABLE:


### PR DESCRIPTION
🗄️ Adds a new index on `wp_actionscheduler_actions` (which aims to reduce the potential for deadlocks).

📝 This is essentially the same work as [in this PR](https://github.com/woocommerce/action-scheduler/pull/535) from @glagonikas (thanks!) and contains their commit (however, the original branch was deleted, hence this separate PR). The only differences are:

* It's been rebased (brought up-to-date with the latest changes in master)
* Index name has been changed for compatibility with `dbDelta()` (previously it contained spaces and commas, which dbDelta rejects: now it is snake_cased)

 Despite my changes being very contained, this means I touched the code and so I figured it was worth getting a final review from someone else (ie, it doesn't need to be a comprehensive review, unless you want to, because that's already happened in [PR 535](https://github.com/woocommerce/action-scheduler/pull/535)). 

I expect merging and closing this one will also automatically close [PR 535](https://github.com/woocommerce/action-scheduler/pull/535).

📈 Please see that earlier PR for discussion points. In addition to that, I want to note here that in my own testing this A) has no appreciable impact on performance and B) though it doesn't reduce deadlocks in all cases, it does in many others. That to say, it doesn't *completely* solve #530 but it is a safe, incremental improvement that will help in many cases.

### Changelog entry

> Fix - Adds a new index to the action table, reducing the potential for deadlocks (props: @glagonikas)
