### PR TITLE
Update stated PHP and WP minimums.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,11 +1,11 @@
 === Action Scheduler ===
 Contributors: Automattic, wpmuguru, claudiosanches, peterfabian1000, vedjain, jamosova, obliviousharmony, konamiman, sadowski, royho, barryhughes-1
 Tags: scheduler, cron
-Requires at least: 4.7
+Requires at least: 5.2
 Tested up to: 5.7
 Stable tag: 3.2.1
 License: GPLv3
-Requires PHP: 5.3
+Requires PHP: 5.6
 
 Action Scheduler - Job Queue for WordPress
 


### PR DESCRIPTION
Updates our stated minimum requirements, from WP 4.7 to WP 5.2 and from PHP 5.3 to PHP 5.6. 

This also means we can stop running Travis against those versions that are no longer supported—that's taken care of in [PR 727](https://github.com/woocommerce/action-scheduler/pull/727) (though, it's not essential that be merged first).

Closes #723.