### PR TITLE
Suppress warnings re safe_mode. #656

### DIFF
--- a/classes/ActionScheduler_Compatibility.php
+++ b/classes/ActionScheduler_Compatibility.php
@@ -92,7 +92,7 @@ class ActionScheduler_Compatibility {
 
 		if ( function_exists( 'wc_set_time_limit' ) ) {
 			wc_set_time_limit( $limit );
-		} elseif ( function_exists( 'set_time_limit' ) && false === strpos( ini_get( 'disable_functions' ), 'set_time_limit' ) && ! ini_get( 'safe_mode' ) ) {
+		} elseif ( function_exists( 'set_time_limit' ) && false === strpos( ini_get( 'disable_functions' ), 'set_time_limit' ) && ! ini_get( 'safe_mode' ) ) { // phpcs:ignore PHPCompatibility.IniDirectives.RemovedIniDirectives.safe_modeDeprecatedRemoved
 			@set_time_limit( $limit );
 		}
 	}


### PR DESCRIPTION
Minor, adds a `phpcs:ignore` rule to suppress warnings about the deprecation of `safe_mode`. Closes #656.

### Testing

* Execute `composer run phpcs classes/ActionScheduler_Compatibility.php`
* Look for `95 | WARNING | INI directive 'safe_mode' is deprecated since PHP 5.3 and removed since PHP 5.4...`
* The above should be gone as of this change.

### Notes

* We could also consider removing the relevant `ini_get()` statement _but_ ostensibly we still support as far back as PHP 5.3 😱 (in terms of plugin readme's PHP declaration and even in terms of CI coverage), for which `safe_mode` is potentially still relevant.
* Could reconsider this status, but that's a bigger/broader discussion for another time, probably.

