### PR TITLE
Handle hidden columns (Tools → Scheduled Actions) | #600

### DIFF
--- a/classes/abstracts/ActionScheduler_Abstract_ListTable.php
+++ b/classes/abstracts/ActionScheduler_Abstract_ListTable.php
@@ -177,7 +177,7 @@ abstract class ActionScheduler_Abstract_ListTable extends WP_List_Table {
 	protected function prepare_column_headers() {
 		$this->_column_headers = array(
 			$this->get_columns(),
-			array(),
+			get_hidden_columns( $this->screen ),
 			$this->get_sortable_columns(),
 		);
 	}


### PR DESCRIPTION
It is already possible to hide columns (from the `Tools → Scheduled Actions` screen, via the _Screen Options_ pulldown) however, unlike with most WP list tables, those changes do not persist between complete page reloads.

This change remedies that by pulling information about hidden columns during column header preparation.

<details>
<summary>:clapper: Screencast showing the change in effect.</summary>

https://user-images.githubusercontent.com/3594411/121270886-67055c00-c877-11eb-8648-0676ee178f78.mov
</details>

### Steps to replicate

* Visit the `Tools → Scheduled Actions` screen
* Using the _Screen Options_ pulldown, try hiding some columns
* Refresh the page
    * Without this change, the columns you just hid will be visible again.
    * With this change, they should remain hidden (until you re-select them from the _Screen Options_ pulldown).
 
Closes #600.

### Changelog

> Fix - Ensures hidden columns (within the Scheduled Actions admin screen) persist between page reloads.


