### PR TITLE
Feature: adding the --ignore-group CLI option

### DIFF
--- a/classes/WP_CLI/ActionScheduler_WPCLI_Scheduler_command.php
+++ b/classes/WP_CLI/ActionScheduler_WPCLI_Scheduler_command.php
@@ -66,7 +66,7 @@ class ActionScheduler_WPCLI_Scheduler_command extends WP_CLI_Command {
 		if ( $ignore_group ) {
 			$ignore_group_array = array_map(
 				function ( $val ) {
-					return ( $val ) ? ActionScheduler_DBStore::mark_group_for_exclussion( $val ) : '';
+					return ActionScheduler_DBStore::mark_group_for_exclussion( $val );
 				},
 				explode( ',', $ignore_group )
 			);

--- a/classes/WP_CLI/ActionScheduler_WPCLI_Scheduler_command.php
+++ b/classes/WP_CLI/ActionScheduler_WPCLI_Scheduler_command.php
@@ -25,7 +25,7 @@ class ActionScheduler_WPCLI_Scheduler_command extends WP_CLI_Command {
 	 * [--group=<group>]
 	 * : Only run actions from the specified group. Omitting this option runs actions from all groups.
 	 *
-	 * [--exclude-group=<group>]
+	 * [--ignore-group=<group>]
 	 * : Run actions by omiting the specified group. Omitting this option runs actions from all groups.
 	 *
 	 * [--free-memory-on=<count>]
@@ -51,7 +51,7 @@ class ActionScheduler_WPCLI_Scheduler_command extends WP_CLI_Command {
 		$hooks         = explode( ',', WP_CLI\Utils\get_flag_value( $assoc_args, 'hooks', '' ) );
 		$hooks         = array_filter( array_map( 'trim', $hooks ) );
 		$group         = \WP_CLI\Utils\get_flag_value( $assoc_args, 'group', '' );
-		$exclude_group = \WP_CLI\Utils\get_flag_value( $assoc_args, 'exclude-group', '' );
+		$ignore_group  = \WP_CLI\Utils\get_flag_value( $assoc_args, 'ignore-group', '' );
 		$free_on       = \WP_CLI\Utils\get_flag_value( $assoc_args, 'free-memory-on', 50 );
 		$sleep         = \WP_CLI\Utils\get_flag_value( $assoc_args, 'pause', 0 );
 		$force         = \WP_CLI\Utils\get_flag_value( $assoc_args, 'force', false );
@@ -63,18 +63,18 @@ class ActionScheduler_WPCLI_Scheduler_command extends WP_CLI_Command {
 		$actions_completed = 0;
 		$unlimited         = $batches === 0;
 
-		if ( $exclude_group ) {
-			$exclude_group_array = explode( ',', $exclude_group );
+		if ( $ignore_group ) {
+			$ignore_group_array = explode( ',', $ignore_group );
 
-			$exclude_group_array = array_map(
+			$ignore_group_array = array_map(
 				function ( $val ) {
 					return ( $val ) ? ActionScheduler_DBStore::mark_group_for_exclussion( $val ) : '';
 				},
-				$exclude_group_array
+				$ignore_group_array
 			);
 
-			if ( count( $exclude_group_array ) ) {
-				$group .= ',' . implode( ',', $exclude_group_array );
+			if ( count( $ignore_group_array ) ) {
+				$group .= ',' . implode( ',', $ignore_group_array );
 			}
 		}
 

--- a/classes/WP_CLI/ActionScheduler_WPCLI_Scheduler_command.php
+++ b/classes/WP_CLI/ActionScheduler_WPCLI_Scheduler_command.php
@@ -45,16 +45,17 @@ class ActionScheduler_WPCLI_Scheduler_command extends WP_CLI_Command {
 	 */
 	public function run( $args, $assoc_args ) {
 		// Handle passed arguments.
-		$batch         = absint( \WP_CLI\Utils\get_flag_value( $assoc_args, 'batch-size', 100 ) );
-		$batches       = absint( \WP_CLI\Utils\get_flag_value( $assoc_args, 'batches', 0 ) );
-		$clean         = absint( \WP_CLI\Utils\get_flag_value( $assoc_args, 'cleanup-batch-size', $batch ) );
-		$hooks         = explode( ',', WP_CLI\Utils\get_flag_value( $assoc_args, 'hooks', '' ) );
-		$hooks         = array_filter( array_map( 'trim', $hooks ) );
-		$group         = \WP_CLI\Utils\get_flag_value( $assoc_args, 'group', '' );
+		$batch   = absint( \WP_CLI\Utils\get_flag_value( $assoc_args, 'batch-size', 100 ) );
+		$batches = absint( \WP_CLI\Utils\get_flag_value( $assoc_args, 'batches', 0 ) );
+		$clean   = absint( \WP_CLI\Utils\get_flag_value( $assoc_args, 'cleanup-batch-size', $batch ) );
+		$hooks   = explode( ',', WP_CLI\Utils\get_flag_value( $assoc_args, 'hooks', '' ) );
+		$hooks   = array_filter( array_map( 'trim', $hooks ) );
+		$group   = \WP_CLI\Utils\get_flag_value( $assoc_args, 'group', '' );
+		$free_on = \WP_CLI\Utils\get_flag_value( $assoc_args, 'free-memory-on', 50 );
+		$sleep   = \WP_CLI\Utils\get_flag_value( $assoc_args, 'pause', 0 );
+		$force   = \WP_CLI\Utils\get_flag_value( $assoc_args, 'force', false );
+
 		$ignore_group  = \WP_CLI\Utils\get_flag_value( $assoc_args, 'ignore-group', '' );
-		$free_on       = \WP_CLI\Utils\get_flag_value( $assoc_args, 'free-memory-on', 50 );
-		$sleep         = \WP_CLI\Utils\get_flag_value( $assoc_args, 'pause', 0 );
-		$force         = \WP_CLI\Utils\get_flag_value( $assoc_args, 'force', false );
 
 		ActionScheduler_DataController::set_free_ticks( $free_on );
 		ActionScheduler_DataController::set_sleep_time( $sleep );

--- a/classes/WP_CLI/ActionScheduler_WPCLI_Scheduler_command.php
+++ b/classes/WP_CLI/ActionScheduler_WPCLI_Scheduler_command.php
@@ -55,7 +55,7 @@ class ActionScheduler_WPCLI_Scheduler_command extends WP_CLI_Command {
 		$sleep   = \WP_CLI\Utils\get_flag_value( $assoc_args, 'pause', 0 );
 		$force   = \WP_CLI\Utils\get_flag_value( $assoc_args, 'force', false );
 
-		$ignore_group  = \WP_CLI\Utils\get_flag_value( $assoc_args, 'ignore-group', '' );
+		$ignore_group = \WP_CLI\Utils\get_flag_value( $assoc_args, 'ignore-group', '' );
 
 		ActionScheduler_DataController::set_free_ticks( $free_on );
 		ActionScheduler_DataController::set_sleep_time( $sleep );

--- a/classes/WP_CLI/ActionScheduler_WPCLI_Scheduler_command.php
+++ b/classes/WP_CLI/ActionScheduler_WPCLI_Scheduler_command.php
@@ -68,7 +68,7 @@ class ActionScheduler_WPCLI_Scheduler_command extends WP_CLI_Command {
 
 			$ignore_group_array = array_map(
 				function ( $val ) {
-					return ActionScheduler_DBStore::mark_group_for_exclussion( $val );
+					return ActionScheduler_DBStore::mark_group_for_exclusion( $val );
 				},
 				explode( ',', $ignore_group )
 			);

--- a/classes/WP_CLI/ActionScheduler_WPCLI_Scheduler_command.php
+++ b/classes/WP_CLI/ActionScheduler_WPCLI_Scheduler_command.php
@@ -63,7 +63,8 @@ class ActionScheduler_WPCLI_Scheduler_command extends WP_CLI_Command {
 		$actions_completed = 0;
 		$unlimited         = $batches === 0;
 
-		if ( $ignore_group ) {
+		if ( ! $group && $ignore_group ) { // there is no need to proceed with the ignore code if $group is set.
+
 			$ignore_group_array = array_map(
 				function ( $val ) {
 					return ActionScheduler_DBStore::mark_group_for_exclussion( $val );

--- a/classes/WP_CLI/ActionScheduler_WPCLI_Scheduler_command.php
+++ b/classes/WP_CLI/ActionScheduler_WPCLI_Scheduler_command.php
@@ -64,13 +64,11 @@ class ActionScheduler_WPCLI_Scheduler_command extends WP_CLI_Command {
 		$unlimited         = $batches === 0;
 
 		if ( $ignore_group ) {
-			$ignore_group_array = explode( ',', $ignore_group );
-
 			$ignore_group_array = array_map(
 				function ( $val ) {
 					return ( $val ) ? ActionScheduler_DBStore::mark_group_for_exclussion( $val ) : '';
 				},
-				$ignore_group_array
+				explode( ',', $ignore_group )
 			);
 
 			if ( count( $ignore_group_array ) ) {

--- a/classes/abstracts/ActionScheduler_Store.php
+++ b/classes/abstracts/ActionScheduler_Store.php
@@ -238,6 +238,8 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 	public static function sanitize_group_name( $slug ) {
 		// removing the ignored group prefix from slug if present.
 		$slug = preg_replace( '/(' . preg_quote( self::IGNORE_GROUP_FLAG, null ) . ')?(.*)/m', '$2', $slug );
+
+		// further sanitisation here with `sanitize_title` maybe?
 		return $slug;
 	}
 

--- a/classes/abstracts/ActionScheduler_Store.php
+++ b/classes/abstracts/ActionScheduler_Store.php
@@ -11,7 +11,7 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 	const STATUS_FAILED         = 'failed';
 	const STATUS_CANCELED       = 'canceled';
 	const DEFAULT_CLASS         = 'ActionScheduler_wpPostStore';
-	const IGNORE_GROUP_FLAG    = '--';
+	const IGNORE_GROUP_FLAG     = '--*IGNORE*--';
 
 	/** @var ActionScheduler_Store */
 	private static $store = NULL;

--- a/classes/abstracts/ActionScheduler_Store.php
+++ b/classes/abstracts/ActionScheduler_Store.php
@@ -226,7 +226,7 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 	 * @param string $slug Group slug name.
 	 * @return string
 	 */
-	public static function mark_group_for_exclussion( $slug ) {
+	public static function mark_group_for_exclusion( $slug ) {
 		return $slug ? self::IGNORE_GROUP_FLAG . $slug : $slug;
 	}
 

--- a/classes/abstracts/ActionScheduler_Store.php
+++ b/classes/abstracts/ActionScheduler_Store.php
@@ -238,7 +238,7 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 	 */
 	public static function sanitize_group_name( $slug ) {
 		// removing the ignored group prefix from slug if present.
-		$slug = preg_replace( '/(' . preg_quote( self::IGNORE_GROUP_FLAG, null ) . ')?(.*)/m', '$2', $slug );
+		$slug = preg_replace( '/^(' . preg_quote( self::IGNORE_GROUP_FLAG, null ) . ')?(.*)/m', '$2', esc_sql( $slug ) );
 
 		// further sanitisation here with `sanitize_title` maybe?
 		return $slug;

--- a/classes/abstracts/ActionScheduler_Store.php
+++ b/classes/abstracts/ActionScheduler_Store.php
@@ -220,7 +220,8 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 	}
 
 	/**
-	 * Mark group for exclussion by prefixing with '-'.
+	 * Mark group for exclusion by applying a special prefix (by default, the value of
+	 * the IGNORE_GROUP_FLAG property).
 	 *
 	 * @param string $slug Group slug name.
 	 * @return string

--- a/classes/abstracts/ActionScheduler_Store.php
+++ b/classes/abstracts/ActionScheduler_Store.php
@@ -226,7 +226,7 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 	 * @return string
 	 */
 	public static function mark_group_for_exclussion( $slug ) {
-		return self::IGNORE_GROUP_FLAG . $slug;
+		return $slug ? self::IGNORE_GROUP_FLAG . $slug : $slug;
 	}
 
 	/**

--- a/classes/abstracts/ActionScheduler_Store.php
+++ b/classes/abstracts/ActionScheduler_Store.php
@@ -5,12 +5,13 @@
  * @codeCoverageIgnore
  */
 abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
-	const STATUS_COMPLETE = 'complete';
-	const STATUS_PENDING  = 'pending';
-	const STATUS_RUNNING  = 'in-progress';
-	const STATUS_FAILED   = 'failed';
-	const STATUS_CANCELED = 'canceled';
-	const DEFAULT_CLASS   = 'ActionScheduler_wpPostStore';
+	const STATUS_COMPLETE       = 'complete';
+	const STATUS_PENDING        = 'pending';
+	const STATUS_RUNNING        = 'in-progress';
+	const STATUS_FAILED         = 'failed';
+	const STATUS_CANCELED       = 'canceled';
+	const DEFAULT_CLASS         = 'ActionScheduler_wpPostStore';
+	const EXCLUDED_GROUP_PREFIX = '--';
 
 	/** @var ActionScheduler_Store */
 	private static $store = NULL;
@@ -207,6 +208,38 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 	 * @return array
 	 */
 	abstract public function find_actions_by_claim_id( $claim_id );
+
+	/**
+	 * Check if group name is prefixed for exclussion.
+	 *
+	 * @param string $slug Group slug name.
+	 * @return boolean
+	 */
+	protected static function group_has_excluded_prefix( $slug ) {
+		return self::EXCLUDED_GROUP_PREFIX === substr( $slug, 0, strlen( self::EXCLUDED_GROUP_PREFIX ) );
+	}
+
+	/**
+	 * Mark group for exclussion by prefixing with '-'.
+	 *
+	 * @param string $slug Group slug name.
+	 * @return string
+	 */
+	public static function mark_group_for_exclussion( $slug ) {
+		return self::EXCLUDED_GROUP_PREFIX . $slug;
+	}
+
+	/**
+	 * Sanitize group name.
+	 *
+	 * @param string $slug Group slug name.
+	 * @return string
+	 */
+	public static function sanitize_group_name( $slug ) {
+		// removing the excluded group prefix from slug if present.
+		$slug = preg_replace( '/(' . preg_quote( self::EXCLUDED_GROUP_PREFIX, null ) . ')?(.*)/m', '$2', $slug );
+		return $slug;
+	}
 
 	/**
 	 * @param string $comparison_operator

--- a/classes/abstracts/ActionScheduler_Store.php
+++ b/classes/abstracts/ActionScheduler_Store.php
@@ -11,7 +11,7 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 	const STATUS_FAILED         = 'failed';
 	const STATUS_CANCELED       = 'canceled';
 	const DEFAULT_CLASS         = 'ActionScheduler_wpPostStore';
-	const EXCLUDED_GROUP_PREFIX = '--';
+	const IGNORE_GROUP_FLAG    = '--';
 
 	/** @var ActionScheduler_Store */
 	private static $store = NULL;
@@ -215,8 +215,8 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 	 * @param string $slug Group slug name.
 	 * @return boolean
 	 */
-	protected static function group_has_excluded_prefix( $slug ) {
-		return self::EXCLUDED_GROUP_PREFIX === substr( $slug, 0, strlen( self::EXCLUDED_GROUP_PREFIX ) );
+	protected static function group_has_ignore_prefix( $slug ) {
+		return self::IGNORE_GROUP_FLAG === substr( $slug, 0, strlen( self::IGNORE_GROUP_FLAG ) );
 	}
 
 	/**
@@ -226,7 +226,7 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 	 * @return string
 	 */
 	public static function mark_group_for_exclussion( $slug ) {
-		return self::EXCLUDED_GROUP_PREFIX . $slug;
+		return self::IGNORE_GROUP_FLAG . $slug;
 	}
 
 	/**
@@ -236,8 +236,8 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 	 * @return string
 	 */
 	public static function sanitize_group_name( $slug ) {
-		// removing the excluded group prefix from slug if present.
-		$slug = preg_replace( '/(' . preg_quote( self::EXCLUDED_GROUP_PREFIX, null ) . ')?(.*)/m', '$2', $slug );
+		// removing the ignored group prefix from slug if present.
+		$slug = preg_replace( '/(' . preg_quote( self::IGNORE_GROUP_FLAG, null ) . ')?(.*)/m', '$2', $slug );
 		return $slug;
 	}
 

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -696,8 +696,6 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 			$params[] = implode( ',', $ignore_group_ids );
 		}
 
-		echo $where;
-		print_r($params);
 		/**
 		 * Sets the order-by clause used in the action claim query.
 		 *

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -138,7 +138,7 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 	 * @param string $slug Group slug.
 	 *
 	 * @return int Group ID.
-	 * @throws \InvalidArgumentException Throws exception when the group slug starts with '-'.
+	 * @throws \InvalidArgumentException Throws exception when the group slug starts with IGNORE_GROUP_FLAG.
 	 */
 	protected function create_group( $slug ) {
 		/** @var \wpdb $wpdb */
@@ -629,7 +629,7 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 	 * @param int       $limit Number of action to include in claim.
 	 * @param \DateTime $before_date Should use UTC timezone.
 	 * @param array     $hooks Hooks to filter for.
-	 * @param string    $group Group to filter for, adding -- in front of the group will have it ignored.
+	 * @param string    $group Group to filter for, adding IGNORE_GROUP_FLAG in front of the group will have it ignored.
 	 *
 	 * @return int The number of actions that were claimed.
 	 * @throws \InvalidArgumentException Throws InvalidArgumentException if group doesn't exist.

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -144,9 +144,9 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 		/** @var \wpdb $wpdb */
 		global $wpdb;
 
-		if ( self::group_has_excluded_prefix( $slug ) ) {
+		if ( self::group_has_ignore_prefix( $slug ) ) {
 			// translators: %s: excluded group name prefix.
-			throw new InvalidArgumentException( sprintf( __( 'Group names cannot start with %s.', 'action-scheduler' ), self::EXCLUDE_GROUP_FLAG ) );
+			throw new InvalidArgumentException( sprintf( __( 'Group names cannot start with %s.', 'action-scheduler' ), self::IGNORE_GROUP_FLAG ) );
 		}
 
 		$wpdb->insert( $wpdb->actionscheduler_groups, array( 'slug' => $slug ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
@@ -675,7 +675,7 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 					throw new InvalidArgumentException( sprintf( __( 'The group "%s" does not exist.', 'action-scheduler' ), $group ) );
 				}
 
-				if ( self::group_has_excluded_prefix( $group ) ) {
+				if ( self::group_has_ignore_prefix( $group ) ) {
 					$where .= ' AND group_id != %d';
 				} else {
 					$where .= ' AND group_id = %d';

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -660,7 +660,7 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 			$params       = array_merge( $params, array_values( $hooks ) );
 		}
 
-		$group_array = explode( ',', $group );
+		$group_array = array_filter( explode( ',', $group ) );
 
 		if ( is_array( $group_array ) && count( $group_array ) ) {
 

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -666,8 +666,7 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 
 			foreach ( $group_array as $group ) {
 
-				$group    = self::sanitize_group_name( $group );
-				$group_id = $this->get_group_id( $group );
+				$group_id = $this->get_group_id( self::sanitize_group_name( $group ) );
 
 				// throw exception if no matching group found, this matches ActionScheduler_wpPostStore's behaviour.
 				if ( empty( $group_id ) ) {
@@ -675,7 +674,7 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 					throw new InvalidArgumentException( sprintf( __( 'The group "%s" does not exist.', 'action-scheduler' ), $group ) );
 				}
 
-				$where   .= ( self::group_has_ignore_prefix( $group ) ? ' AND group_id != %d' : ' AND group_id = %d' );
+				$where   .= ' AND group_id ' . ( self::group_has_ignore_prefix( $group ) ? '!= %d' : '= %d' );
 				$params[] = $group_id;
 			}
 		}

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -629,7 +629,7 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 	 * @param int       $limit Number of action to include in claim.
 	 * @param \DateTime $before_date Should use UTC timezone.
 	 * @param array     $hooks Hooks to filter for.
-	 * @param string    $group Group to filter for, adding IGNORE_GROUP_FLAG in front of the group will have it ignored.
+	 * @param string    $group Comma-separated list of groups to filter by. Adding IGNORE_GROUP_FLAG in front of a group will cause it to be ignored.
 	 *
 	 * @return int The number of actions that were claimed.
 	 * @throws \InvalidArgumentException Throws InvalidArgumentException if group doesn't exist.

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -666,12 +666,13 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 
 			foreach ( $group_array as $group ) {
 
-				$group_id = $this->get_group_id( self::sanitize_group_name( $group ) );
+				$sanitized_group_name = self::sanitize_group_name( $group );
+				$group_id             = $this->get_group_id( $sanitized_group_name, false );
 
 				// throw exception if no matching group found, this matches ActionScheduler_wpPostStore's behaviour.
 				if ( empty( $group_id ) ) {
 					/* translators: %s: group name */
-					throw new InvalidArgumentException( sprintf( __( 'The group "%s" does not exist.', 'action-scheduler' ), $group ) );
+					throw new InvalidArgumentException( sprintf( __( 'The group "%s" does not exist.', 'action-scheduler' ), $sanitized_group_name ) );
 				}
 
 				$where   .= ' AND group_id ' . ( self::group_has_ignore_prefix( $group ) ? '!= %d' : '= %d' );

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -675,11 +675,7 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 					throw new InvalidArgumentException( sprintf( __( 'The group "%s" does not exist.', 'action-scheduler' ), $group ) );
 				}
 
-				if ( self::group_has_ignore_prefix( $group ) ) {
-					$where .= ' AND group_id != %d';
-				} else {
-					$where .= ' AND group_id = %d';
-				}
+				$where   .= ( self::group_has_ignore_prefix( $group ) ? ' AND group_id != %d' : ' AND group_id = %d' );
 				$params[] = $group_id;
 			}
 		}

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -145,7 +145,7 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 		global $wpdb;
 
 		if ( self::group_has_ignore_prefix( $slug ) ) {
-			// translators: %s: excluded group name prefix.
+			// translators: %s: ignored group name prefix.
 			throw new InvalidArgumentException( sprintf( __( 'Group names cannot start with %s.', 'action-scheduler' ), self::IGNORE_GROUP_FLAG ) );
 		}
 
@@ -629,7 +629,7 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 	 * @param int       $limit Number of action to include in claim.
 	 * @param \DateTime $before_date Should use UTC timezone.
 	 * @param array     $hooks Hooks to filter for.
-	 * @param string    $group Group to filter for, adding -- in front of the group will have it excluded.
+	 * @param string    $group Group to filter for, adding -- in front of the group will have it ignored.
 	 *
 	 * @return int The number of actions that were claimed.
 	 * @throws \InvalidArgumentException Throws InvalidArgumentException if group doesn't exist.

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -689,9 +689,7 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 		if ( count( $include_group_ids ) ) {
 			$where   .= ' AND group_id IN (%s)';
 			$params[] = implode( ',', $include_group_ids );
-		}
-
-		if ( count( $ignore_group_ids ) ) {
+		} elseif ( count( $ignore_group_ids ) ) {
 			$where   .= ' AND group_id NOT IN (%s)';
 			$params[] = implode( ',', $ignore_group_ids );
 		}

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -146,7 +146,7 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 
 		if ( self::group_has_excluded_prefix( $slug ) ) {
 			// translators: %s: excluded group name prefix.
-			throw new InvalidArgumentException( sprintf( __( 'Group names cannot start with %s.', 'action-scheduler' ), self::EXCLUDED_GROUP_PREFIX ) );
+			throw new InvalidArgumentException( sprintf( __( 'Group names cannot start with %s.', 'action-scheduler' ), self::EXCLUDE_GROUP_FLAG ) );
 		}
 
 		$wpdb->insert( $wpdb->actionscheduler_groups, array( 'slug' => $slug ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -146,7 +146,7 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 
 		if ( self::group_has_ignore_prefix( $slug ) ) {
 			// translators: %s: ignored group name prefix.
-			throw new InvalidArgumentException( sprintf( __( 'Group names cannot start with %s.', 'action-scheduler' ), self::IGNORE_GROUP_FLAG ) );
+			throw new InvalidArgumentException( sprintf( esc_html__( 'Group names cannot start with %s.', 'action-scheduler' ), self::IGNORE_GROUP_FLAG ) );
 		}
 
 		$wpdb->insert( $wpdb->actionscheduler_groups, array( 'slug' => $slug ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery

--- a/docs/wp-cli.md
+++ b/docs/wp-cli.md
@@ -30,7 +30,7 @@ These are the commands available to use with Action Scheduler:
     * `--batches` - This is the number of batches to run. Using 0 means that batches will continue running until there are no more actions to run.
     * `--hooks` - Process only actions with specific hook or hooks, like `'woocommerce_scheduled_subscription_payment'`. By default, actions with any hook will be processed. Define multiple hooks as a comma separated string (without spaces), e.g. `--hooks=woocommerce_scheduled_subscription_trial_end,woocommerce_scheduled_subscription_payment,woocommerce_scheduled_subscription_expiration`
     * `--group` - Process only actions in a specific group, like `'woocommerce-memberships'`. By default, actions in any group (or no group) will be processed. Accepts comma-separated list of groups to filter by. Adding --*IGNORE*-- in front of a group will cause it to be ignored.
-    * `-ignore-group` - Ignore processing actions from groups found inside the comma separated list of values.
+    * `--ignore-group` - Ignore processing actions from groups found inside the comma separated list of values.
     * `--force` - By default, Action Scheduler limits the number of concurrent batches that can be run at once to ensure the server does not get overwhelmed. Using the `--force` flag overrides this behavior to force the WP CLI queue to run.
 
 The best way to get a full list of commands and their available options is to use WP CLI itself. This can be done by running `wp action-scheduler` to list all Action Scheduler commands, or by including the `--help` flag with any of the individual commands. This will provide all relevant parameters and flags for the command.

--- a/docs/wp-cli.md
+++ b/docs/wp-cli.md
@@ -30,7 +30,7 @@ These are the commands available to use with Action Scheduler:
     * `--batches` - This is the number of batches to run. Using 0 means that batches will continue running until there are no more actions to run.
     * `--hooks` - Process only actions with specific hook or hooks, like `'woocommerce_scheduled_subscription_payment'`. By default, actions with any hook will be processed. Define multiple hooks as a comma separated string (without spaces), e.g. `--hooks=woocommerce_scheduled_subscription_trial_end,woocommerce_scheduled_subscription_payment,woocommerce_scheduled_subscription_expiration`
     * `--group` - Process only actions in a specific group, like `'woocommerce-memberships'`. By default, actions in any group (or no group) will be processed. Accepts comma-separated list of groups to filter by. Adding --*IGNORE*-- in front of a group will cause it to be ignored.
-    * `-ignore-group` - Ignore processing actions from groups found in the the comma separated list of values.
+    * `-ignore-group` - Ignore processing actions from groups found inside the comma separated list of values.
     * `--force` - By default, Action Scheduler limits the number of concurrent batches that can be run at once to ensure the server does not get overwhelmed. Using the `--force` flag overrides this behavior to force the WP CLI queue to run.
 
 The best way to get a full list of commands and their available options is to use WP CLI itself. This can be done by running `wp action-scheduler` to list all Action Scheduler commands, or by including the `--help` flag with any of the individual commands. This will provide all relevant parameters and flags for the command.

--- a/docs/wp-cli.md
+++ b/docs/wp-cli.md
@@ -29,7 +29,8 @@ These are the commands available to use with Action Scheduler:
     * `--batch-size` - This is the number of actions to run in a single batch. The default is `100`.
     * `--batches` - This is the number of batches to run. Using 0 means that batches will continue running until there are no more actions to run.
     * `--hooks` - Process only actions with specific hook or hooks, like `'woocommerce_scheduled_subscription_payment'`. By default, actions with any hook will be processed. Define multiple hooks as a comma separated string (without spaces), e.g. `--hooks=woocommerce_scheduled_subscription_trial_end,woocommerce_scheduled_subscription_payment,woocommerce_scheduled_subscription_expiration`
-    * `--group` - Process only actions in a specific group, like `'woocommerce-memberships'`. By default, actions in any group (or no group) will be processed.
+    * `--group` - Process only actions in a specific group, like `'woocommerce-memberships'`. By default, actions in any group (or no group) will be processed. Accepts comma-separated list of groups to filter by. Adding --*IGNORE*-- in front of a group will cause it to be ignored.
+    * `-ignore-group` - Ignore processing actions from groups found in the the comma separated list of values.
     * `--force` - By default, Action Scheduler limits the number of concurrent batches that can be run at once to ensure the server does not get overwhelmed. Using the `--force` flag overrides this behavior to force the WP CLI queue to run.
 
 The best way to get a full list of commands and their available options is to use WP CLI itself. This can be done by running `wp action-scheduler` to list all Action Scheduler commands, or by including the `--help` flag with any of the individual commands. This will provide all relevant parameters and flags for the command.


### PR DESCRIPTION
This PR fixes https://github.com/woocommerce/action-scheduler/issues/736.

As suggested in the issue, a `--ignore-group` option is the desired approach to name this.

The PR also adds support for multiple comma-separated groups, so `--ignore-group=group1,group2` could be used as well. This implementation would also allow for the `--group` option to take comma-separated values as `--group=group1,group2`.

## Why this approach?

Looking at the `$runner->setup( $batch, $hooks, $group, $force, $ignore_group );` alternative, where we would have to pass the `$ignore_group` additional parameter, the `$group` and `$ignore_group` are very similar, so maybe using a flag to specify which group to ignore as proposed in this PR might make the code a little bit simpler?

## Tests - TBD

Happy to add any related tests if this approach is considered valid.
