### PR TITLE
[PHP 8.1] Fix code that causes deprecation notices

### DIFF
--- a/classes/ActionScheduler_DateTime.php
+++ b/classes/ActionScheduler_DateTime.php
@@ -24,6 +24,7 @@ class ActionScheduler_DateTime extends DateTime {
 	 *
 	 * @return int
 	 */
+	#[\ReturnTypeWillChange]
 	public function getTimestamp() {
 		return method_exists( 'DateTime', 'getTimestamp' ) ? parent::getTimestamp() : $this->format( 'U' );
 	}
@@ -45,6 +46,7 @@ class ActionScheduler_DateTime extends DateTime {
 	 * @return int
 	 * @link http://php.net/manual/en/datetime.getoffset.php
 	 */
+	#[\ReturnTypeWillChange]
 	public function getOffset() {
 		return $this->utcOffset ? $this->utcOffset : parent::getOffset();
 	}
@@ -57,6 +59,7 @@ class ActionScheduler_DateTime extends DateTime {
 	 * @return static
 	 * @link http://php.net/manual/en/datetime.settimezone.php
 	 */
+	#[\ReturnTypeWillChange]
 	public function setTimezone( $timezone ) {
 		$this->utcOffset = 0;
 		parent::setTimezone( $timezone );

--- a/functions.php
+++ b/functions.php
@@ -313,7 +313,7 @@ function as_get_datetime_object( $date_string = null, $timezone = 'UTC' ) {
 	} elseif ( is_numeric( $date_string ) ) {
 		$date = new ActionScheduler_DateTime( '@' . $date_string, new DateTimeZone( $timezone ) );
 	} else {
-		$date = new ActionScheduler_DateTime( $date_string ?? 'now', new DateTimeZone( $timezone ) );
+		$date = new ActionScheduler_DateTime( null === $date_string ? 'now' : $date_string, new DateTimeZone( $timezone ) );
 	}
 	return $date;
 }

--- a/functions.php
+++ b/functions.php
@@ -313,7 +313,7 @@ function as_get_datetime_object( $date_string = null, $timezone = 'UTC' ) {
 	} elseif ( is_numeric( $date_string ) ) {
 		$date = new ActionScheduler_DateTime( '@' . $date_string, new DateTimeZone( $timezone ) );
 	} else {
-		$date = new ActionScheduler_DateTime( $date_string, new DateTimeZone( $timezone ) );
+		$date = new ActionScheduler_DateTime( $date_string ?? 'now', new DateTimeZone( $timezone ) );
 	}
 	return $date;
 }


### PR DESCRIPTION
This pull request just fixes a few parts of the code that causes deprecation notices under PHP 8.1 (caused by passing `null` to the `DateTime` constructor and by [mismatching return types](https://php.watch/versions/8.1/ReturnTypeWillChange)) when running the WooCommerce core unit tests. See [the fix pull request in WooCommerce core](https://github.com/woocommerce/woocommerce/pull/31333).
