### PR TITLE
Remove the NOT NULL from date fields

### DIFF
--- a/classes/abstracts/ActionScheduler_Abstract_Schema.php
+++ b/classes/abstracts/ActionScheduler_Abstract_Schema.php
@@ -18,6 +18,11 @@ abstract class ActionScheduler_Abstract_Schema {
 	protected $schema_version = 1;
 
 	/**
+	 * @var string Schema version stored in database.
+	 */
+	protected $db_version;
+
+	/**
 	 * @var array Names of tables that will be registered by this class.
 	 */
 	protected $tables = [];
@@ -42,6 +47,13 @@ abstract class ActionScheduler_Abstract_Schema {
 		// create the tables
 		if ( $this->schema_update_required() || $force_update ) {
 			foreach ( $this->tables as $table ) {
+				/**
+				 * Allow custom processing before updating a table schema.
+				 *
+				 * @param string $table Name of table being updated.
+				 * @param string $db_version Existing version of the table being updated.
+				 */
+				do_action( 'action_scheduler_before_schema_update', $table, $this->db_version );
 				$this->update_table( $table );
 			}
 			$this->mark_schema_update_complete();
@@ -63,11 +75,11 @@ abstract class ActionScheduler_Abstract_Schema {
 	 * @return bool
 	 */
 	private function schema_update_required() {
-		$option_name         = 'schema-' . static::class;
-		$version_found_in_db = get_option( $option_name, 0 );
+		$option_name      = 'schema-' . static::class;
+		$this->db_version = get_option( $option_name, 0 );
 
 		// Check for schema option stored by the Action Scheduler Custom Tables plugin in case site has migrated from that plugin with an older schema
-		if ( 0 === $version_found_in_db ) {
+		if ( 0 === $this->db_version ) {
 
 			$plugin_option_name = 'schema-';
 
@@ -80,12 +92,12 @@ abstract class ActionScheduler_Abstract_Schema {
 					break;
 			}
 
-			$version_found_in_db = get_option( $plugin_option_name, 0 );
+			$this->db_version = get_option( $plugin_option_name, 0 );
 
 			delete_option( $plugin_option_name );
 		}
 
-		return version_compare( $version_found_in_db, $this->schema_version, '<' );
+		return version_compare( $this->db_version, $this->schema_version, '<' );
 	}
 
 	/**

--- a/classes/abstracts/ActionScheduler_Abstract_Schema.php
+++ b/classes/abstracts/ActionScheduler_Abstract_Schema.php
@@ -28,6 +28,12 @@ abstract class ActionScheduler_Abstract_Schema {
 	protected $tables = [];
 
 	/**
+	 * Can optionally be used by concrete classes to carry out additional initialization work
+	 * as needed.
+	 */
+	public function init() {}
+
+	/**
 	 * Register tables with WordPress, and create them if needed.
 	 *
 	 * @param bool $force_update Optional. Default false. Use true to always run the schema update.

--- a/classes/data-stores/ActionScheduler_DBLogger.php
+++ b/classes/data-stores/ActionScheduler_DBLogger.php
@@ -99,9 +99,8 @@ class ActionScheduler_DBLogger extends ActionScheduler_Logger {
 	 * @codeCoverageIgnore
 	 */
 	public function init() {
-
-		add_action( 'action_scheduler_before_schema_update', array( $this, 'update_logs_schema_4_0' ), 10, 2 );
 		$table_maker = new ActionScheduler_LoggerSchema();
+		$table_maker->init();
 		$table_maker->register_tables();
 
 		parent::init();
@@ -147,32 +146,5 @@ class ActionScheduler_DBLogger extends ActionScheduler_Logger {
 		$sql_query .= implode( ',', $value_rows );
 
 		$wpdb->query( $sql_query );
-	}
-
-	/**
-	 * Update the logs table schema to allow the datetime fields to be NULL.
-	 * The NOT NULL causes a conflict with some versions of MySQL configured with sql_mode=NO_ZERO_DATE.
-	 *
-	 * @param string $table Name of table being updated.
-	 * @param string $db_version The existing schema version of the table.
-	 */
-	public function update_logs_schema_4_0( $table, $db_version ) {
-		global $wpdb;
-		if ( 'actionscheduler_logs' !== $table || version_compare( $db_version, '3', '>=' ) ) {
-			return;
-		}
-
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		$table_name   = $wpdb->prefix . 'actionscheduler_logs';
-		$table_list   = $wpdb->get_col( "SHOW TABLES LIKE '${table_name}'" );
-		$default_date = ActionScheduler_StoreSchema::DEFAULT_DATE;
-		if ( ! empty( $table_list ) ) {
-			$query = "ALTER TABLE ${table_name}
-				MODIFY COLUMN log_date_gmt datetime NULL default '${default_date}',
-				MODIFY COLUMN log_date_local datetime NULL default '${default_date}'
-			";
-			$wpdb->query( $query );
-		}
-		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 	}
 }

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -31,8 +31,8 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 	 * @codeCoverageIgnore
 	 */
 	public function init() {
-		add_action( 'action_scheduler_before_schema_update', array( $this, 'update_actions_schema_5_0' ), 10, 2 );
 		$table_maker = new ActionScheduler_StoreSchema();
+		$table_maker->init();
 		$table_maker->register_tables();
 	}
 
@@ -592,35 +592,6 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 		$date = $this->get_date_gmt( $action_id );
 		ActionScheduler_TimezoneHelper::set_local_timezone( $date );
 		return $date;
-	}
-
-	/**
-	 * Update the actions table schema to allow the datetime fields to be NULL.
-	 * The NOT NULL causes a conflict with some versions of MySQL configured with sql_mode=NO_ZERO_DATE.
-	 *
-	 * @param string $table Name of table being updated.
-	 * @param string $db_version The existing schema version of the table.
-	 */
-	public function update_actions_schema_5_0( $table, $db_version ) {
-		global $wpdb;
-		if ( 'actionscheduler_actions' !== $table || version_compare( $db_version, '5', '>=' ) ) {
-			return;
-		}
-
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		$table_name   = $wpdb->prefix . 'actionscheduler_actions';
-		$table_list   = $wpdb->get_col( "SHOW TABLES LIKE '${table_name}'" );
-		$default_date = ActionScheduler_StoreSchema::DEFAULT_DATE;
-		if ( ! empty( $table_list ) ) {
-			$query = "ALTER TABLE ${table_name}
-				MODIFY COLUMN scheduled_date_gmt datetime NULL default '${default_date}',
-				MODIFY COLUMN scheduled_date_local datetime NULL default '${default_date}',
-				MODIFY COLUMN last_attempt_gmt datetime NULL default '${default_date}',
-				MODIFY COLUMN last_attempt_local datetime NULL default '${default_date}'
-			";
-			$wpdb->query( $query );
-		}
-		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 	}
 
 	/**

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -31,6 +31,7 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 	 * @codeCoverageIgnore
 	 */
 	public function init() {
+		add_action( 'action_scheduler_before_schema_update', array( $this, 'update_actions_schema_4_0' ), 10, 2 );
 		$table_maker = new ActionScheduler_StoreSchema();
 		$table_maker->register_tables();
 	}
@@ -168,6 +169,19 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 		if ( ! empty( $data->extended_args ) ) {
 			$data->args = $data->extended_args;
 			unset( $data->extended_args );
+		}
+
+		// Convert NULL dates to zero dates.
+		$date_fields = [
+			'scheduled_date_gmt',
+			'scheduled_date_local',
+			'last_attempt_gmt',
+			'last_attempt_gmt'
+		];
+		foreach( $date_fields as $date_field ) {
+			if ( is_null( $data->$date_field ) ) {
+				$data->$date_field = ActionScheduler_StoreSchema::DEFAULT_DATE;
+			}
 		}
 
 		try {
@@ -578,6 +592,35 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 		$date = $this->get_date_gmt( $action_id );
 		ActionScheduler_TimezoneHelper::set_local_timezone( $date );
 		return $date;
+	}
+
+	/**
+	 * Update the actions table schema to allow the datetime fields to be NULL.
+	 * The NOT NULL causes a conflict with some versions of MySQL configured with sql_mode=NO_ZERO_DATE.
+	 *
+	 * @param string $table Name of table being updated.
+	 * @param string $db_version The existing schema version of the table.
+	 */
+	public function update_actions_schema_4_0( $table, $db_version ) {
+		global $wpdb;
+		if ( 'actionscheduler_actions' !== $table || version_compare( $db_version, '4', '>=' ) ) {
+			return;
+		}
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$table_name   = $wpdb->prefix . 'actionscheduler_actions';
+		$table_list   = $wpdb->get_col( "SHOW TABLES LIKE '${table_name}'" );
+		$default_date = ActionScheduler_StoreSchema::DEFAULT_DATE;
+		if ( ! empty( $table_list ) ) {
+			$query = "ALTER TABLE ${table_name}
+				MODIFY COLUMN scheduled_date_gmt datetime NULL default '${default_date}',
+				MODIFY COLUMN scheduled_date_local datetime NULL default '${default_date}',
+				MODIFY COLUMN last_attempt_gmt datetime NULL default '${default_date}',
+				MODIFY COLUMN last_attempt_local datetime NULL default '${default_date}'
+			";
+			$wpdb->query( $query );
+		}
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 	}
 
 	/**

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -31,7 +31,7 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 	 * @codeCoverageIgnore
 	 */
 	public function init() {
-		add_action( 'action_scheduler_before_schema_update', array( $this, 'update_actions_schema_4_0' ), 10, 2 );
+		add_action( 'action_scheduler_before_schema_update', array( $this, 'update_actions_schema_5_0' ), 10, 2 );
 		$table_maker = new ActionScheduler_StoreSchema();
 		$table_maker->register_tables();
 	}
@@ -601,9 +601,9 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 	 * @param string $table Name of table being updated.
 	 * @param string $db_version The existing schema version of the table.
 	 */
-	public function update_actions_schema_4_0( $table, $db_version ) {
+	public function update_actions_schema_5_0( $table, $db_version ) {
 		global $wpdb;
-		if ( 'actionscheduler_actions' !== $table || version_compare( $db_version, '4', '>=' ) ) {
+		if ( 'actionscheduler_actions' !== $table || version_compare( $db_version, '5', '>=' ) ) {
 			return;
 		}
 

--- a/classes/schema/ActionScheduler_LoggerSchema.php
+++ b/classes/schema/ActionScheduler_LoggerSchema.php
@@ -21,6 +21,13 @@ class ActionScheduler_LoggerSchema extends ActionScheduler_Abstract_Schema {
 		];
 	}
 
+	/**
+	 * Performs additional setup work required to support this schema.
+	 */
+	public function init() {
+		add_action( 'action_scheduler_before_schema_update', array( $this, 'update_schema_3_0' ), 10, 2 );
+	}
+
 	protected function get_table_definition( $table ) {
 		global $wpdb;
 		$table_name       = $wpdb->$table;
@@ -44,5 +51,40 @@ class ActionScheduler_LoggerSchema extends ActionScheduler_Abstract_Schema {
 			default:
 				return '';
 		}
+	}
+
+	/**
+	 * Update the logs table schema, allowing datetime fields to be NULL.
+	 *
+	 * This is needed because the NOT NULL constraint causes a conflict with some versions of MySQL
+	 * configured with sql_mode=NO_ZERO_DATE, which can for instance lead to tables not being created.
+	 *
+	 * Most other schema updates happen via ActionScheduler_Abstract_Schema::update_table(), however
+	 * that method relies on dbDelta() and this change is not possible when using that function.
+	 *
+	 * @param string $table Name of table being updated.
+	 * @param string $db_version The existing schema version of the table.
+	 */
+	public function update_schema_3_0( $table, $db_version ) {
+		global $wpdb;
+
+		if ( 'actionscheduler_logs' !== $table || version_compare( $db_version, '3', '>=' ) ) {
+			return;
+		}
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$table_name   = $wpdb->prefix . 'actionscheduler_logs';
+		$table_list   = $wpdb->get_col( "SHOW TABLES LIKE '${table_name}'" );
+		$default_date = ActionScheduler_StoreSchema::DEFAULT_DATE;
+
+		if ( ! empty( $table_list ) ) {
+			$query = "
+				ALTER TABLE ${table_name}
+				MODIFY COLUMN log_date_gmt datetime NULL default '${default_date}',
+				MODIFY COLUMN log_date_local datetime NULL default '${default_date}'
+			";
+			$wpdb->query( $query ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		}
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 	}
 }

--- a/classes/schema/ActionScheduler_LoggerSchema.php
+++ b/classes/schema/ActionScheduler_LoggerSchema.php
@@ -13,7 +13,7 @@ class ActionScheduler_LoggerSchema extends ActionScheduler_Abstract_Schema {
 	/**
 	 * @var int Increment this value to trigger a schema update.
 	 */
-	protected $schema_version = 2;
+	protected $schema_version = 3;
 
 	public function __construct() {
 		$this->tables = [
@@ -29,12 +29,13 @@ class ActionScheduler_LoggerSchema extends ActionScheduler_Abstract_Schema {
 
 			case self::LOG_TABLE:
 
+				$default_date = ActionScheduler_StoreSchema::DEFAULT_DATE;
 				return "CREATE TABLE {$table_name} (
 				        log_id bigint(20) unsigned NOT NULL auto_increment,
 				        action_id bigint(20) unsigned NOT NULL,
 				        message text NOT NULL,
-				        log_date_gmt datetime NOT NULL default '0000-00-00 00:00:00',
-				        log_date_local datetime NOT NULL default '0000-00-00 00:00:00',
+				        log_date_gmt datetime NULL default '${default_date}',
+				        log_date_local datetime NULL default '${default_date}',
 				        PRIMARY KEY  (log_id),
 				        KEY action_id (action_id),
 				        KEY log_date_gmt (log_date_gmt)

--- a/classes/schema/ActionScheduler_StoreSchema.php
+++ b/classes/schema/ActionScheduler_StoreSchema.php
@@ -11,6 +11,7 @@ class ActionScheduler_StoreSchema extends ActionScheduler_Abstract_Schema {
 	const ACTIONS_TABLE = 'actionscheduler_actions';
 	const CLAIMS_TABLE  = 'actionscheduler_claims';
 	const GROUPS_TABLE  = 'actionscheduler_groups';
+	const DEFAULT_DATE  = '0000-00-00 00:00:00';
 
 	/**
 	 * @var int Increment this value to trigger a schema update.
@@ -30,6 +31,7 @@ class ActionScheduler_StoreSchema extends ActionScheduler_Abstract_Schema {
 		$table_name       = $wpdb->$table;
 		$charset_collate  = $wpdb->get_charset_collate();
 		$max_index_length = 191; // @see wp_get_db_schema()
+		$default_date     = self::DEFAULT_DATE;
 		switch ( $table ) {
 
 			case self::ACTIONS_TABLE:
@@ -38,14 +40,14 @@ class ActionScheduler_StoreSchema extends ActionScheduler_Abstract_Schema {
 				        action_id bigint(20) unsigned NOT NULL auto_increment,
 				        hook varchar(191) NOT NULL,
 				        status varchar(20) NOT NULL,
-				        scheduled_date_gmt datetime NOT NULL default '0000-00-00 00:00:00',
-				        scheduled_date_local datetime NOT NULL default '0000-00-00 00:00:00',
+				        scheduled_date_gmt datetime NULL default '${default_date}',
+				        scheduled_date_local datetime NULL default '${default_date}',
 				        args varchar($max_index_length),
 				        schedule longtext,
 				        group_id bigint(20) unsigned NOT NULL default '0',
 				        attempts int(11) NOT NULL default '0',
-				        last_attempt_gmt datetime NOT NULL default '0000-00-00 00:00:00',
-				        last_attempt_local datetime NOT NULL default '0000-00-00 00:00:00',
+				        last_attempt_gmt datetime NULL default '${default_date}',
+				        last_attempt_local datetime NULL default '${default_date}',
 				        claim_id bigint(20) unsigned NOT NULL default '0',
 				        extended_args varchar(8000) DEFAULT NULL,
 				        PRIMARY KEY  (action_id),
@@ -63,7 +65,7 @@ class ActionScheduler_StoreSchema extends ActionScheduler_Abstract_Schema {
 
 				return "CREATE TABLE {$table_name} (
 				        claim_id bigint(20) unsigned NOT NULL auto_increment,
-				        date_created_gmt datetime NOT NULL default '0000-00-00 00:00:00',
+				        date_created_gmt datetime NULL default '${default_date}',
 				        PRIMARY KEY  (claim_id),
 				        KEY date_created_gmt (date_created_gmt)
 				        ) $charset_collate";

--- a/classes/schema/ActionScheduler_StoreSchema.php
+++ b/classes/schema/ActionScheduler_StoreSchema.php
@@ -16,7 +16,7 @@ class ActionScheduler_StoreSchema extends ActionScheduler_Abstract_Schema {
 	/**
 	 * @var int Increment this value to trigger a schema update.
 	 */
-	protected $schema_version = 4;
+	protected $schema_version = 5;
 
 	public function __construct() {
 		$this->tables = [

--- a/classes/schema/ActionScheduler_StoreSchema.php
+++ b/classes/schema/ActionScheduler_StoreSchema.php
@@ -26,6 +26,13 @@ class ActionScheduler_StoreSchema extends ActionScheduler_Abstract_Schema {
 		];
 	}
 
+	/**
+	 * Performs additional setup work required to support this schema.
+	 */
+	public function init() {
+		add_action( 'action_scheduler_before_schema_update', array( $this, 'update_schema_5_0' ), 10, 2 );
+	}
+
 	protected function get_table_definition( $table ) {
 		global $wpdb;
 		$table_name       = $wpdb->$table;
@@ -82,5 +89,42 @@ class ActionScheduler_StoreSchema extends ActionScheduler_Abstract_Schema {
 			default:
 				return '';
 		}
+	}
+
+	/**
+	 * Update the actions table schema, allowing datetime fields to be NULL.
+	 *
+	 * This is needed because the NOT NULL constraint causes a conflict with some versions of MySQL
+	 * configured with sql_mode=NO_ZERO_DATE, which can for instance lead to tables not being created.
+	 *
+	 * Most other schema updates happen via ActionScheduler_Abstract_Schema::update_table(), however
+	 * that method relies on dbDelta() and this change is not possible when using that function.
+	 *
+	 * @param string $table Name of table being updated.
+	 * @param string $db_version The existing schema version of the table.
+	 */
+	public function update_schema_5_0( $table, $db_version ) {
+		global $wpdb;
+
+		if ( 'actionscheduler_actions' !== $table || version_compare( $db_version, '5', '>=' ) ) {
+			return;
+		}
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$table_name   = $wpdb->prefix . 'actionscheduler_actions';
+		$table_list   = $wpdb->get_col( "SHOW TABLES LIKE '${table_name}'" );
+		$default_date = self::DEFAULT_DATE;
+
+		if ( ! empty( $table_list ) ) {
+			$query = "
+				ALTER TABLE ${table_name}
+				MODIFY COLUMN scheduled_date_gmt datetime NULL default '${default_date}',
+				MODIFY COLUMN scheduled_date_local datetime NULL default '${default_date}',
+				MODIFY COLUMN last_attempt_gmt datetime NULL default '${default_date}',
+				MODIFY COLUMN last_attempt_local datetime NULL default '${default_date}'
+		";
+			$wpdb->query( $query ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		}
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 	}
 }


### PR DESCRIPTION
This is a re-play of [PR 622](https://github.com/woocommerce/action-scheduler/pull/622) (authored by Ron) and already tested/approved. 

However, it was merged into a release branch that was originally intended to be the basis of the `3.2.0` release (which actually shipped already, but with a different set of changes). That release branch contains other changes we don't want/need here and so this PR:

* Is a cherry-pick of Ron's work relating *specifically to the problem described in [#519](https://github.com/woocommerce/action-scheduler/issues/519)* (therefore, please see [the original PR for testing instructions](https://github.com/woocommerce/action-scheduler/pull/622))
* The only modifications to Ron's work is to the DBStore schema version (as of 3.2.1 we are already at [schema version `4`](https://github.com/woocommerce/action-scheduler/blob/3.2.1/classes/schema/ActionScheduler_StoreSchema.php#L18), so I bumped it up to `5`)—the LoggerSchema version is fine as is

---

### Other notes

* In addition to the instructions in [PR 622](https://github.com/woocommerce/action-scheduler/pull/622), remember that if you have to test more than once you will need to reset the following options:
    * `schema-ActionScheduler_LoggerSchema` (set to `2`)
    * `schema-ActionScheduler_StoreSchema` (set to `4`)
* Because it's a schema change, this will need to ship as a major release (so, probably `3.3.0`)

Closes #519.