### PR TITLE
fix: clearer logger timeout message

### DIFF
--- a/classes/abstracts/ActionScheduler_Logger.php
+++ b/classes/abstracts/ActionScheduler_Logger.php
@@ -109,8 +109,7 @@ abstract class ActionScheduler_Logger {
 
 	public function log_timed_out_action( $action_id, $timeout ) {
 		/* translators: %s: amount of time */
-		$this->log( $action_id, sprintf( __( 'action marked as failed after %s seconds. Unknown error occurred. Check server, PHP and database error logs to diagnose cause.
-', 'action-scheduler' ), $timeout ) );
+		$this->log( $action_id, sprintf( __( 'action marked as failed after %s seconds. Unknown error occurred. Check server, PHP and database error logs to diagnose cause.', 'action-scheduler' ), $timeout ) );
 	}
 
 	public function log_unexpected_shutdown( $action_id, $error ) {

--- a/classes/abstracts/ActionScheduler_Logger.php
+++ b/classes/abstracts/ActionScheduler_Logger.php
@@ -109,7 +109,8 @@ abstract class ActionScheduler_Logger {
 
 	public function log_timed_out_action( $action_id, $timeout ) {
 		/* translators: %s: amount of time */
-		$this->log( $action_id, sprintf( __( 'action timed out after %s seconds', 'action-scheduler' ), $timeout ) );
+		$this->log( $action_id, sprintf( __( 'action marked as failed after %s seconds. Unknown error occurred. Check server, PHP and database error logs to diagnose cause.
+', 'action-scheduler' ), $timeout ) );
 	}
 
 	public function log_unexpected_shutdown( $action_id, $error ) {


### PR DESCRIPTION
This PR fixes https://github.com/woocommerce/action-scheduler/issues/646 by making the timeout message more clear and indicating this is a marked failure due to a time limit, so an intentional action that could help users locate the source of the issue faster.

There should be no performance issues around it.

### Changelog

> Tweak - Improve messaging when logging timeout errors.