### PR TITLE
PHPCS fixes for ActionScheduler_WpPostStore class

### DIFF
--- a/classes/data-stores/ActionScheduler_wpPostStore.php
+++ b/classes/data-stores/ActionScheduler_wpPostStore.php
@@ -856,7 +856,7 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 	/**
 	 * Mark failure on action.
 	 *
-	 * @param string $action_id - Action ID.
+	 * @param int $action_id Action ID.
 	 *
 	 * @return void
 	 * @throws RuntimeException When unable to mark failure on action ID.


### PR DESCRIPTION
This PR fixes the PHPCS scans issued in https://github.com/woocommerce/action-scheduler/issues/661 

Current PHPCS scan shows:

```
FOUND 213 ERRORS AND 68 WARNINGS AFFECTING 193 LINES
...
```

after the PR, the scan shows:

```
FOUND 1 ERROR AFFECTING 1 LINE
-------------------------------------------------------------------------------------------------
 6 | ERROR | Class name is not valid; consider ActionScheduler_WpPostStore instead
```