### PR TITLE
fix: parsing of day of week when `#` used

### DIFF
--- a/lib/cron-expression/CronExpression_DayOfWeekField.php
+++ b/lib/cron-expression/CronExpression_DayOfWeekField.php
@@ -53,8 +53,8 @@ class CronExpression_DayOfWeekField extends CronExpression_AbstractField
         if (strpos($value, '#')) {
             list($weekday, $nth) = explode('#', $value);
             // Validate the hash fields
-            if ($weekday < 1 || $weekday > 5) {
-                throw new InvalidArgumentException("Weekday must be a value between 1 and 5. {$weekday} given");
+            if ($weekday < 0 || $weekday > 7) {
+                throw new InvalidArgumentException("Weekday must be a value between 0 and 7. {$weekday} given");
             }
             if ($nth > 5) {
                 throw new InvalidArgumentException('There are never more than 5 of a given weekday in a month');


### PR DESCRIPTION
Currently, we only can use 1 to 5 as a **"day of week"** when we use `#` sign with it.

In this PR, **Day of week** range check is set to 0 to 7.
it fixes the parsing of string with `#` sign. eg. `0 12 ? 1/1 SUN#2 *`

fix: https://github.com/woocommerce/action-scheduler/issues/781
