### PR TITLE
Release/3.3.0

### DIFF
--- a/action-scheduler.php
+++ b/action-scheduler.php
@@ -5,7 +5,7 @@
  * Description: A robust scheduling library for use in WordPress plugins.
  * Author: Automattic
  * Author URI: https://automattic.com/
- * Version: 3.2.1
+ * Version: 3.3.0
  * License: GPLv3
  *
  * Copyright 2019 Automattic, Inc.  (https://automattic.com/contact/)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,9 +1,15 @@
 *** Changelog ***
 
+= 3.3.0 - 2021-xx-xx =
+* Enhancement - Adds as_has_scheduled_action() to provide a performant way to test for existing actions. #645
+* Fix - Improves compatibility with environments where NO_ZERO_DATE is enabled. #519
+* Fix - Adds safety checks to guard against errors when our database tables cannot be created. #645
+* Dev - Now supports queries that use multiple statuses. #649
+* Dev - Minimum requirements for WordPress and PHP bumped (to 5.2 and 5.6 respectively). #723
+
 = 3.2.1 - 2021-06-21 =
 * Fix - Add extra safety/account for different versions of AS and different loading patterns. #714
 * Fix - Handle hidden columns (Tools → Scheduled Actions) | #600.
-
 
 = 3.2.0 - 2021-06-03 =
 * Fix - Add "no ordering" option to as_next_scheduled_action().

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** Changelog ***
 
-= 3.3.0 - 2021-xx-xx =
+= 3.3.0 - 2021-09-15 =
 * Enhancement - Adds as_has_scheduled_action() to provide a performant way to test for existing actions. #645
 * Fix - Improves compatibility with environments where NO_ZERO_DATE is enabled. #519
 * Fix - Adds safety checks to guard against errors when our database tables cannot be created. #645

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "action-scheduler",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "action-scheduler",
   "title": "Action Scheduler",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "homepage": "https://actionscheduler.org/",
   "repository": {
     "type": "git",

--- a/readme.txt
+++ b/readme.txt
@@ -47,10 +47,16 @@ Collaboration is cool. We'd love to work with you to improve Action Scheduler. [
 
 == Changelog ==
 
+= 3.3.0 - 2021-xx-xx =
+* Enhancement - Adds as_has_scheduled_action() to provide a performant way to test for existing actions. #645
+* Fix - Improves compatibility with environments where NO_ZERO_DATE is enabled. #519
+* Fix - Adds safety checks to guard against errors when our database tables cannot be created. #645
+* Dev - Now supports queries that use multiple statuses. #649
+* Dev - Minimum requirements for WordPress and PHP bumped (to 5.2 and 5.6 respectively). #723
+
 = 3.2.1 - 2021-06-21 =
 * Fix - Add extra safety/account for different versions of AS and different loading patterns. #714
 * Fix - Handle hidden columns (Tools → Scheduled Actions) | #600.
-
 
 = 3.2.0 - 2021-06-03 =
 * Fix - Add "no ordering" option to as_next_scheduled_action().

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: Automattic, wpmuguru, claudiosanches, peterfabian1000, vedjain, ja
 Tags: scheduler, cron
 Requires at least: 5.2
 Tested up to: 5.7
-Stable tag: 3.2.1
+Stable tag: 3.3.0
 License: GPLv3
 Requires PHP: 5.6
 
@@ -47,7 +47,7 @@ Collaboration is cool. We'd love to work with you to improve Action Scheduler. [
 
 == Changelog ==
 
-= 3.3.0 - 2021-xx-xx =
+= 3.3.0 - 2021-09-15 =
 * Enhancement - Adds as_has_scheduled_action() to provide a performant way to test for existing actions. #645
 * Fix - Improves compatibility with environments where NO_ZERO_DATE is enabled. #519
 * Fix - Adds safety checks to guard against errors when our database tables cannot be created. #645


### PR DESCRIPTION
Changelog and version bumps (via the release tool) for [3.3.0](https://github.com/woocommerce/action-scheduler/releases/tag/3.3.0).