### PR TITLE
Prepare for 3.3.0

### DIFF
--- a/action-scheduler.php
+++ b/action-scheduler.php
@@ -1,5 +1,5 @@
 <?php
-/*
+/**
  * Plugin Name: Action Scheduler
  * Plugin URI: https://actionscheduler.org
  * Description: A robust scheduling library for use in WordPress plugins.
@@ -23,35 +23,42 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
+ * @package ActionScheduler
  */
 
-if ( ! function_exists( 'action_scheduler_register_3_dot_2_dot_1' ) ) {
+if ( ! function_exists( 'action_scheduler_register_3_dot_3_dot_0' ) && function_exists( 'add_action' ) ) {
 
 	if ( ! class_exists( 'ActionScheduler_Versions' ) ) {
-		require_once( 'classes/ActionScheduler_Versions.php' );
+		require_once __DIR__ . '/classes/ActionScheduler_Versions.php';
 		add_action( 'plugins_loaded', array( 'ActionScheduler_Versions', 'initialize_latest_version' ), 1, 0 );
 	}
 
-	add_action( 'plugins_loaded', 'action_scheduler_register_3_dot_2_dot_1', 0, 0 );
+	add_action( 'plugins_loaded', 'action_scheduler_register_3_dot_3_dot_0', 0, 0 );
 
-	function action_scheduler_register_3_dot_2_dot_1() {
+	/**
+	 * Registers this version of Action Scheduler.
+	 */
+	function action_scheduler_register_3_dot_3_dot_0() {
 		$versions = ActionScheduler_Versions::instance();
-		$versions->register( '3.2.1', 'action_scheduler_initialize_3_dot_2_dot_1' );
+		$versions->register( '3.3.0', 'action_scheduler_initialize_3_dot_3_dot_0' );
 	}
 
-	function action_scheduler_initialize_3_dot_2_dot_1() {
+	/**
+	 * Initializes this version of Action Scheduler.
+	 */
+	function action_scheduler_initialize_3_dot_3_dot_0() {
 		// A final safety check is required even here, because historic versions of Action Scheduler
 		// followed a different pattern (in some unusual cases, we could reach this point and the
 		// ActionScheduler class is already defined—so we need to guard against that).
 		if ( ! class_exists( 'ActionScheduler' ) ) {
-			require_once( 'classes/abstracts/ActionScheduler.php' );
+			require_once __DIR__ . '/classes/abstracts/ActionScheduler.php';
 			ActionScheduler::init( __FILE__ );
 		}
 	}
 
 	// Support usage in themes - load this version if no plugin has loaded a version yet.
 	if ( did_action( 'plugins_loaded' ) && ! doing_action( 'plugins_loaded' ) && ! class_exists( 'ActionScheduler' ) ) {
-		action_scheduler_initialize_3_dot_2_dot_1();
+		action_scheduler_register_3_dot_3_dot_0();
 		do_action( 'action_scheduler_pre_theme_init' );
 		ActionScheduler_Versions::initialize_latest_version();
 	}

--- a/action-scheduler.php
+++ b/action-scheduler.php
@@ -58,7 +58,7 @@ if ( ! function_exists( 'action_scheduler_register_3_dot_3_dot_0' ) && function_
 
 	// Support usage in themes - load this version if no plugin has loaded a version yet.
 	if ( did_action( 'plugins_loaded' ) && ! doing_action( 'plugins_loaded' ) && ! class_exists( 'ActionScheduler' ) ) {
-		action_scheduler_register_3_dot_3_dot_0();
+		action_scheduler_initialize_3_dot_3_dot_0();
 		do_action( 'action_scheduler_pre_theme_init' );
 		ActionScheduler_Versions::initialize_latest_version();
 	}


### PR DESCRIPTION
Updates the initialization functions, ready for the 3.3.0 release.

Also adds:

- Some changes to satisfy the project's PHPCS ruleset (adds docblocks, removes superfluous parens from the require statements, etc).
- Some safety changes that were originally intended to land in the [3.2.0 release](https://github.com/woocommerce/action-scheduler/pull/621/files#diff-3656dd24b02354fa4258e4ed49dafa655b6ca34dc8b436752e6c991f2ca8418a) (including the check to see if `add_action()` is defined, and prefixing of the require paths with `__DIR__`) that were missed previously.

Updates #758.

### Testing instructions

Simple:

- Deactivate all other plugins.
- Checkout this branch (into the plugin directory, if it isn't already there).
- Activate.
- Confirm the Tools → Scheduled Actions screen is available.

Further (optional) testing steps:

- Additionally clone a second copy of Action Scheduler.
- Clone into a plugin directory named something like `aaa_action_scheduler` (so that WP loads this new version first).
- Checkout `3.2.1` (or any earlier tag) and run `composer i`.
- Activate (you should now have two versions of Action Scheduler installed and active).
- Confirm the Tools → Scheduled Actions screen is available.
- Using the Help tab on that screen, confirm it reads **About Action Scheduler 3.3.0**.

<img width="938" alt="help-tab" src="https://user-images.githubusercontent.com/3594411/133162734-3463f418-0a07-4117-80de-81d9a290fb71.png">
