### PR TITLE
Also use the forked version of PHPUnit 7.5 when running tests under PHP 7.4 (GitHub Actions)

### DIFF
--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -67,8 +67,8 @@ jobs:
               chmod +x /tmp/phpunit
               rm ./vendor/bin/phpunit
               mv /tmp/phpunit ./vendor/bin/phpunit
-          # PHP 8.0 or higher: use our custom fork of PhpUnit 7.5
-          elif [ "$(php -r "echo version_compare( PHP_VERSION, '8.0', '>=' );")" ]; then
+          # PHP 7.4 or higher: use our custom fork of PhpUnit 7.5
+          elif [ "$(php -r "echo version_compare( PHP_VERSION, '7.4', '>=' );")" ]; then
               curl -L https://github.com/woocommerce/phpunit/archive/add-compatibility-with-php8-to-phpunit-7.zip -o /tmp/phpunit-7.5-fork.zip
               unzip -d /tmp/phpunit-7.5-fork /tmp/phpunit-7.5-fork.zip
               composer --working-dir=/tmp/phpunit-7.5-fork/phpunit-add-compatibility-with-php8-to-phpunit-7 install


### PR DESCRIPTION
When our tests run under GitHub Actions, a couple of tests consistently fail under PHP 7.4 (expand details below to see the specific errors).

<details>

```
There were 2 errors:

1) ActionScheduler_QueueRunner_Test::test_store_fetch_action_failure_schedule_next_instance
Function ReflectionType::__toString() is deprecated

/home/runner/work/action-scheduler/action-scheduler/tests/phpunit/runner/ActionScheduler_QueueRunner_Test.php:300
/home/runner/work/action-scheduler/action-scheduler/tests/phpunit/deprecated/ActionScheduler_UnitTestCase.php:35

2) ActionScheduler_QueueRunner_Test::test_store_fetch_action_failure_schedule_next_instance
Function ReflectionType::__toString() is deprecated

/home/runner/work/action-scheduler/action-scheduler/tests/phpunit/runner/ActionScheduler_QueueRunner_Test.php:300
/home/runner/work/action-scheduler/action-scheduler/tests/phpunit/deprecated/ActionScheduler_UnitTestCase.php:38

ERRORS!
Tests: 1176, Assertions: 1236, Errors: 2.
Error: Process completed with exit code 2.
```

</details>

This was essentially because we were running tests under PHP 7.4 with PHPUnit 5.7. Using (our fork of) PHPUnit 7.5 fixes this.