### PR TITLE
Allow filtering of ORDER BY on claim_actions

### DIFF
--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -655,10 +655,10 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 			$params[] = $group_id;
 		}
 
-		$order    = "ORDER BY attempts ASC, scheduled_date_gmt ASC, action_id ASC LIMIT %d";
+		$order    = apply_filters('action_scheduler_claim_actions_order_by', 'ORDER BY attempts ASC, scheduled_date_gmt ASC, action_id ASC' );
 		$params[] = $limit;
 
-		$sql = $wpdb->prepare( "{$update} {$where} {$order}", $params );
+		$sql = $wpdb->prepare( "{$update} {$where} {$order} LIMIT %d", $params );
 
 		$rows_affected = $wpdb->query( $sql );
 		if ( $rows_affected === false ) {

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -655,7 +655,14 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 			$params[] = $group_id;
 		}
 
-		$order    = apply_filters('action_scheduler_claim_actions_order_by', 'ORDER BY attempts ASC, scheduled_date_gmt ASC, action_id ASC' );
+		/**
+		 * Sets the order-by clause used in the action claim query.
+		 *
+		 * @since x.x.x
+		 *
+		 * @param string $order_by_sql
+		 */
+		$order    = apply_filters( 'action_scheduler_claim_actions_order_by', 'ORDER BY attempts ASC, scheduled_date_gmt ASC, action_id ASC' );
 		$params[] = $limit;
 
 		$sql = $wpdb->prepare( "{$update} {$where} {$order} LIMIT %d", $params );


### PR DESCRIPTION
Conditionally resolves #530 

Using `ORDER BY` makes the query excessively slow and leads to deadlocks. Without ORDER BY, the query will still pick the oldest actions (in most cases) because it'll order them based on the action_id which is sequential. For most cases, dropping the ORDER BY will have no negative impact, but will greatly improve performance and reduce deadlocks.

Stores that do not mind the order that AS actions run, can reduce/prevent deadlocks by removing the `ORDER BY` using this filter.

This is a less invasive and backwards compatible approach compared to #748 

### Changelog

> Dev - Adds new filter `action_scheduler_claim_actions_order_by` to allow tuning of the claim query (props @glagonikas)