### PR TITLE
PHPCS fixes (for ActionScheduler_DBStore.php)

### DIFF
--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -40,10 +40,10 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 	 * Save an action.
 	 *
 	 * @param ActionScheduler_Action $action Action object.
-	 * @param \DateTime              $date Optional schedule date. Default null.
+	 * @param DateTime              $date Optional schedule date. Default null.
 	 *
 	 * @return int Action ID.
-	 * @throws \RuntimeException     Throws exception when saving the action fails.
+	 * @throws RuntimeException     Throws exception when saving the action fails.
 	 */
 	public function save_action( ActionScheduler_Action $action, \DateTime $date = null ) {
 		try {


### PR DESCRIPTION
Replay of https://github.com/woocommerce/action-scheduler/pull/769, but rebased on master to allow our CI checks to run.

Closes #663.