### PR TITLE
Do not lower the max_execution_time if it is already set to 0 (unlimited)

### DIFF
--- a/classes/ActionScheduler_Compatibility.php
+++ b/classes/ActionScheduler_Compatibility.php
@@ -83,17 +83,27 @@ class ActionScheduler_Compatibility {
 	 *
 	 * Only allows raising the existing limit and prevents lowering it. Wrapper for wc_set_time_limit(), when available.
 	 *
-	 * @param int The time limit in seconds.
+	 * @param int $limit The time limit in seconds.
 	 */
 	public static function raise_time_limit( $limit = 0 ) {
-		if ( $limit < ini_get( 'max_execution_time' ) ) {
+		$limit = (int) $limit;
+		$max_execution_time = (int) ini_get( 'max_execution_time' );
+
+		/*
+		 * If the max execution time is already unlimited (zero), or if it exceeds or is equal to the proposed
+		 * limit, there is no reason for us to make further changes (we never want to lower it).
+		 */
+		if (
+			0 === $max_execution_time
+			|| ( $max_execution_time >= $limit && $limit !== 0 )
+		) {
 			return;
 		}
 
 		if ( function_exists( 'wc_set_time_limit' ) ) {
 			wc_set_time_limit( $limit );
 		} elseif ( function_exists( 'set_time_limit' ) && false === strpos( ini_get( 'disable_functions' ), 'set_time_limit' ) && ! ini_get( 'safe_mode' ) ) { // phpcs:ignore PHPCompatibility.IniDirectives.RemovedIniDirectives.safe_modeDeprecatedRemoved
-			@set_time_limit( $limit );
+			@set_time_limit( $limit ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 		}
 	}
 }

--- a/tests/phpunit/helpers/ActionScheduler_Compatibility_Test.php
+++ b/tests/phpunit/helpers/ActionScheduler_Compatibility_Test.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * @group helpers
+ */
+class ActionScheduler_Compatibility_Test extends ActionScheduler_UnitTestCase {
+	/**
+	 * Test the logic relating to ActionScheduler_Compatibility::raise_time_limit().
+	 */
+	public function test_raise_time_limit() {
+		// We'll want to restore things after this test.
+		$default_max_execution_time = ini_get( 'max_execution_time' );
+
+		ini_set( 'max_execution_time', 0 );
+		ActionScheduler_Compatibility::raise_time_limit( 10 );
+		$this->assertEquals(
+			'0',
+			ini_get( 'max_execution_time' ),
+			'If the max_execution_time was already zero (unlimited), then it will not be changed.'
+		);
+
+		ini_set( 'max_execution_time', 60 );
+		ActionScheduler_Compatibility::raise_time_limit( 30 );
+		$this->assertEquals(
+			'60',
+			ini_get( 'max_execution_time' ),
+			'If the max_execution_time was already a higher value than we specify, then it will not be changed.'
+		);
+
+		ActionScheduler_Compatibility::raise_time_limit( 200 );
+		$this->assertEquals(
+			'200',
+			ini_get( 'max_execution_time' ),
+			'If the max_execution_time was a lower value than we specify, but was above zero, then it will be updated to the new value.'
+		);
+
+		ActionScheduler_Compatibility::raise_time_limit( 0 );
+		$this->assertEquals(
+			'0',
+			ini_get( 'max_execution_time' ),
+			'If the max_execution_time was a positive, non-zero value and we then specify zero (unlimited) as the new value, then it will be updated.'
+		);
+
+		// Cleanup.
+		ini_set( 'max_execution_time', $default_max_execution_time );
+	}
+}


### PR DESCRIPTION
Our [`ActionScheduler_Compatibility::raise_time_limit()`](https://github.com/woocommerce/action-scheduler/blob/3.2.1/classes/ActionScheduler_Compatibility.php#L81-L98) is designed so that it (theoretically), _"Only allows raising the existing limit and prevents lowering it."_

However, in cases where the max time is already 0 [(zero means unlimited)](https://www.php.net/manual/en/info.configuration.php#ini.max-execution-time) and a value such as 30 is passed to this method, the `max_execution_time` will indeed be changed to 30, effectively lowering it. This change addresses that.

### Testing

Testing this is a little awkward, but I'd suggest using the WP CLI shell (`wp shell`) and running through permutations similar to those you see in the related tests, for example:

```
% wp shell
>>> ini_set( 'max_execution_time', '0' )
=> "0"
>>> ActionScheduler_Compatibility::raise_time_limit( 30 )
=> null
>>> ini_get( 'max_execution_time' )
=> "0"
>>> # ↑ Should be '0' (with this branch)
>>> #   May be '30' (with current tagged release)
```

Things you can try with this approach:

- Ensure if the `max_execution_time` is zero (unlimited), subsequent calls to this method **do not** change it.
- Ensure if `max_execution_time` is a non-zero positive int (such as 30), calls to this method where a lower non-zero value (such as 20) are passed **do not** change it.
- Ensure if `max_execution_time` is a non-zero positive int (such as 30), calls to this method where zero _or_ a higher value (such as 60) are passed **do** change it appropriately.

If you decide to test this way, remember you will need to restart `wp shell` when you change branch.

Closes #754 and #745.