### PR TITLE
Avoid triggering autoloaders during the version resolution process 

### DIFF
--- a/action-scheduler.php
+++ b/action-scheduler.php
@@ -28,7 +28,7 @@
 
 if ( ! function_exists( 'action_scheduler_register_3_dot_3_dot_0' ) && function_exists( 'add_action' ) ) {
 
-	if ( ! class_exists( 'ActionScheduler_Versions' ) ) {
+	if ( ! class_exists( 'ActionScheduler_Versions', false ) ) {
 		require_once __DIR__ . '/classes/ActionScheduler_Versions.php';
 		add_action( 'plugins_loaded', array( 'ActionScheduler_Versions', 'initialize_latest_version' ), 1, 0 );
 	}
@@ -50,14 +50,14 @@ if ( ! function_exists( 'action_scheduler_register_3_dot_3_dot_0' ) && function_
 		// A final safety check is required even here, because historic versions of Action Scheduler
 		// followed a different pattern (in some unusual cases, we could reach this point and the
 		// ActionScheduler class is already defined—so we need to guard against that).
-		if ( ! class_exists( 'ActionScheduler' ) ) {
+		if ( ! class_exists( 'ActionScheduler', false ) ) {
 			require_once __DIR__ . '/classes/abstracts/ActionScheduler.php';
 			ActionScheduler::init( __FILE__ );
 		}
 	}
 
 	// Support usage in themes - load this version if no plugin has loaded a version yet.
-	if ( did_action( 'plugins_loaded' ) && ! doing_action( 'plugins_loaded' ) && ! class_exists( 'ActionScheduler' ) ) {
+	if ( did_action( 'plugins_loaded' ) && ! doing_action( 'plugins_loaded' ) && ! class_exists( 'ActionScheduler', false ) ) {
 		action_scheduler_initialize_3_dot_3_dot_0();
 		do_action( 'action_scheduler_pre_theme_init' );
 		ActionScheduler_Versions::initialize_latest_version();


### PR DESCRIPTION
Contains commits from https://github.com/woocommerce/action-scheduler/pull/731 (already reviewed, but needed a further rebase to solve an issue with CI).

Closes #730.

### Changelog

> Fix - Avoid triggering autoloaders during the version resolution process (props @olegabr). 