### PR TITLE
Add extra safety/account for different versions of AS and different loading patterns

### DIFF
--- a/action-scheduler.php
+++ b/action-scheduler.php
@@ -40,12 +40,17 @@ if ( ! function_exists( 'action_scheduler_register_3_dot_2_dot_0' ) ) {
 	}
 
 	function action_scheduler_initialize_3_dot_2_dot_0() {
-		require_once( 'classes/abstracts/ActionScheduler.php' );
-		ActionScheduler::init( __FILE__ );
+		// A final safety check is required even here, because historic versions of Action Scheduler
+		// followed a different pattern (in some unusual cases, we could reach this point and the
+		// ActionScheduler class is already defined—so we need to guard against that).
+		if ( class_exists( 'ActionScheduler' ) ) {
+			require_once( 'classes/abstracts/ActionScheduler.php' );
+			ActionScheduler::init( __FILE__ );
+		}
 	}
 
 	// Support usage in themes - load this version if no plugin has loaded a version yet.
-	if ( did_action( 'plugins_loaded' ) && ! class_exists( 'ActionScheduler' ) ) {
+	if ( did_action( 'plugins_loaded' ) && ! doing_action( 'plugins_loaded' ) && ! class_exists( 'ActionScheduler' ) ) {
 		action_scheduler_initialize_3_dot_2_dot_0();
 		do_action( 'action_scheduler_pre_theme_init' );
 		ActionScheduler_Versions::initialize_latest_version();

--- a/action-scheduler.php
+++ b/action-scheduler.php
@@ -43,7 +43,7 @@ if ( ! function_exists( 'action_scheduler_register_3_dot_2_dot_0' ) ) {
 		// A final safety check is required even here, because historic versions of Action Scheduler
 		// followed a different pattern (in some unusual cases, we could reach this point and the
 		// ActionScheduler class is already defined—so we need to guard against that).
-		if ( class_exists( 'ActionScheduler' ) ) {
+		if ( ! class_exists( 'ActionScheduler' ) ) {
 			require_once( 'classes/abstracts/ActionScheduler.php' );
 			ActionScheduler::init( __FILE__ );
 		}


### PR DESCRIPTION
A more complete breakdown of the problem can be found in #714 but, in essence, if two plugins are present and both include different versions of Action Scheduler (3.2.0 and 3.1.6, for example) and each uses a different loading pattern, a fatal error can occur.

`Cannot declare class ActionScheduler, because the name is already in use`

Closes #714.

## Steps to replicate

* Activate WooCommerce (current trunk code) with AS 3.2.0.
* Activate another plugin that includes AS 3.1.6. This plugin should load Action Scheduler during `plugins_loaded` (priority `-10`), which is a strategy we document [over here](https://actionscheduler.org/usage/#load-order).
    * This plugin should be named something like `z-plugin` to make it load _after_ WooCommerce.
* Try to access your WordPress site, observe the fatal error.

## Testing

* Make sure you can replicate the original problem (see also [PR 713](https://github.com/woocommerce/action-scheduler/pull/713) for additional context).
* With respect to the above steps to replicate, replace the version of Action Scheduler loaded by WooCommerce with this updated version.
* Problem should be resolved.

## Notes

* An alternative to this solution could be modifying `ActionScheduler_Versions::initialize_latest_version()` and placing an extra safety check there.

## Changelog

> Fix - Resolves a potential error when multiple versions of Action Scheduler are loaded by different plugins. 