### PR TITLE
Improve safety in cases where tables are not successfully created.

### DIFF
--- a/classes/abstracts/ActionScheduler_Abstract_Schema.php
+++ b/classes/abstracts/ActionScheduler_Abstract_Schema.php
@@ -150,4 +150,23 @@ abstract class ActionScheduler_Abstract_Schema {
 	protected function get_full_table_name( $table ) {
 		return $GLOBALS[ 'wpdb' ]->prefix . $table;
 	}
+
+	/**
+	 * Confirms that all of the tables registered by this schema class have been created.
+	 *
+	 * @return bool
+	 */
+	public function tables_exist() {
+		global $wpdb;
+
+		$existing_tables = $wpdb->get_col( 'SHOW TABLES' );
+		$expected_tables = array_map(
+			function ( $table_name ) use ( $wpdb ) {
+				return $wpdb->prefix . $table_name;
+			},
+			$this->tables
+		);
+
+		return count( array_intersect( $existing_tables, $expected_tables ) ) === count( $expected_tables );
+	}
 }

--- a/classes/migration/Controller.php
+++ b/classes/migration/Controller.php
@@ -2,7 +2,9 @@
 
 namespace Action_Scheduler\Migration;
 
-use Action_Scheduler\WP_CLI\Migration_Command;
+use ActionScheduler_DataController;
+use ActionScheduler_LoggerSchema;
+use ActionScheduler_StoreSchema;
 use Action_Scheduler\WP_CLI\ProgressBar;
 
 /**
@@ -87,12 +89,30 @@ class Controller {
 	}
 
 	/**
-	 * Set up the background migration process
+	 * Set up the background migration process.
 	 *
 	 * @return void
 	 */
 	public function schedule_migration() {
-		if ( \ActionScheduler_DataController::is_migration_complete() || $this->migration_scheduler->is_migration_scheduled() ) {
+		$logging_tables = new ActionScheduler_LoggerSchema();
+		$store_tables   = new ActionScheduler_StoreSchema();
+
+		/*
+		 * In some unusual cases, the expected tables may not have been created. In such cases
+		 * we do not schedule a migration as doing so will lead to fatal error conditions.
+		 *
+		 * In such cases the user will likely visit the Tools > Scheduled Actions screen to
+		 * investigate, and will see appropriate messaging (this step also triggers an attempt
+		 * to rebuild any missing tables).
+		 *
+		 * @see https://github.com/woocommerce/action-scheduler/issues/653
+		 */
+		if (
+			ActionScheduler_DataController::is_migration_complete()
+			|| $this->migration_scheduler->is_migration_scheduled()
+			|| ! $store_tables->tables_exist()
+			|| ! $logging_tables->tables_exist()
+		) {
 			return;
 		}
 

--- a/tests/phpunit/migration/Controller_Test.php
+++ b/tests/phpunit/migration/Controller_Test.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Contains tests for the Migration Controller.
+ *
+ * @package test_cases\migration
+ */
+
+use ActionScheduler_StoreSchema as Schema;
+use Action_Scheduler\Migration\Controller;
+use Action_Scheduler\Migration\Scheduler;
+
+/**
+ * Test the migration controller.
+ *
+ * @group migration
+ */
+class Controller_Test extends ActionScheduler_UnitTestCase {
+	/**
+	 * Test to ensure the Migration Controller will schedule the migration.
+	 */
+	public function test_schedules_migration() {
+		as_unschedule_action( Scheduler::HOOK );
+		Controller::instance()->schedule_migration();
+
+		$this->assertTrue(
+			as_next_scheduled_action( Scheduler::HOOK ) > 0,
+			'Confirm that the Migration Controller scheduled the migration.'
+		);
+
+		as_unschedule_action( Scheduler::HOOK );
+	}
+
+	/**
+	 * Test to ensure that if an essential table is missing, the Migration
+	 * Controller will not schedule a migration.
+	 *
+	 * @see https://github.com/woocommerce/action-scheduler/issues/653
+	 */
+	public function test_migration_not_scheduled_if_tables_are_missing() {
+		as_unschedule_action( Scheduler::HOOK );
+		$this->rename_claims_table();
+		Controller::instance()->schedule_migration();
+
+		$this->assertFalse(
+			as_next_scheduled_action( Scheduler::HOOK ),
+			'When required tables are missing, the migration will not be scheduled.'
+		);
+
+		$this->restore_claims_table_name();
+	}
+
+	/**
+	 * Rename the claims table, so that it cannot be used by the library.
+	 */
+	private function rename_claims_table() {
+		global $wpdb;
+		$normal_table_name   = $wpdb->prefix . Schema::CLAIMS_TABLE;
+		$modified_table_name = $normal_table_name . 'x';
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$wpdb->query( "RENAME TABLE {$normal_table_name} TO {$modified_table_name}" );
+	}
+
+	/**
+	 * Restore the expected name of the claims table, so that it can be used by the library
+	 * and any further tests.
+	 */
+	private function restore_claims_table_name() {
+		global $wpdb;
+		$normal_table_name   = $wpdb->prefix . Schema::CLAIMS_TABLE;
+		$modified_table_name = $normal_table_name . 'x';
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$wpdb->query( "RENAME TABLE {$modified_table_name} TO {$normal_table_name}" );
+	}
+}


### PR DESCRIPTION
In some unusual cases, one or more Action Scheduler tables may not be created (may apply to production environments where the necessary grants to `CREATE TABLE` are not set).

This can be a particular problem when a consumer plugin such as WooCommerce is activated because if, upon activation, the library attempts to schedule the migration process then the assumption is that the custom db tables already exist. If the actions table in particular does not exist, though, the end result is a fatal error (uncaught exception). Grizzly details and real-world examples can be found in the chain of linked issues (open #653 and you will find other associated reports).

Following earlier discussion, continually testing on every request to see if all of the expected tables exist seemed like overkill and so, in this changeset, we simply test to ensure the expected Logging and Store tables exist _before_ allowing a migration to be scheduled. This should mitigate the worst effects of this problem (ie, it should avoid users being unable to activate consumer plugins such as WooCommerce and should avoid them being 'locked out' of their admin environment) without unnecessary overhead.

Closes #653.

### How to test

Setup:

* Install WooCommerce 5.5.2 (you could probably substitute any other plugin that bundles Action Scheduler). Leave deactivated.
* Install Action Scheduler **(this branch)**. Leave deactivated.

Confirm "normal"/expected behavior:

* Activate WooCommerce.
* Should work!

Now simulate the problem:

* Deactivate WooCommerce.
* Rename `wp_actionscheduler_actions` to `wp_actionscheduler_actionsx` (or add whatever suffix/prefix you like)
* Try to activate WooCommerce.
* You will probably see a _"There has been a critical error on this website"_ screen and if you check your logs (or if you have something like Query Monitor active) you may see details of an uncaught RuntimeException concerning the missing table.
* You will probably also find the same problem across the site, not just in the plugin admin screen—ie, the user is effectively 'locked out'.

Test the fix:

* Because of the fatal conditions we've created, you likely won't easily be able to deactivate WooCommerce. To resolve this, simply rename the table back to the original name.
* Now the error is cleared,  deactivate WooCommerce.
* Activate Action Scheduler plugin (again, must be this branch): plugin loading conventions should mean that this version of Action Scheduler is the one that is loaded into memory (instead of whichever version is included in WooCommerce).
* Once again, rename `wp_actionscheduler_actions` to `wp_actionscheduler_actionsx`.
* Try to activate WooCommerce: this time it should activate successfully—no lock out (though if you use Query Monitor, you may see that tool catches various related database errors—we don't need to worry about that here, because they don't result in the user being blocked from performing further actions).

Finally _(not related to this changeset, but just to complete the picture):_

* Visit the **Tools ▸ Scheduled Actions** screen (if a user experienced this problem, they would probably find their way here—whether on their own initiative or after being steered by a support team, etc).
* You will see a message reading _"It appears one or more database tables were missing. Attempting to re-create the missing table(s)."_
* This doesn't guarantee the missing tables will be recreated (in an environment where this problem arises, probably they will not be) ... but I wanted to show there was some sort of user messaging already in the mix.

### Changelog

> Fix - Reduce risk of uncaught exceptions locking out users during plugin activation, in some unusual cases.