### PR TITLE
Update docs in preparation for 3.3.0 release.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -191,6 +191,29 @@ as_next_scheduled_action( $hook, $args, $group );
 (integer|boolean) The timestamp for the next occurrence, or false if nothing was found.
 
 
+## Function Reference / `as_has_scheduled_action()`
+
+### Description
+
+Check if there is a scheduled action in the queue, but more efficiently than as_next_scheduled_action(). It's recommended to use this function when you need to know whether a specific action is currently scheduled. _Available since 3.3.0._
+
+### Usage
+
+```php
+as_has_scheduled_action( $hook, $args, $group );
+```
+
+### Parameters
+
+- **$hook** (string)(required) Name of the action hook. Default: _none_.
+- **$args** (array) Arguments passed to callbacks when the hook triggers. Default: _`array()`_.
+- **$group** (string) The group the job is assigned to. Default: _''_.
+
+### Return value
+
+(boolean) True if a matching action is pending or in-progress, false otherwise.
+
+
 ## Function Reference / `as_get_scheduled_actions()`
 
 ### Description

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -108,7 +108,7 @@ require_once( plugin_dir_path( __FILE__ ) . '/libraries/action-scheduler/action-
  * so that our callback is run then.
  */
 function eg_schedule_midnight_log() {
-	if ( false === as_next_scheduled_action( 'eg_midnight_log' ) ) {
+	if ( false === as_has_scheduled_action( 'eg_midnight_log' ) ) {
 		as_schedule_recurring_action( strtotime( 'tomorrow' ), DAY_IN_SECONDS, 'eg_midnight_log' );
 	}
 }
@@ -123,4 +123,4 @@ function eg_log_action_data() {
 add_action( 'eg_midnight_log', 'eg_log_action_data' );
 ```
 
-For more details on all available API functions, and the data they accept, refer to the [API Reference](/api/).
+Note that the `as_has_scheduled_action()` function was added in 3.3.0: if you are using an earlier version, you should substitute `as_next_scheduled_action()` instead. For more details on all available API functions, and the data they accept, refer to the [API Reference](/api/).

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -123,4 +123,4 @@ function eg_log_action_data() {
 add_action( 'eg_midnight_log', 'eg_log_action_data' );
 ```
 
-Note that the `as_has_scheduled_action()` function was added in 3.3.0: if you are using an earlier version, you should substitute `as_next_scheduled_action()` instead. For more details on all available API functions, and the data they accept, refer to the [API Reference](/api/).
+Note that the `as_has_scheduled_action()` function was added in 3.3.0: if you are using an earlier version, you should use `as_next_scheduled_action()` instead. For more details on all available API functions, and the data they accept, refer to the [API Reference](/api/).


### PR DESCRIPTION
Changes to [our project docs](https://actionscheduler.org) for the upcoming 3.3.0 release, principally to reflect the addition of the new `as_has_scheduled_action()` function introduced in #688.

💡 Please review but do not merge (merge will happen once the 3.3.0 release happens).