### PR TITLE
Use a different style of relative link | #616

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -20,7 +20,7 @@ Functions return similar values and accept similar arguments to their WP-Cron co
 
 ## API Function Availability
 
-As mentioned in the [Usage - Load Order](/usage/#load-order) section, Action Scheduler will initialize itself on the `'init'` hook with priority `1`. While API functions are loaded prior to this and can be called, they should not be called until after `'init'` with priority `1`, because each component, like the data store, has not yet been initialized.
+As mentioned in the [Usage - Load Order](usage.md#load-order) section, Action Scheduler will initialize itself on the `'init'` hook with priority `1`. While API functions are loaded prior to this and can be called, they should not be called until after `'init'` with priority `1`, because each component, like the data store, has not yet been initialized.
 
 Do not use Action Scheduler API functions prior to `'init'` hook with priority `1`. Doing so could lead to unexpected results, like data being stored in the incorrect location.
 


### PR DESCRIPTION
Per [this guide](https://github.blog/2016-12-05-relative-links-for-github-pages/), switching to a relative link that references the markdown file will work nicely both when viewed within GitHub, and also over on GitHub Pages (for us, that means [this site](https://actionscheduler.org/)).

Closes #616.