### PR TITLE
Fixes #802 cancel action fatals

### DIFF
--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -446,7 +446,7 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 			array( '%s' ),
 			array( '%d' )
 		);
-		if ( empty( $updated ) ) {
+		if ( false === $updated ) {
 			/* translators: %s: action ID */
 			throw new \InvalidArgumentException( sprintf( __( 'Unidentified action %s', 'action-scheduler' ), $action_id ) );
 		}

--- a/functions.php
+++ b/functions.php
@@ -115,15 +115,23 @@ function as_unschedule_action( $hook, $args = array(), $group = '' ) {
 		$params['args'] = $args;
 	}
 
-	try {
-		$action_id = ActionScheduler::store()->query_action( $params );
-		if ( $action_id ) {
+	$action_id = ActionScheduler::store()->query_action( $params );
+
+	if ( $action_id ) {
+		try {
 			ActionScheduler::store()->cancel_action( $action_id );
+		} catch ( Exception $exception ) {
+			ActionScheduler::logger()->log(
+				$action_id,
+				sprintf(
+					/* translators: %s is the name of the hook to be cancelled. */
+					__( 'Caught exception while cancelling action: %s', 'action-scheduler' ),
+					esc_attr( $hook )
+				)
+			);
+
+			$action_id = null;
 		}
-	} catch ( Exception $exception ) {
-		$message = sprintf( __( 'Caught exception while cancelling action: %s', 'action-scheduler' ), esc_attr( $hook ) );
-		error_log( $message, E_WARNING );
-		$action_id = null;
 	}
 
 	return $action_id;

--- a/functions.php
+++ b/functions.php
@@ -115,9 +115,15 @@ function as_unschedule_action( $hook, $args = array(), $group = '' ) {
 		$params['args'] = $args;
 	}
 
-	$action_id = ActionScheduler::store()->query_action( $params );
-	if ( $action_id ) {
-		ActionScheduler::store()->cancel_action( $action_id );
+	try {
+		$action_id = ActionScheduler::store()->query_action( $params );
+		if ( $action_id ) {
+			ActionScheduler::store()->cancel_action( $action_id );
+		}
+	} catch ( Exception $exception ) {
+		$message = sprintf( __( 'Caught exception while cancelling action: %s', 'action-scheduler' ), esc_attr( $hook ) );
+		error_log( $message, E_WARNING );
+		$action_id = null;
 	}
 
 	return $action_id;


### PR DESCRIPTION
Compare database update boolean result when determining to throw an exception (on cancel action).

### Changelog

> Fix - When cancelling actions, only throw an exception in the event of a database error and improve handing of this from within as_unschedule_action().