### PR TITLE
WP_Async_Request upgrade source

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -105,3 +105,14 @@ It requires no setup, and won't override any WordPress APIs (unless you want it 
 Action Scheduler is designed to manage the scheduled actions on a single site. It has no special handling for running queues across multiple sites in a multisite network. That said, because its storage and Queue Runner are completely swappable, it would be possible to write multisite handling classes to use with it.
 
 If you'd like to create a multisite plugin to do this and release it publicly to help others, [open a new issue to let us know](https://github.com/woocommerce/action-scheduler/issues/new), we'd love to help you with it.
+
+
+### How can I change the Action Scheduler User-Agent to better identify its requests?
+
+function eg_define_custom_user_agent( $args ) {
+  $versions           = ActionScheduler_Versions::instance();
+  $args['user-agent'] = 'Action Scheduler/' . $versions->latest_version();
+
+	return $args;
+}
+add_filter( 'as_async_request_queue_runner_post_args', 'eg_define_custom_user_agent', 10, 1 );

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -114,8 +114,8 @@ The User-Agent parameter is just one of them and can be adjusted as:
 
 ```
 function eg_define_custom_user_agent( $args ) {
-    $versions           = ActionScheduler_Versions::instance();
-    $args['user-agent'] = 'Action Scheduler/' . $versions->latest_version();
+	$versions           = ActionScheduler_Versions::instance();
+	$args['user-agent'] = 'Action Scheduler/' . $versions->latest_version();
 
 	return $args;
 }

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -106,9 +106,13 @@ Action Scheduler is designed to manage the scheduled actions on a single site. I
 
 If you'd like to create a multisite plugin to do this and release it publicly to help others, [open a new issue to let us know](https://github.com/woocommerce/action-scheduler/issues/new), we'd love to help you with it.
 
-
 ### How can I change the Action Scheduler User-Agent to better identify its requests?
 
+Action Scheduler has a filter available named `as_async_request_queue_runner_post_args` which can be used to filter the arguments that are being sent to the `wp_remote_post` call.
+
+The User-Agent parameter is just one of them and can be adjusted as:
+
+```
 function eg_define_custom_user_agent( $args ) {
   $versions           = ActionScheduler_Versions::instance();
   $args['user-agent'] = 'Action Scheduler/' . $versions->latest_version();
@@ -116,3 +120,4 @@ function eg_define_custom_user_agent( $args ) {
 	return $args;
 }
 add_filter( 'as_async_request_queue_runner_post_args', 'eg_define_custom_user_agent', 10, 1 );
+```

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -114,8 +114,8 @@ The User-Agent parameter is just one of them and can be adjusted as:
 
 ```
 function eg_define_custom_user_agent( $args ) {
-  $versions           = ActionScheduler_Versions::instance();
-  $args['user-agent'] = 'Action Scheduler/' . $versions->latest_version();
+    $versions           = ActionScheduler_Versions::instance();
+    $args['user-agent'] = 'Action Scheduler/' . $versions->latest_version();
 
 	return $args;
 }

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -110,7 +110,7 @@ If you'd like to create a multisite plugin to do this and release it publicly to
 
 Action Scheduler has a filter available named `as_async_request_queue_runner_post_args` which can be used to filter the arguments that are being sent to the `wp_remote_post` call.
 
-The User-Agent parameter is just one of them and can be adjusted as:
+The User-Agent parameter is just one of them and can be adjusted as follows:
 
 ```
 function eg_define_custom_user_agent( $args ) {

--- a/lib/WP_Async_Request.php
+++ b/lib/WP_Async_Request.php
@@ -13,6 +13,7 @@ License URI: https://github.com/deliciousbrains/wp-background-processing/commit/
 */
 
 if ( ! class_exists( 'WP_Async_Request' ) ) {
+
 	/**
 	 * Abstract WP_Async_Request class.
 	 *

--- a/lib/WP_Async_Request.php
+++ b/lib/WP_Async_Request.php
@@ -13,7 +13,6 @@ License URI: https://github.com/deliciousbrains/wp-background-processing/commit/
 */
 
 if ( ! class_exists( 'WP_Async_Request' ) ) {
-
 	/**
 	 * Abstract WP_Async_Request class.
 	 *
@@ -104,10 +103,17 @@ if ( ! class_exists( 'WP_Async_Request' ) ) {
 				return $this->query_args;
 			}
 
-			return array(
+			$args = array(
 				'action' => $this->identifier,
 				'nonce'  => wp_create_nonce( $this->identifier ),
 			);
+
+			/**
+			 * Filters the post arguments used during an async request.
+			 *
+			 * @param array $url
+			 */
+			return apply_filters( $this->identifier . '_query_args', $args );
 		}
 
 		/**
@@ -120,7 +126,14 @@ if ( ! class_exists( 'WP_Async_Request' ) ) {
 				return $this->query_url;
 			}
 
-			return admin_url( 'admin-ajax.php' );
+			$url = admin_url( 'admin-ajax.php' );
+
+			/**
+			 * Filters the post arguments used during an async request.
+			 *
+			 * @param string $url
+			 */
+			return apply_filters( $this->identifier . '_query_url', $url );
 		}
 
 		/**
@@ -133,13 +146,20 @@ if ( ! class_exists( 'WP_Async_Request' ) ) {
 				return $this->post_args;
 			}
 
-			return array(
+			$args = array(
 				'timeout'   => 0.01,
 				'blocking'  => false,
 				'body'      => $this->data,
 				'cookies'   => $_COOKIE,
 				'sslverify' => apply_filters( 'https_local_ssl_verify', false ),
 			);
+
+			/**
+			 * Filters the post arguments used during an async request.
+			 *
+			 * @param array $args
+			 */
+			return apply_filters( $this->identifier . '_post_args', $args );
 		}
 
 		/**


### PR DESCRIPTION
As detailed in issue #787, to address that issue and introduce the proposed User-Agent filters, it would be beneficial to upgrade the `WP_Async_Request` library from [upstream](https://github.com/deliciousbrains/wp-background-processing/blob/master/classes/wp-async-request.php) as that includes the needed filters already.

As noted in the commit code, there are no major changes to the source library other than expanding the original code with some `apply_filters`, so performance-wise, there should be no impact.

### Changelog

> Dev - Updated WP_Async_Request class from the WP Background Processing library, adding several new filters.