### PR TITLE
Throw an exception (mark as failed) scheduled actions without any callbacks

### DIFF
--- a/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php
+++ b/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php
@@ -152,24 +152,6 @@ abstract class ActionScheduler_Abstract_QueueRunner extends ActionScheduler_Abst
 	}
 
 	/**
-	 * Specifically intended for use with recurring actions, this method assesses if they are of the same type
-	 * (for instance, they are both CronSchedule objects) and if the recurrence patterns are the same.
-	 *
-	 * @param ActionScheduler_Schedule $schedule_a
-	 * @param ActionScheduler_Schedule $schedule_b
-	 *
-	 * @return bool
-	 */
-	private function schedules_match( ActionScheduler_Schedule $schedule_a, ActionScheduler_Schedule $schedule_b ) {
-		return (
-			get_class( $schedule_a ) === get_class( $schedule_b )
-			&& method_exists( $schedule_a, 'get_recurrence' )
-			&& method_exists( $schedule_b, 'get_recurrence' )
-			&& $schedule_a->get_recurrence() === $schedule_b->get_recurrence()
-		);
-	}
-
-	/**
 	 * Run the queue cleaner.
 	 *
 	 * @author Jeremy Pry

--- a/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php
+++ b/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php
@@ -119,8 +119,8 @@ abstract class ActionScheduler_Abstract_QueueRunner extends ActionScheduler_Abst
 		 * Controls the failure threshold for recurring actions.
 		 *
 		 * Before rescheduling a recurring action, we look at its status. If it failed, we then check if all of the most
-		 * recent instances (upto the threshold set by the filter) have also failed, in which case we will not log a
-		 * further action.
+		 * recent actions (upto the threshold set by this filter) sharing the same hook have also failed: if they have,
+		 * that is considered consistent failure and a new instance of the action will not be scheduled.
 		 *
 		 * @param int $failure_threshold Number of actions of the same hook to examine for failure. Defaults to 5.
 		 */

--- a/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php
+++ b/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php
@@ -133,7 +133,7 @@ abstract class ActionScheduler_Abstract_QueueRunner extends ActionScheduler_Abst
 			'date'         => date_create( 'now', timezone_open( 'UTC' ) )->format( 'Y-m-d H:i:s' ),
 			'date_compare' => '<',
 			'per_page'     => 1,
-			'offset'       => $consistent_failure_threshold
+			'offset'       => $consistent_failure_threshold - 1
 		);
 
 		$first_failing_action_id = $this->store->query_actions( $query_args );

--- a/classes/actions/ActionScheduler_Action.php
+++ b/classes/actions/ActionScheduler_Action.php
@@ -18,8 +18,29 @@ class ActionScheduler_Action {
 		$this->set_group($group);
 	}
 
+	/**
+	 * Executes the action.
+	 *
+	 * If no callbacks are registered, an exception will be thrown and the action will not be
+	 * fired. This is useful to help detect cases where the code responsible for setting up
+	 * a scheduled action no longer exists.
+	 *
+	 * @throws Exception If no callbacks are registered for this action.
+	 */
 	public function execute() {
-		return do_action_ref_array( $this->get_hook(), array_values( $this->get_args() ) );
+		$hook = $this->get_hook();
+
+		if ( ! has_action( $hook ) ) {
+			throw new Exception(
+				sprintf(
+					/* translators: 1: action hook. */
+					__( 'Scheduled action for %1$s will not be executed as no callbacks are registered.', 'action-scheduler' ),
+					$hook
+				)
+			);
+		}
+
+		do_action_ref_array( $hook, array_values( $this->get_args() ) );
 	}
 
 	/**

--- a/tests/ActionScheduler_UnitTestCase.php
+++ b/tests/ActionScheduler_UnitTestCase.php
@@ -4,37 +4,24 @@
  * Class ActionScheduler_UnitTestCase
  */
 class ActionScheduler_UnitTestCase extends WP_UnitTestCase {
-	/**
-	 * Scheduled action hook that can be used when we want to simulate an action
-	 * with a registered callback.
-	 */
-	const HOOK_WITH_CALLBACK = 'hook_with_callback';
 
 	protected $existing_timezone;
 
 	/**
-	 * Shared setup logic.
+	 * Perform test set-up work.
 	 */
 	public function set_up() {
-		add_action( self::HOOK_WITH_CALLBACK, array( $this, 'empty_callback') );
+		ActionScheduler_Callbacks::add_callbacks();
 		parent::set_up();
 	}
 
 	/**
-	 * Shared tear-down logic.
+	 * Perform test tear-down work.
 	 */
 	public function tear_down() {
-		remove_action( self::HOOK_WITH_CALLBACK, array( $this, 'empty_callback' ) );
+		ActionScheduler_Callbacks::remove_callbacks();
 		parent::tear_down();
 	}
-
-	/**
-	 * This stub is used as the callback function for the self::HOOK_WITH_CALLBACK hook.
-	 *
-	 * Action Scheduler will mark actions as 'failed' if a callback does not exist, this
-	 * simply serves to act as the callback for various test scenarios in child classes.
-	 */
-	public function empty_callback() {}
 
 	/**
 	 * Counts the number of test cases executed by run(TestResult result).

--- a/tests/ActionScheduler_UnitTestCase.php
+++ b/tests/ActionScheduler_UnitTestCase.php
@@ -4,8 +4,37 @@
  * Class ActionScheduler_UnitTestCase
  */
 class ActionScheduler_UnitTestCase extends WP_UnitTestCase {
+	/**
+	 * Scheduled action hook that can be used when we want to simulate an action
+	 * with a registered callback.
+	 */
+	const HOOK_WITH_CALLBACK = 'hook_with_callback';
 
 	protected $existing_timezone;
+
+	/**
+	 * Shared setup logic.
+	 */
+	public function set_up() {
+		add_action( self::HOOK_WITH_CALLBACK, array( $this, 'empty_callback') );
+		parent::set_up();
+	}
+
+	/**
+	 * Shared tear-down logic.
+	 */
+	public function tear_down() {
+		remove_action( self::HOOK_WITH_CALLBACK, array( $this, 'empty_callback' ) );
+		parent::tear_down();
+	}
+
+	/**
+	 * This stub is used as the callback function for the self::HOOK_WITH_CALLBACK hook.
+	 *
+	 * Action Scheduler will mark actions as 'failed' if a callback does not exist, this
+	 * simply serves to act as the callback for various test scenarios in child classes.
+	 */
+	public function empty_callback() {}
 
 	/**
 	 * Counts the number of test cases executed by run(TestResult result).

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -30,6 +30,7 @@ if ( class_exists( 'PHPUnit\Framework\TestResult' ) ) { // PHPUnit 6.0 or newer
 	include_once('phpunit/deprecated/ActionScheduler_UnitTestCase.php');
 }
 
+include_once 'phpunit/helpers/ActionScheduler_Callbacks.php';
 include_once('phpunit/ActionScheduler_Mocker.php');
 include_once('phpunit/ActionScheduler_Mock_Async_Request_QueueRunner.php');
 include_once('phpunit/jobstore/AbstractStoreTest.php');

--- a/tests/phpunit/deprecated/ActionScheduler_UnitTestCase.php
+++ b/tests/phpunit/deprecated/ActionScheduler_UnitTestCase.php
@@ -8,6 +8,22 @@ class ActionScheduler_UnitTestCase extends WP_UnitTestCase {
 	protected $existing_timezone;
 
 	/**
+	 * Perform test set-up work.
+	 */
+	public function set_up() {
+		ActionScheduler_Callbacks::add_callbacks();
+		parent::set_up();
+	}
+
+	/**
+	 * Perform test tear-down work.
+	 */
+	public function tear_down() {
+		ActionScheduler_Callbacks::remove_callbacks();
+		parent::tear_down();
+	}
+
+	/**
 	 * Counts the number of test cases executed by run(TestResult result).
 	 *
 	 * @return int

--- a/tests/phpunit/helpers/ActionScheduler_Callbacks.php
+++ b/tests/phpunit/helpers/ActionScheduler_Callbacks.php
@@ -1,0 +1,31 @@
+<?php
+
+class ActionScheduler_Callbacks {
+	/**
+	 * Scheduled action hook that can be used when we want to simulate an action
+	 * with a registered callback.
+	 */
+	const HOOK_WITH_CALLBACK = 'hook_with_callback';
+
+	/**
+	 * Setup callbacks for different types of hook.
+	 */
+	public static function add_callbacks() {
+		add_action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, array( __CLASS__, 'empty_callback') );
+	}
+
+	/**
+	 * Remove callbacks.
+	 */
+	public static function remove_callbacks() {
+		remove_action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, array( __CLASS__, 'empty_callback' ) );
+	}
+
+	/**
+	 * This stub is used as the callback function for the ActionScheduler_Callbacks::HOOK_WITH_CALLBACK hook.
+	 *
+	 * Action Scheduler will mark actions as 'failed' if a callback does not exist, this
+	 * simply serves to act as the callback for various test scenarios in child classes.
+	 */
+	public static function empty_callback() {}
+}

--- a/tests/phpunit/jobs/ActionScheduler_Action_Test.php
+++ b/tests/phpunit/jobs/ActionScheduler_Action_Test.php
@@ -8,30 +8,30 @@ class ActionScheduler_Action_Test extends ActionScheduler_UnitTestCase {
 	public function test_set_schedule() {
 		$time = as_get_datetime_object();
 		$schedule = new ActionScheduler_SimpleSchedule($time);
-		$action = new ActionScheduler_Action('my_hook', array(), $schedule);
+		$action = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, array(), $schedule );
 		$this->assertEquals( $schedule, $action->get_schedule() );
 	}
 
 	public function test_null_schedule() {
-		$action = new ActionScheduler_Action('my_hook');
+		$action = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK );
 		$this->assertInstanceOf( 'ActionScheduler_NullSchedule', $action->get_schedule() );
 	}
 
 	public function test_set_hook() {
-		$action = new ActionScheduler_Action('my_hook');
-		$this->assertEquals( 'my_hook', $action->get_hook() );
+		$action = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK );
+		$this->assertEquals( self::HOOK_WITH_CALLBACK, $action->get_hook() );
 	}
 
 	public function test_args() {
-		$action = new ActionScheduler_Action('my_hook');
+		$action = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK );
 		$this->assertEmpty($action->get_args());
 
-		$action = new ActionScheduler_Action('my_hook', array(5,10,15));
+		$action = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, array( 5, 10, 15 ) );
 		$this->assertEqualSets(array(5,10,15), $action->get_args());
 	}
 
 	public function test_set_group() {
-		$action = new ActionScheduler_Action('my_hook', array(), NULL, 'my_group');
+		$action = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, array(), NULL, 'my_group' );
 		$this->assertEquals('my_group', $action->get_group());
 	}
 
@@ -52,4 +52,3 @@ class ActionScheduler_Action_Test extends ActionScheduler_UnitTestCase {
 		$this->assertEquals( $random, reset($event['args']) );
 	}
 }
- 

--- a/tests/phpunit/jobs/ActionScheduler_Action_Test.php
+++ b/tests/phpunit/jobs/ActionScheduler_Action_Test.php
@@ -8,30 +8,30 @@ class ActionScheduler_Action_Test extends ActionScheduler_UnitTestCase {
 	public function test_set_schedule() {
 		$time = as_get_datetime_object();
 		$schedule = new ActionScheduler_SimpleSchedule($time);
-		$action = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, array(), $schedule );
+		$action = new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, array(), $schedule );
 		$this->assertEquals( $schedule, $action->get_schedule() );
 	}
 
 	public function test_null_schedule() {
-		$action = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK );
+		$action = new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK );
 		$this->assertInstanceOf( 'ActionScheduler_NullSchedule', $action->get_schedule() );
 	}
 
 	public function test_set_hook() {
-		$action = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK );
-		$this->assertEquals( self::HOOK_WITH_CALLBACK, $action->get_hook() );
+		$action = new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK );
+		$this->assertEquals( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, $action->get_hook() );
 	}
 
 	public function test_args() {
-		$action = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK );
+		$action = new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK );
 		$this->assertEmpty($action->get_args());
 
-		$action = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, array( 5, 10, 15 ) );
+		$action = new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, array( 5, 10, 15 ) );
 		$this->assertEqualSets(array(5,10,15), $action->get_args());
 	}
 
 	public function test_set_group() {
-		$action = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, array(), NULL, 'my_group' );
+		$action = new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, array(), NULL, 'my_group' );
 		$this->assertEquals('my_group', $action->get_group());
 	}
 

--- a/tests/phpunit/jobstore/AbstractStoreTest.php
+++ b/tests/phpunit/jobstore/AbstractStoreTest.php
@@ -3,6 +3,7 @@
 namespace Action_Scheduler\Tests\DataStores;
 
 use ActionScheduler_Action;
+use ActionScheduler_Callbacks;
 use ActionScheduler_IntervalSchedule;
 use ActionScheduler_SimpleSchedule;
 use ActionScheduler_Store;
@@ -27,7 +28,7 @@ abstract class AbstractStoreTest extends ActionScheduler_UnitTestCase {
 	public function test_get_status() {
 		$time = as_get_datetime_object('-10 minutes');
 		$schedule = new ActionScheduler_IntervalSchedule($time, HOUR_IN_SECONDS);
-		$action = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, array(), $schedule);
+		$action = new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, array(), $schedule);
 		$store = $this->get_store();
 		$action_id = $store->save_action($action);
 
@@ -44,18 +45,18 @@ abstract class AbstractStoreTest extends ActionScheduler_UnitTestCase {
 
 	public function test_query_actions_query_type_arg_invalid_option() {
 		$this->expectException( InvalidArgumentException::class );
-		$this->get_store()->query_actions( array( 'hook' => self::HOOK_WITH_CALLBACK ), 'invalid' );
+		$this->get_store()->query_actions( array( 'hook' => ActionScheduler_Callbacks::HOOK_WITH_CALLBACK ), 'invalid' );
 	}
 
 	public function test_query_actions_query_type_arg_valid_options() {
 		$store = $this->get_store();
 		$schedule = new ActionScheduler_SimpleSchedule( as_get_datetime_object( 'tomorrow' ) );
 
-		$action_id_1 = $store->save_action( new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, array( 1 ), $schedule ) );
-		$action_id_2 = $store->save_action( new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, array( 1 ), $schedule ) );
+		$action_id_1 = $store->save_action( new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, array( 1 ), $schedule ) );
+		$action_id_2 = $store->save_action( new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, array( 1 ), $schedule ) );
 
-		$this->assertEquals( array( $action_id_1, $action_id_2 ), $store->query_actions( array( 'hook' => self::HOOK_WITH_CALLBACK ) ) );
-		$this->assertEquals( 2, $store->query_actions( array( 'hook' => self::HOOK_WITH_CALLBACK ), 'count' ) );
+		$this->assertEquals( array( $action_id_1, $action_id_2 ), $store->query_actions( array( 'hook' => ActionScheduler_Callbacks::HOOK_WITH_CALLBACK ) ) );
+		$this->assertEquals( 2, $store->query_actions( array( 'hook' => ActionScheduler_Callbacks::HOOK_WITH_CALLBACK ), 'count' ) );
 	}
 
 	public function test_query_actions_by_single_status() {

--- a/tests/phpunit/jobstore/AbstractStoreTest.php
+++ b/tests/phpunit/jobstore/AbstractStoreTest.php
@@ -27,7 +27,7 @@ abstract class AbstractStoreTest extends ActionScheduler_UnitTestCase {
 	public function test_get_status() {
 		$time = as_get_datetime_object('-10 minutes');
 		$schedule = new ActionScheduler_IntervalSchedule($time, HOUR_IN_SECONDS);
-		$action = new ActionScheduler_Action('my_hook', array(), $schedule);
+		$action = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, array(), $schedule);
 		$store = $this->get_store();
 		$action_id = $store->save_action($action);
 
@@ -44,18 +44,18 @@ abstract class AbstractStoreTest extends ActionScheduler_UnitTestCase {
 
 	public function test_query_actions_query_type_arg_invalid_option() {
 		$this->expectException( InvalidArgumentException::class );
-		$this->get_store()->query_actions( array( 'hook' => 'my_hook' ), 'invalid' );
+		$this->get_store()->query_actions( array( 'hook' => self::HOOK_WITH_CALLBACK ), 'invalid' );
 	}
 
 	public function test_query_actions_query_type_arg_valid_options() {
 		$store = $this->get_store();
 		$schedule = new ActionScheduler_SimpleSchedule( as_get_datetime_object( 'tomorrow' ) );
 
-		$action_id_1 = $store->save_action( new ActionScheduler_Action( 'my_hook', array( 1 ), $schedule ) );
-		$action_id_2 = $store->save_action( new ActionScheduler_Action( 'my_hook', array( 1 ), $schedule ) );
+		$action_id_1 = $store->save_action( new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, array( 1 ), $schedule ) );
+		$action_id_2 = $store->save_action( new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, array( 1 ), $schedule ) );
 
-		$this->assertEquals( array( $action_id_1, $action_id_2 ), $store->query_actions( array( 'hook' => 'my_hook' ) ) );
-		$this->assertEquals( 2, $store->query_actions( array( 'hook' => 'my_hook' ), 'count' ) );
+		$this->assertEquals( array( $action_id_1, $action_id_2 ), $store->query_actions( array( 'hook' => self::HOOK_WITH_CALLBACK ) ) );
+		$this->assertEquals( 2, $store->query_actions( array( 'hook' => self::HOOK_WITH_CALLBACK ), 'count' ) );
 	}
 
 	public function test_query_actions_by_single_status() {

--- a/tests/phpunit/jobstore/ActionScheduler_DBStoreMigrator_Test.php
+++ b/tests/phpunit/jobstore/ActionScheduler_DBStoreMigrator_Test.php
@@ -10,7 +10,7 @@ class ActionScheduler_DBStoreMigrator_Test extends ActionScheduler_UnitTestCase 
 		$scheduled_date    = as_get_datetime_object( strtotime( '-24 hours' ) );
 		$last_attempt_date = as_get_datetime_object( strtotime( '-23 hours' ) );
 
-		$action = new ActionScheduler_FinishedAction( self::HOOK_WITH_CALLBACK, [], new ActionScheduler_SimpleSchedule( $scheduled_date ) );
+		$action = new ActionScheduler_FinishedAction( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, [], new ActionScheduler_SimpleSchedule( $scheduled_date ) );
 		$store  = new ActionScheduler_DBStoreMigrator();
 
 		$action_id   = $store->save_action( $action, null, $last_attempt_date );

--- a/tests/phpunit/jobstore/ActionScheduler_DBStoreMigrator_Test.php
+++ b/tests/phpunit/jobstore/ActionScheduler_DBStoreMigrator_Test.php
@@ -10,7 +10,7 @@ class ActionScheduler_DBStoreMigrator_Test extends ActionScheduler_UnitTestCase 
 		$scheduled_date    = as_get_datetime_object( strtotime( '-24 hours' ) );
 		$last_attempt_date = as_get_datetime_object( strtotime( '-23 hours' ) );
 
-		$action = new ActionScheduler_FinishedAction( 'my_hook', [], new ActionScheduler_SimpleSchedule( $scheduled_date ) );
+		$action = new ActionScheduler_FinishedAction( self::HOOK_WITH_CALLBACK, [], new ActionScheduler_SimpleSchedule( $scheduled_date ) );
 		$store  = new ActionScheduler_DBStoreMigrator();
 
 		$action_id   = $store->save_action( $action, null, $last_attempt_date );

--- a/tests/phpunit/jobstore/ActionScheduler_DBStore_Test.php
+++ b/tests/phpunit/jobstore/ActionScheduler_DBStore_Test.php
@@ -29,7 +29,7 @@ class ActionScheduler_DBStore_Test extends AbstractStoreTest {
 	public function test_create_action() {
 		$time      = as_get_datetime_object();
 		$schedule  = new ActionScheduler_SimpleSchedule( $time );
-		$action    = new ActionScheduler_Action( 'my_hook', [], $schedule );
+		$action    = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, [], $schedule );
 		$store     = new ActionScheduler_DBStore();
 		$action_id = $store->save_action( $action );
 
@@ -38,7 +38,7 @@ class ActionScheduler_DBStore_Test extends AbstractStoreTest {
 
 	public function test_create_action_with_scheduled_date() {
 		$time        = as_get_datetime_object( strtotime( '-1 week' ) );
-		$action      = new ActionScheduler_Action( 'my_hook', [], new ActionScheduler_SimpleSchedule( $time ) );
+		$action      = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, [], new ActionScheduler_SimpleSchedule( $time ) );
 		$store       = new ActionScheduler_DBStore();
 		$action_id   = $store->save_action( $action, $time );
 		$action_date = $store->get_date( $action_id );
@@ -49,7 +49,7 @@ class ActionScheduler_DBStore_Test extends AbstractStoreTest {
 	public function test_retrieve_action() {
 		$time      = as_get_datetime_object();
 		$schedule  = new ActionScheduler_SimpleSchedule( $time );
-		$action    = new ActionScheduler_Action( 'my_hook', [], $schedule, 'my_group' );
+		$action    = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, [], $schedule, 'my_group' );
 		$store     = new ActionScheduler_DBStore();
 		$action_id = $store->save_action( $action );
 
@@ -63,7 +63,7 @@ class ActionScheduler_DBStore_Test extends AbstractStoreTest {
 	public function test_cancel_action() {
 		$time      = as_get_datetime_object();
 		$schedule  = new ActionScheduler_SimpleSchedule( $time );
-		$action    = new ActionScheduler_Action( 'my_hook', [], $schedule, 'my_group' );
+		$action    = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, [], $schedule, 'my_group' );
 		$store     = new ActionScheduler_DBStore();
 		$action_id = $store->save_action( $action );
 		$store->cancel_action( $action_id );
@@ -99,7 +99,7 @@ class ActionScheduler_DBStore_Test extends AbstractStoreTest {
 			$delta     = sprintf( '+%d day', $day );
 			$time      = as_get_datetime_object( $delta );
 			$schedule  = new ActionScheduler_SimpleSchedule( $time );
-			$action    = new ActionScheduler_Action( 'my_hook', [], $schedule, $group );
+			$action    = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, [], $schedule, $group );
 			$actions[] = $store->save_action( $action );
 		}
 		$store->cancel_actions_by_group( $group );
@@ -116,7 +116,7 @@ class ActionScheduler_DBStore_Test extends AbstractStoreTest {
 		for ( $i = 3; $i > - 3; $i -- ) {
 			$time     = as_get_datetime_object( $i . ' hours' );
 			$schedule = new ActionScheduler_SimpleSchedule( $time );
-			$action   = new ActionScheduler_Action( 'my_hook', [ $i ], $schedule, 'my_group' );
+			$action   = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, [ $i ], $schedule, 'my_group' );
 
 			$created_actions[] = $store->save_action( $action );
 		}
@@ -133,8 +133,8 @@ class ActionScheduler_DBStore_Test extends AbstractStoreTest {
 		$store           = new ActionScheduler_DBStore();
 		$schedule        = new ActionScheduler_SimpleSchedule( as_get_datetime_object( '-1 hour' ) );
 		$created_actions = array(
-			$store->save_action( new ActionScheduler_Action( 'my_hook', array( 1 ), $schedule, 'my_group' ) ),
-			$store->save_action( new ActionScheduler_Action( 'my_hook', array( 1 ), $schedule, 'my_group' ) ),
+			$store->save_action( new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, array( 1 ), $schedule, 'my_group' ) ),
+			$store->save_action( new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, array( 1 ), $schedule, 'my_group' ) ),
 		);
 
 		$claim = $store->stake_claim();
@@ -208,7 +208,7 @@ class ActionScheduler_DBStore_Test extends AbstractStoreTest {
 			foreach ( $unique_groups as $unique_group ) {
 				$time     = as_get_datetime_object( $i . ' hours' );
 				$schedule = new ActionScheduler_SimpleSchedule( $time );
-				$action   = new ActionScheduler_Action( 'my_hook', [ $i ], $schedule, $unique_group );
+				$action   = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, [ $i ], $schedule, $unique_group );
 
 				$created_actions[ $unique_group ][] = $store->save_action( $action );
 			}
@@ -360,7 +360,7 @@ class ActionScheduler_DBStore_Test extends AbstractStoreTest {
 		for ( $i = 0; $i > - 3; $i -- ) {
 			$time     = as_get_datetime_object( $i . ' hours' );
 			$schedule = new ActionScheduler_SimpleSchedule( $time );
-			$action   = new ActionScheduler_Action( 'my_hook', [ $i ], $schedule, 'my_group' );
+			$action   = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, [ $i ], $schedule, 'my_group' );
 
 			$created_actions[] = $store->save_action( $action );
 		}
@@ -377,7 +377,7 @@ class ActionScheduler_DBStore_Test extends AbstractStoreTest {
 		for ( $i = 0; $i > - 3; $i -- ) {
 			$time     = as_get_datetime_object( $i . ' hours' );
 			$schedule = new ActionScheduler_SimpleSchedule( $time );
-			$action   = new ActionScheduler_Action( 'my_hook', [ $i ], $schedule, 'my_group' );
+			$action   = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, [ $i ], $schedule, 'my_group' );
 
 			$created_actions[] = $store->save_action( $action );
 		}
@@ -396,18 +396,18 @@ class ActionScheduler_DBStore_Test extends AbstractStoreTest {
 		for ( $i = - 3; $i <= 3; $i ++ ) {
 			$time     = as_get_datetime_object( $i . ' hours' );
 			$schedule = new ActionScheduler_SimpleSchedule( $time );
-			$action   = new ActionScheduler_Action( 'my_hook', [ $i ], $schedule, 'my_group' );
+			$action   = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, [ $i ], $schedule, 'my_group' );
 
 			$created_actions[] = $store->save_action( $action );
 		}
 
-		$next_no_args = $store->find_action( 'my_hook' );
+		$next_no_args = $store->find_action( self::HOOK_WITH_CALLBACK );
 		$this->assertEquals( $created_actions[ 0 ], $next_no_args );
 
-		$next_with_args = $store->find_action( 'my_hook', [ 'args' => [ 1 ] ] );
+		$next_with_args = $store->find_action( self::HOOK_WITH_CALLBACK, [ 'args' => [ 1 ] ] );
 		$this->assertEquals( $created_actions[ 4 ], $next_with_args );
 
-		$non_existent = $store->find_action( 'my_hook', [ 'args' => [ 17 ] ] );
+		$non_existent = $store->find_action( self::HOOK_WITH_CALLBACK, [ 'args' => [ 17 ] ] );
 		$this->assertNull( $non_existent );
 	}
 
@@ -415,19 +415,19 @@ class ActionScheduler_DBStore_Test extends AbstractStoreTest {
 		$store    = new ActionScheduler_DBStore();
 		$schedule = new ActionScheduler_SimpleSchedule( as_get_datetime_object( 'tomorrow' ) );
 
-		$abc = $store->save_action( new ActionScheduler_Action( 'my_hook', [ 1 ], $schedule, 'abc' ) );
-		$def = $store->save_action( new ActionScheduler_Action( 'my_hook', [ 1 ], $schedule, 'def' ) );
-		$ghi = $store->save_action( new ActionScheduler_Action( 'my_hook', [ 1 ], $schedule, 'ghi' ) );
+		$abc = $store->save_action( new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, [ 1 ], $schedule, 'abc' ) );
+		$def = $store->save_action( new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, [ 1 ], $schedule, 'def' ) );
+		$ghi = $store->save_action( new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, [ 1 ], $schedule, 'ghi' ) );
 
-		$this->assertEquals( $abc, $store->find_action( 'my_hook', [ 'group' => 'abc' ] ) );
-		$this->assertEquals( $def, $store->find_action( 'my_hook', [ 'group' => 'def' ] ) );
-		$this->assertEquals( $ghi, $store->find_action( 'my_hook', [ 'group' => 'ghi' ] ) );
+		$this->assertEquals( $abc, $store->find_action( self::HOOK_WITH_CALLBACK, [ 'group' => 'abc' ] ) );
+		$this->assertEquals( $def, $store->find_action( self::HOOK_WITH_CALLBACK, [ 'group' => 'def' ] ) );
+		$this->assertEquals( $ghi, $store->find_action( self::HOOK_WITH_CALLBACK, [ 'group' => 'ghi' ] ) );
 	}
 
 	public function test_get_run_date() {
 		$time      = as_get_datetime_object( '-10 minutes' );
 		$schedule  = new ActionScheduler_IntervalSchedule( $time, HOUR_IN_SECONDS );
-		$action    = new ActionScheduler_Action( 'my_hook', [], $schedule );
+		$action    = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, [], $schedule );
 		$store     = new ActionScheduler_DBStore();
 		$action_id = $store->save_action( $action );
 

--- a/tests/phpunit/jobstore/ActionScheduler_DBStore_Test.php
+++ b/tests/phpunit/jobstore/ActionScheduler_DBStore_Test.php
@@ -29,7 +29,7 @@ class ActionScheduler_DBStore_Test extends AbstractStoreTest {
 	public function test_create_action() {
 		$time      = as_get_datetime_object();
 		$schedule  = new ActionScheduler_SimpleSchedule( $time );
-		$action    = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, [], $schedule );
+		$action    = new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, [], $schedule );
 		$store     = new ActionScheduler_DBStore();
 		$action_id = $store->save_action( $action );
 
@@ -38,7 +38,7 @@ class ActionScheduler_DBStore_Test extends AbstractStoreTest {
 
 	public function test_create_action_with_scheduled_date() {
 		$time        = as_get_datetime_object( strtotime( '-1 week' ) );
-		$action      = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, [], new ActionScheduler_SimpleSchedule( $time ) );
+		$action      = new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, [], new ActionScheduler_SimpleSchedule( $time ) );
 		$store       = new ActionScheduler_DBStore();
 		$action_id   = $store->save_action( $action, $time );
 		$action_date = $store->get_date( $action_id );
@@ -49,7 +49,7 @@ class ActionScheduler_DBStore_Test extends AbstractStoreTest {
 	public function test_retrieve_action() {
 		$time      = as_get_datetime_object();
 		$schedule  = new ActionScheduler_SimpleSchedule( $time );
-		$action    = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, [], $schedule, 'my_group' );
+		$action    = new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, [], $schedule, 'my_group' );
 		$store     = new ActionScheduler_DBStore();
 		$action_id = $store->save_action( $action );
 
@@ -63,7 +63,7 @@ class ActionScheduler_DBStore_Test extends AbstractStoreTest {
 	public function test_cancel_action() {
 		$time      = as_get_datetime_object();
 		$schedule  = new ActionScheduler_SimpleSchedule( $time );
-		$action    = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, [], $schedule, 'my_group' );
+		$action    = new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, [], $schedule, 'my_group' );
 		$store     = new ActionScheduler_DBStore();
 		$action_id = $store->save_action( $action );
 		$store->cancel_action( $action_id );
@@ -99,7 +99,7 @@ class ActionScheduler_DBStore_Test extends AbstractStoreTest {
 			$delta     = sprintf( '+%d day', $day );
 			$time      = as_get_datetime_object( $delta );
 			$schedule  = new ActionScheduler_SimpleSchedule( $time );
-			$action    = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, [], $schedule, $group );
+			$action    = new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, [], $schedule, $group );
 			$actions[] = $store->save_action( $action );
 		}
 		$store->cancel_actions_by_group( $group );
@@ -116,7 +116,7 @@ class ActionScheduler_DBStore_Test extends AbstractStoreTest {
 		for ( $i = 3; $i > - 3; $i -- ) {
 			$time     = as_get_datetime_object( $i . ' hours' );
 			$schedule = new ActionScheduler_SimpleSchedule( $time );
-			$action   = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, [ $i ], $schedule, 'my_group' );
+			$action   = new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, [ $i ], $schedule, 'my_group' );
 
 			$created_actions[] = $store->save_action( $action );
 		}
@@ -133,8 +133,8 @@ class ActionScheduler_DBStore_Test extends AbstractStoreTest {
 		$store           = new ActionScheduler_DBStore();
 		$schedule        = new ActionScheduler_SimpleSchedule( as_get_datetime_object( '-1 hour' ) );
 		$created_actions = array(
-			$store->save_action( new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, array( 1 ), $schedule, 'my_group' ) ),
-			$store->save_action( new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, array( 1 ), $schedule, 'my_group' ) ),
+			$store->save_action( new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, array( 1 ), $schedule, 'my_group' ) ),
+			$store->save_action( new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, array( 1 ), $schedule, 'my_group' ) ),
 		);
 
 		$claim = $store->stake_claim();
@@ -208,7 +208,7 @@ class ActionScheduler_DBStore_Test extends AbstractStoreTest {
 			foreach ( $unique_groups as $unique_group ) {
 				$time     = as_get_datetime_object( $i . ' hours' );
 				$schedule = new ActionScheduler_SimpleSchedule( $time );
-				$action   = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, [ $i ], $schedule, $unique_group );
+				$action   = new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, [ $i ], $schedule, $unique_group );
 
 				$created_actions[ $unique_group ][] = $store->save_action( $action );
 			}
@@ -360,7 +360,7 @@ class ActionScheduler_DBStore_Test extends AbstractStoreTest {
 		for ( $i = 0; $i > - 3; $i -- ) {
 			$time     = as_get_datetime_object( $i . ' hours' );
 			$schedule = new ActionScheduler_SimpleSchedule( $time );
-			$action   = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, [ $i ], $schedule, 'my_group' );
+			$action   = new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, [ $i ], $schedule, 'my_group' );
 
 			$created_actions[] = $store->save_action( $action );
 		}
@@ -377,7 +377,7 @@ class ActionScheduler_DBStore_Test extends AbstractStoreTest {
 		for ( $i = 0; $i > - 3; $i -- ) {
 			$time     = as_get_datetime_object( $i . ' hours' );
 			$schedule = new ActionScheduler_SimpleSchedule( $time );
-			$action   = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, [ $i ], $schedule, 'my_group' );
+			$action   = new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, [ $i ], $schedule, 'my_group' );
 
 			$created_actions[] = $store->save_action( $action );
 		}
@@ -396,18 +396,18 @@ class ActionScheduler_DBStore_Test extends AbstractStoreTest {
 		for ( $i = - 3; $i <= 3; $i ++ ) {
 			$time     = as_get_datetime_object( $i . ' hours' );
 			$schedule = new ActionScheduler_SimpleSchedule( $time );
-			$action   = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, [ $i ], $schedule, 'my_group' );
+			$action   = new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, [ $i ], $schedule, 'my_group' );
 
 			$created_actions[] = $store->save_action( $action );
 		}
 
-		$next_no_args = $store->find_action( self::HOOK_WITH_CALLBACK );
+		$next_no_args = $store->find_action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK );
 		$this->assertEquals( $created_actions[ 0 ], $next_no_args );
 
-		$next_with_args = $store->find_action( self::HOOK_WITH_CALLBACK, [ 'args' => [ 1 ] ] );
+		$next_with_args = $store->find_action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, [ 'args' => [ 1 ] ] );
 		$this->assertEquals( $created_actions[ 4 ], $next_with_args );
 
-		$non_existent = $store->find_action( self::HOOK_WITH_CALLBACK, [ 'args' => [ 17 ] ] );
+		$non_existent = $store->find_action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, [ 'args' => [ 17 ] ] );
 		$this->assertNull( $non_existent );
 	}
 
@@ -415,19 +415,19 @@ class ActionScheduler_DBStore_Test extends AbstractStoreTest {
 		$store    = new ActionScheduler_DBStore();
 		$schedule = new ActionScheduler_SimpleSchedule( as_get_datetime_object( 'tomorrow' ) );
 
-		$abc = $store->save_action( new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, [ 1 ], $schedule, 'abc' ) );
-		$def = $store->save_action( new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, [ 1 ], $schedule, 'def' ) );
-		$ghi = $store->save_action( new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, [ 1 ], $schedule, 'ghi' ) );
+		$abc = $store->save_action( new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, [ 1 ], $schedule, 'abc' ) );
+		$def = $store->save_action( new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, [ 1 ], $schedule, 'def' ) );
+		$ghi = $store->save_action( new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, [ 1 ], $schedule, 'ghi' ) );
 
-		$this->assertEquals( $abc, $store->find_action( self::HOOK_WITH_CALLBACK, [ 'group' => 'abc' ] ) );
-		$this->assertEquals( $def, $store->find_action( self::HOOK_WITH_CALLBACK, [ 'group' => 'def' ] ) );
-		$this->assertEquals( $ghi, $store->find_action( self::HOOK_WITH_CALLBACK, [ 'group' => 'ghi' ] ) );
+		$this->assertEquals( $abc, $store->find_action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, [ 'group' => 'abc' ] ) );
+		$this->assertEquals( $def, $store->find_action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, [ 'group' => 'def' ] ) );
+		$this->assertEquals( $ghi, $store->find_action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, [ 'group' => 'ghi' ] ) );
 	}
 
 	public function test_get_run_date() {
 		$time      = as_get_datetime_object( '-10 minutes' );
 		$schedule  = new ActionScheduler_IntervalSchedule( $time, HOUR_IN_SECONDS );
-		$action    = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, [], $schedule );
+		$action    = new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, [], $schedule );
 		$store     = new ActionScheduler_DBStore();
 		$action_id = $store->save_action( $action );
 

--- a/tests/phpunit/jobstore/ActionScheduler_wpPostStore_Test.php
+++ b/tests/phpunit/jobstore/ActionScheduler_wpPostStore_Test.php
@@ -20,7 +20,7 @@ class ActionScheduler_wpPostStore_Test extends AbstractStoreTest {
 	public function test_create_action() {
 		$time = as_get_datetime_object();
 		$schedule = new ActionScheduler_SimpleSchedule($time);
-		$action = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, array(), $schedule );
+		$action = new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, array(), $schedule );
 		$store = new ActionScheduler_wpPostStore();
 		$action_id = $store->save_action($action);
 
@@ -29,7 +29,7 @@ class ActionScheduler_wpPostStore_Test extends AbstractStoreTest {
 
 	public function test_create_action_with_scheduled_date() {
 		$time   = as_get_datetime_object( strtotime( '-1 week' ) );
-		$action = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, array(), new ActionScheduler_SimpleSchedule( $time ) );
+		$action = new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, array(), new ActionScheduler_SimpleSchedule( $time ) );
 		$store  = new ActionScheduler_wpPostStore();
 
 		$action_id   = $store->save_action( $action, $time );
@@ -41,7 +41,7 @@ class ActionScheduler_wpPostStore_Test extends AbstractStoreTest {
 	public function test_retrieve_action() {
 		$time = as_get_datetime_object();
 		$schedule = new ActionScheduler_SimpleSchedule($time);
-		$action = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, array(), $schedule, 'my_group' );
+		$action = new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, array(), $schedule, 'my_group' );
 		$store = new ActionScheduler_wpPostStore();
 		$action_id = $store->save_action($action);
 
@@ -78,7 +78,7 @@ class ActionScheduler_wpPostStore_Test extends AbstractStoreTest {
 	public function test_cancel_action() {
 		$time = as_get_datetime_object();
 		$schedule = new ActionScheduler_SimpleSchedule($time);
-		$action = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, array(), $schedule, 'my_group' );
+		$action = new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, array(), $schedule, 'my_group' );
 		$store = new ActionScheduler_wpPostStore();
 		$action_id = $store->save_action($action);
 		$store->cancel_action( $action_id );
@@ -115,7 +115,7 @@ class ActionScheduler_wpPostStore_Test extends AbstractStoreTest {
 			$delta     = sprintf( '+%d day', $day );
 			$time      = as_get_datetime_object( $delta );
 			$schedule  = new ActionScheduler_SimpleSchedule( $time );
-			$action    = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, array(), $schedule, $group );
+			$action    = new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, array(), $schedule, $group );
 			$actions[] = $store->save_action( $action );
 		}
 		$store->cancel_actions_by_group( $group );
@@ -132,7 +132,7 @@ class ActionScheduler_wpPostStore_Test extends AbstractStoreTest {
 		for ( $i = 3 ; $i > -3 ; $i-- ) {
 			$time = as_get_datetime_object($i.' hours');
 			$schedule = new ActionScheduler_SimpleSchedule($time);
-			$action = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, array($i), $schedule, 'my_group' );
+			$action = new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, array($i), $schedule, 'my_group' );
 			$created_actions[] = $store->save_action($action);
 		}
 
@@ -147,8 +147,8 @@ class ActionScheduler_wpPostStore_Test extends AbstractStoreTest {
 		$store           = new ActionScheduler_wpPostStore();
 		$schedule        = new ActionScheduler_SimpleSchedule( as_get_datetime_object( '-1 hour' ) );
 		$created_actions = array(
-			$store->save_action( new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, array( 1 ), $schedule, 'my_group' ) ),
-			$store->save_action( new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, array( 1 ), $schedule, 'my_group' ) ),
+			$store->save_action( new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, array( 1 ), $schedule, 'my_group' ) ),
+			$store->save_action( new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, array( 1 ), $schedule, 'my_group' ) ),
 		);
 
 		$claim = $store->stake_claim();
@@ -173,7 +173,7 @@ class ActionScheduler_wpPostStore_Test extends AbstractStoreTest {
 		for ( $i = 0 ; $i > -3 ; $i-- ) {
 			$time = as_get_datetime_object($i.' hours');
 			$schedule = new ActionScheduler_SimpleSchedule($time);
-			$action = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, array($i), $schedule, 'my_group' );
+			$action = new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, array($i), $schedule, 'my_group' );
 			$created_actions[] = $store->save_action($action);
 		}
 
@@ -189,7 +189,7 @@ class ActionScheduler_wpPostStore_Test extends AbstractStoreTest {
 		for ( $i = 0 ; $i > -3 ; $i-- ) {
 			$time = as_get_datetime_object($i.' hours');
 			$schedule = new ActionScheduler_SimpleSchedule($time);
-			$action = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, array($i), $schedule, 'my_group' );
+			$action = new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, array($i), $schedule, 'my_group' );
 			$created_actions[] = $store->save_action($action);
 		}
 
@@ -207,30 +207,30 @@ class ActionScheduler_wpPostStore_Test extends AbstractStoreTest {
 		for ( $i = -3 ; $i <= 3 ; $i++ ) {
 			$time = as_get_datetime_object($i.' hours');
 			$schedule = new ActionScheduler_SimpleSchedule($time);
-			$action = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, array($i), $schedule, 'my_group' );
+			$action = new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, array($i), $schedule, 'my_group' );
 			$created_actions[] = $store->save_action($action);
 		}
 
-		$next_no_args = $store->find_action( self::HOOK_WITH_CALLBACK );
+		$next_no_args = $store->find_action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK );
 		$this->assertEquals( $created_actions[0], $next_no_args );
 
-		$next_with_args = $store->find_action( self::HOOK_WITH_CALLBACK, array( 'args' => array( 1 ) ) );
+		$next_with_args = $store->find_action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, array( 'args' => array( 1 ) ) );
 		$this->assertEquals( $created_actions[4], $next_with_args );
 
-		$non_existent = $store->find_action( self::HOOK_WITH_CALLBACK, array( 'args' => array( 17 ) ) );
+		$non_existent = $store->find_action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, array( 'args' => array( 17 ) ) );
 		$this->assertNull( $non_existent );
 	}
 
 	public function test_search_by_group() {
 		$store = new ActionScheduler_wpPostStore();
 		$schedule = new ActionScheduler_SimpleSchedule(as_get_datetime_object('tomorrow'));
-		$abc = $store->save_action( new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, array( 1 ), $schedule, 'abc' ) );
-		$def = $store->save_action( new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, array( 1 ), $schedule, 'def' ) );
-		$ghi = $store->save_action( new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, array( 1 ), $schedule, 'ghi' ) );
+		$abc = $store->save_action( new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, array( 1 ), $schedule, 'abc' ) );
+		$def = $store->save_action( new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, array( 1 ), $schedule, 'def' ) );
+		$ghi = $store->save_action( new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, array( 1 ), $schedule, 'ghi' ) );
 
-		$this->assertEquals( $abc, $store->find_action( self::HOOK_WITH_CALLBACK, array( 'group' => 'abc' ) ) );
-		$this->assertEquals( $def, $store->find_action( self::HOOK_WITH_CALLBACK, array( 'group' => 'def' ) ) );
-		$this->assertEquals( $ghi, $store->find_action( self::HOOK_WITH_CALLBACK, array( 'group' => 'ghi' ) ) );
+		$this->assertEquals( $abc, $store->find_action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, array( 'group' => 'abc' ) ) );
+		$this->assertEquals( $def, $store->find_action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, array( 'group' => 'def' ) ) );
+		$this->assertEquals( $ghi, $store->find_action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, array( 'group' => 'ghi' ) ) );
 	}
 
 	public function test_post_author() {
@@ -238,7 +238,7 @@ class ActionScheduler_wpPostStore_Test extends AbstractStoreTest {
 
 		$time = as_get_datetime_object();
 		$schedule = new ActionScheduler_SimpleSchedule($time);
-		$action = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, array(), $schedule );
+		$action = new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, array(), $schedule );
 		$store = new ActionScheduler_wpPostStore();
 		$action_id = $store->save_action($action);
 
@@ -253,7 +253,7 @@ class ActionScheduler_wpPostStore_Test extends AbstractStoreTest {
 
 
 		$schedule = new ActionScheduler_SimpleSchedule($time);
-		$action = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, array(), $schedule );
+		$action = new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, array(), $schedule );
 		$action_id = $store->save_action($action);
 		$post = get_post($action_id);
 		$this->assertEquals(0, $post->post_author);
@@ -267,7 +267,7 @@ class ActionScheduler_wpPostStore_Test extends AbstractStoreTest {
 	public function test_post_status_for_recurring_action() {
 		$time = as_get_datetime_object('10 minutes');
 		$schedule = new ActionScheduler_IntervalSchedule($time, HOUR_IN_SECONDS);
-		$action = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, array(), $schedule );
+		$action = new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, array(), $schedule );
 		$store = new ActionScheduler_wpPostStore();
 		$action_id = $store->save_action($action);
 
@@ -285,7 +285,7 @@ class ActionScheduler_wpPostStore_Test extends AbstractStoreTest {
 	public function test_get_run_date() {
 		$time = as_get_datetime_object('-10 minutes');
 		$schedule = new ActionScheduler_IntervalSchedule($time, HOUR_IN_SECONDS);
-		$action = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, array(), $schedule );
+		$action = new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, array(), $schedule );
 		$store = new ActionScheduler_wpPostStore();
 		$action_id = $store->save_action($action);
 

--- a/tests/phpunit/jobstore/ActionScheduler_wpPostStore_Test.php
+++ b/tests/phpunit/jobstore/ActionScheduler_wpPostStore_Test.php
@@ -20,7 +20,7 @@ class ActionScheduler_wpPostStore_Test extends AbstractStoreTest {
 	public function test_create_action() {
 		$time = as_get_datetime_object();
 		$schedule = new ActionScheduler_SimpleSchedule($time);
-		$action = new ActionScheduler_Action('my_hook', array(), $schedule);
+		$action = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, array(), $schedule );
 		$store = new ActionScheduler_wpPostStore();
 		$action_id = $store->save_action($action);
 
@@ -29,7 +29,7 @@ class ActionScheduler_wpPostStore_Test extends AbstractStoreTest {
 
 	public function test_create_action_with_scheduled_date() {
 		$time   = as_get_datetime_object( strtotime( '-1 week' ) );
-		$action = new ActionScheduler_Action( 'my_hook', array(), new ActionScheduler_SimpleSchedule( $time ) );
+		$action = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, array(), new ActionScheduler_SimpleSchedule( $time ) );
 		$store  = new ActionScheduler_wpPostStore();
 
 		$action_id   = $store->save_action( $action, $time );
@@ -41,7 +41,7 @@ class ActionScheduler_wpPostStore_Test extends AbstractStoreTest {
 	public function test_retrieve_action() {
 		$time = as_get_datetime_object();
 		$schedule = new ActionScheduler_SimpleSchedule($time);
-		$action = new ActionScheduler_Action('my_hook', array(), $schedule, 'my_group');
+		$action = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, array(), $schedule, 'my_group' );
 		$store = new ActionScheduler_wpPostStore();
 		$action_id = $store->save_action($action);
 
@@ -78,7 +78,7 @@ class ActionScheduler_wpPostStore_Test extends AbstractStoreTest {
 	public function test_cancel_action() {
 		$time = as_get_datetime_object();
 		$schedule = new ActionScheduler_SimpleSchedule($time);
-		$action = new ActionScheduler_Action('my_hook', array(), $schedule, 'my_group');
+		$action = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, array(), $schedule, 'my_group' );
 		$store = new ActionScheduler_wpPostStore();
 		$action_id = $store->save_action($action);
 		$store->cancel_action( $action_id );
@@ -115,7 +115,7 @@ class ActionScheduler_wpPostStore_Test extends AbstractStoreTest {
 			$delta     = sprintf( '+%d day', $day );
 			$time      = as_get_datetime_object( $delta );
 			$schedule  = new ActionScheduler_SimpleSchedule( $time );
-			$action    = new ActionScheduler_Action( 'my_hook', array(), $schedule, $group );
+			$action    = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, array(), $schedule, $group );
 			$actions[] = $store->save_action( $action );
 		}
 		$store->cancel_actions_by_group( $group );
@@ -132,7 +132,7 @@ class ActionScheduler_wpPostStore_Test extends AbstractStoreTest {
 		for ( $i = 3 ; $i > -3 ; $i-- ) {
 			$time = as_get_datetime_object($i.' hours');
 			$schedule = new ActionScheduler_SimpleSchedule($time);
-			$action = new ActionScheduler_Action('my_hook', array($i), $schedule, 'my_group');
+			$action = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, array($i), $schedule, 'my_group' );
 			$created_actions[] = $store->save_action($action);
 		}
 
@@ -147,8 +147,8 @@ class ActionScheduler_wpPostStore_Test extends AbstractStoreTest {
 		$store           = new ActionScheduler_wpPostStore();
 		$schedule        = new ActionScheduler_SimpleSchedule( as_get_datetime_object( '-1 hour' ) );
 		$created_actions = array(
-			$store->save_action( new ActionScheduler_Action( 'my_hook', array( 1 ), $schedule, 'my_group' ) ),
-			$store->save_action( new ActionScheduler_Action( 'my_hook', array( 1 ), $schedule, 'my_group' ) ),
+			$store->save_action( new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, array( 1 ), $schedule, 'my_group' ) ),
+			$store->save_action( new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, array( 1 ), $schedule, 'my_group' ) ),
 		);
 
 		$claim = $store->stake_claim();
@@ -173,7 +173,7 @@ class ActionScheduler_wpPostStore_Test extends AbstractStoreTest {
 		for ( $i = 0 ; $i > -3 ; $i-- ) {
 			$time = as_get_datetime_object($i.' hours');
 			$schedule = new ActionScheduler_SimpleSchedule($time);
-			$action = new ActionScheduler_Action('my_hook', array($i), $schedule, 'my_group');
+			$action = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, array($i), $schedule, 'my_group' );
 			$created_actions[] = $store->save_action($action);
 		}
 
@@ -189,7 +189,7 @@ class ActionScheduler_wpPostStore_Test extends AbstractStoreTest {
 		for ( $i = 0 ; $i > -3 ; $i-- ) {
 			$time = as_get_datetime_object($i.' hours');
 			$schedule = new ActionScheduler_SimpleSchedule($time);
-			$action = new ActionScheduler_Action('my_hook', array($i), $schedule, 'my_group');
+			$action = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, array($i), $schedule, 'my_group' );
 			$created_actions[] = $store->save_action($action);
 		}
 
@@ -207,30 +207,30 @@ class ActionScheduler_wpPostStore_Test extends AbstractStoreTest {
 		for ( $i = -3 ; $i <= 3 ; $i++ ) {
 			$time = as_get_datetime_object($i.' hours');
 			$schedule = new ActionScheduler_SimpleSchedule($time);
-			$action = new ActionScheduler_Action('my_hook', array($i), $schedule, 'my_group');
+			$action = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, array($i), $schedule, 'my_group' );
 			$created_actions[] = $store->save_action($action);
 		}
 
-		$next_no_args = $store->find_action( 'my_hook' );
+		$next_no_args = $store->find_action( self::HOOK_WITH_CALLBACK );
 		$this->assertEquals( $created_actions[0], $next_no_args );
 
-		$next_with_args = $store->find_action( 'my_hook', array( 'args' => array( 1 ) ) );
+		$next_with_args = $store->find_action( self::HOOK_WITH_CALLBACK, array( 'args' => array( 1 ) ) );
 		$this->assertEquals( $created_actions[4], $next_with_args );
 
-		$non_existent = $store->find_action( 'my_hook', array( 'args' => array( 17 ) ) );
+		$non_existent = $store->find_action( self::HOOK_WITH_CALLBACK, array( 'args' => array( 17 ) ) );
 		$this->assertNull( $non_existent );
 	}
 
 	public function test_search_by_group() {
 		$store = new ActionScheduler_wpPostStore();
 		$schedule = new ActionScheduler_SimpleSchedule(as_get_datetime_object('tomorrow'));
-		$abc = $store->save_action(new ActionScheduler_Action('my_hook', array(1), $schedule, 'abc'));
-		$def = $store->save_action(new ActionScheduler_Action('my_hook', array(1), $schedule, 'def'));
-		$ghi = $store->save_action(new ActionScheduler_Action('my_hook', array(1), $schedule, 'ghi'));
+		$abc = $store->save_action( new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, array( 1 ), $schedule, 'abc' ) );
+		$def = $store->save_action( new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, array( 1 ), $schedule, 'def' ) );
+		$ghi = $store->save_action( new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, array( 1 ), $schedule, 'ghi' ) );
 
-		$this->assertEquals( $abc, $store->find_action('my_hook', array('group' => 'abc')));
-		$this->assertEquals( $def, $store->find_action('my_hook', array('group' => 'def')));
-		$this->assertEquals( $ghi, $store->find_action('my_hook', array('group' => 'ghi')));
+		$this->assertEquals( $abc, $store->find_action( self::HOOK_WITH_CALLBACK, array( 'group' => 'abc' ) ) );
+		$this->assertEquals( $def, $store->find_action( self::HOOK_WITH_CALLBACK, array( 'group' => 'def' ) ) );
+		$this->assertEquals( $ghi, $store->find_action( self::HOOK_WITH_CALLBACK, array( 'group' => 'ghi' ) ) );
 	}
 
 	public function test_post_author() {
@@ -238,7 +238,7 @@ class ActionScheduler_wpPostStore_Test extends AbstractStoreTest {
 
 		$time = as_get_datetime_object();
 		$schedule = new ActionScheduler_SimpleSchedule($time);
-		$action = new ActionScheduler_Action('my_hook', array(), $schedule);
+		$action = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, array(), $schedule );
 		$store = new ActionScheduler_wpPostStore();
 		$action_id = $store->save_action($action);
 
@@ -253,7 +253,7 @@ class ActionScheduler_wpPostStore_Test extends AbstractStoreTest {
 
 
 		$schedule = new ActionScheduler_SimpleSchedule($time);
-		$action = new ActionScheduler_Action('my_hook', array(), $schedule);
+		$action = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, array(), $schedule );
 		$action_id = $store->save_action($action);
 		$post = get_post($action_id);
 		$this->assertEquals(0, $post->post_author);
@@ -267,7 +267,7 @@ class ActionScheduler_wpPostStore_Test extends AbstractStoreTest {
 	public function test_post_status_for_recurring_action() {
 		$time = as_get_datetime_object('10 minutes');
 		$schedule = new ActionScheduler_IntervalSchedule($time, HOUR_IN_SECONDS);
-		$action = new ActionScheduler_Action('my_hook', array(), $schedule);
+		$action = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, array(), $schedule );
 		$store = new ActionScheduler_wpPostStore();
 		$action_id = $store->save_action($action);
 
@@ -285,7 +285,7 @@ class ActionScheduler_wpPostStore_Test extends AbstractStoreTest {
 	public function test_get_run_date() {
 		$time = as_get_datetime_object('-10 minutes');
 		$schedule = new ActionScheduler_IntervalSchedule($time, HOUR_IN_SECONDS);
-		$action = new ActionScheduler_Action('my_hook', array(), $schedule);
+		$action = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, array(), $schedule );
 		$store = new ActionScheduler_wpPostStore();
 		$action_id = $store->save_action($action);
 

--- a/tests/phpunit/logging/ActionScheduler_DBLogger_Test.php
+++ b/tests/phpunit/logging/ActionScheduler_DBLogger_Test.php
@@ -34,7 +34,7 @@ class ActionScheduler_DBLogger_Test extends ActionScheduler_UnitTestCase {
 	}
 
 	public function test_execution_logs() {
-		$action_id = as_schedule_single_action( time(), __METHOD__ );
+		$action_id = as_schedule_single_action( time(), self::HOOK_WITH_CALLBACK );
 		$logger = ActionScheduler::logger();
 		$started = new ActionScheduler_LogEntry( $action_id, 'action started via Unit Tests' );
 		$finished = new ActionScheduler_LogEntry( $action_id, 'action complete via Unit Tests' );
@@ -113,7 +113,7 @@ class ActionScheduler_DBLogger_Test extends ActionScheduler_UnitTestCase {
 	public function test_deleted_action_cleanup() {
 		$time = as_get_datetime_object('-10 minutes');
 		$schedule = new \ActionScheduler_SimpleSchedule($time);
-		$action = new \ActionScheduler_Action('my_hook', array(), $schedule);
+		$action = new \ActionScheduler_Action( self::HOOK_WITH_CALLBACK, array(), $schedule);
 		$store = new ActionScheduler_DBStore();
 		$action_id = $store->save_action($action);
 

--- a/tests/phpunit/logging/ActionScheduler_DBLogger_Test.php
+++ b/tests/phpunit/logging/ActionScheduler_DBLogger_Test.php
@@ -34,7 +34,7 @@ class ActionScheduler_DBLogger_Test extends ActionScheduler_UnitTestCase {
 	}
 
 	public function test_execution_logs() {
-		$action_id = as_schedule_single_action( time(), self::HOOK_WITH_CALLBACK );
+		$action_id = as_schedule_single_action( time(), ActionScheduler_Callbacks::HOOK_WITH_CALLBACK );
 		$logger = ActionScheduler::logger();
 		$started = new ActionScheduler_LogEntry( $action_id, 'action started via Unit Tests' );
 		$finished = new ActionScheduler_LogEntry( $action_id, 'action complete via Unit Tests' );
@@ -113,7 +113,7 @@ class ActionScheduler_DBLogger_Test extends ActionScheduler_UnitTestCase {
 	public function test_deleted_action_cleanup() {
 		$time = as_get_datetime_object('-10 minutes');
 		$schedule = new \ActionScheduler_SimpleSchedule($time);
-		$action = new \ActionScheduler_Action( self::HOOK_WITH_CALLBACK, array(), $schedule);
+		$action = new \ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, array(), $schedule);
 		$store = new ActionScheduler_DBStore();
 		$action_id = $store->save_action($action);
 

--- a/tests/phpunit/logging/ActionScheduler_wpCommentLogger_Test.php
+++ b/tests/phpunit/logging/ActionScheduler_wpCommentLogger_Test.php
@@ -80,7 +80,7 @@ class ActionScheduler_wpCommentLogger_Test extends ActionScheduler_UnitTestCase 
 	}
 
 	public function test_execution_comments() {
-		$action_id = as_schedule_single_action( time(), self::HOOK_WITH_CALLBACK );
+		$action_id = as_schedule_single_action( time(), ActionScheduler_Callbacks::HOOK_WITH_CALLBACK );
 		$logger = ActionScheduler::logger();
 		$started = new ActionScheduler_LogEntry( $action_id, 'action started via Unit Tests' );
 		$finished = new ActionScheduler_LogEntry( $action_id, 'action complete via Unit Tests' );
@@ -119,7 +119,7 @@ class ActionScheduler_wpCommentLogger_Test extends ActionScheduler_UnitTestCase 
 		try {
 			$this->_a_hook_callback_that_throws_an_exception();
 		} catch ( Exception $e ) {
-			do_action( 'action_scheduler_failed_to_schedule_next_instance', $action_id, $e, new ActionScheduler_Action( self::HOOK_WITH_CALLBACK ) );
+			do_action( 'action_scheduler_failed_to_schedule_next_instance', $action_id, $e, new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK ) );
 		}
 
 		$logs = $logger->get_logs( $action_id );

--- a/tests/phpunit/logging/ActionScheduler_wpCommentLogger_Test.php
+++ b/tests/phpunit/logging/ActionScheduler_wpCommentLogger_Test.php
@@ -80,7 +80,7 @@ class ActionScheduler_wpCommentLogger_Test extends ActionScheduler_UnitTestCase 
 	}
 
 	public function test_execution_comments() {
-		$action_id = as_schedule_single_action( time(), 'a hook' );
+		$action_id = as_schedule_single_action( time(), self::HOOK_WITH_CALLBACK );
 		$logger = ActionScheduler::logger();
 		$started = new ActionScheduler_LogEntry( $action_id, 'action started via Unit Tests' );
 		$finished = new ActionScheduler_LogEntry( $action_id, 'action complete via Unit Tests' );

--- a/tests/phpunit/logging/ActionScheduler_wpCommentLogger_Test.php
+++ b/tests/phpunit/logging/ActionScheduler_wpCommentLogger_Test.php
@@ -119,7 +119,7 @@ class ActionScheduler_wpCommentLogger_Test extends ActionScheduler_UnitTestCase 
 		try {
 			$this->_a_hook_callback_that_throws_an_exception();
 		} catch ( Exception $e ) {
-			do_action( 'action_scheduler_failed_to_schedule_next_instance', $action_id, $e, new ActionScheduler_Action('my_hook') );
+			do_action( 'action_scheduler_failed_to_schedule_next_instance', $action_id, $e, new ActionScheduler_Action( self::HOOK_WITH_CALLBACK ) );
 		}
 
 		$logs = $logger->get_logs( $action_id );

--- a/tests/phpunit/migration/ActionMigrator_Test.php
+++ b/tests/phpunit/migration/ActionMigrator_Test.php
@@ -24,7 +24,7 @@ class ActionMigrator_Test extends ActionScheduler_UnitTestCase {
 
 		$time      = as_get_datetime_object();
 		$schedule  = new ActionScheduler_SimpleSchedule( $time );
-		$action    = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, [], $schedule, 'my_group' );
+		$action    = new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, [], $schedule, 'my_group' );
 		$action_id = $source->save_action( $action );
 
 		$new_id = $migrator->migrate( $action_id );
@@ -65,7 +65,7 @@ class ActionMigrator_Test extends ActionScheduler_UnitTestCase {
 
 		$time      = as_get_datetime_object();
 		$schedule  = new ActionScheduler_SimpleSchedule( $time );
-		$action    = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, [], $schedule, 'my_group' );
+		$action    = new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, [], $schedule, 'my_group' );
 		$action_id = $source->save_action( $action );
 		$source->mark_complete( $action_id );
 
@@ -92,7 +92,7 @@ class ActionMigrator_Test extends ActionScheduler_UnitTestCase {
 
 		$time      = as_get_datetime_object();
 		$schedule  = new ActionScheduler_SimpleSchedule( $time );
-		$action    = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, [], $schedule, 'my_group' );
+		$action    = new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, [], $schedule, 'my_group' );
 		$action_id = $source->save_action( $action );
 		$source->mark_failure( $action_id );
 
@@ -119,7 +119,7 @@ class ActionMigrator_Test extends ActionScheduler_UnitTestCase {
 
 		$time      = as_get_datetime_object();
 		$schedule  = new ActionScheduler_SimpleSchedule( $time );
-		$action    = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, [], $schedule, 'my_group' );
+		$action    = new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, [], $schedule, 'my_group' );
 		$action_id = $source->save_action( $action );
 		$source->cancel_action( $action_id );
 

--- a/tests/phpunit/migration/ActionMigrator_Test.php
+++ b/tests/phpunit/migration/ActionMigrator_Test.php
@@ -24,7 +24,7 @@ class ActionMigrator_Test extends ActionScheduler_UnitTestCase {
 
 		$time      = as_get_datetime_object();
 		$schedule  = new ActionScheduler_SimpleSchedule( $time );
-		$action    = new ActionScheduler_Action( 'my_hook', [], $schedule, 'my_group' );
+		$action    = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, [], $schedule, 'my_group' );
 		$action_id = $source->save_action( $action );
 
 		$new_id = $migrator->migrate( $action_id );
@@ -65,7 +65,7 @@ class ActionMigrator_Test extends ActionScheduler_UnitTestCase {
 
 		$time      = as_get_datetime_object();
 		$schedule  = new ActionScheduler_SimpleSchedule( $time );
-		$action    = new ActionScheduler_Action( 'my_hook', [], $schedule, 'my_group' );
+		$action    = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, [], $schedule, 'my_group' );
 		$action_id = $source->save_action( $action );
 		$source->mark_complete( $action_id );
 
@@ -92,7 +92,7 @@ class ActionMigrator_Test extends ActionScheduler_UnitTestCase {
 
 		$time      = as_get_datetime_object();
 		$schedule  = new ActionScheduler_SimpleSchedule( $time );
-		$action    = new ActionScheduler_Action( 'my_hook', [], $schedule, 'my_group' );
+		$action    = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, [], $schedule, 'my_group' );
 		$action_id = $source->save_action( $action );
 		$source->mark_failure( $action_id );
 
@@ -119,7 +119,7 @@ class ActionMigrator_Test extends ActionScheduler_UnitTestCase {
 
 		$time      = as_get_datetime_object();
 		$schedule  = new ActionScheduler_SimpleSchedule( $time );
-		$action    = new ActionScheduler_Action( 'my_hook', [], $schedule, 'my_group' );
+		$action    = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, [], $schedule, 'my_group' );
 		$action_id = $source->save_action( $action );
 		$source->cancel_action( $action_id );
 

--- a/tests/phpunit/migration/BatchFetcher_Test.php
+++ b/tests/phpunit/migration/BatchFetcher_Test.php
@@ -33,12 +33,12 @@ class BatchFetcher_Test extends ActionScheduler_UnitTestCase {
 		for ( $i = 0; $i < 5; $i ++ ) {
 			$time     = as_get_datetime_object( $i + 1 . ' minutes' );
 			$schedule = new ActionScheduler_SimpleSchedule( $time );
-			$action   = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, [], $schedule );
+			$action   = new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, [], $schedule );
 			$future[] = $store->save_action( $action );
 
 			$time     = as_get_datetime_object( $i + 1 . ' minutes ago' );
 			$schedule = new ActionScheduler_SimpleSchedule( $time );
-			$action   = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, [], $schedule );
+			$action   = new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, [], $schedule );
 			$due[]    = $store->save_action( $action );
 		}
 
@@ -58,12 +58,12 @@ class BatchFetcher_Test extends ActionScheduler_UnitTestCase {
 		for ( $i = 0; $i < 5; $i ++ ) {
 			$time     = as_get_datetime_object( $i + 1 . ' minutes' );
 			$schedule = new ActionScheduler_SimpleSchedule( $time );
-			$action   = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, [], $schedule );
+			$action   = new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, [], $schedule );
 			$future[] = $store->save_action( $action );
 
 			$time       = as_get_datetime_object( $i + 1 . ' minutes ago' );
 			$schedule   = new ActionScheduler_SimpleSchedule( $time );
-			$action     = new ActionScheduler_FinishedAction( self::HOOK_WITH_CALLBACK, [], $schedule );
+			$action     = new ActionScheduler_FinishedAction( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, [], $schedule );
 			$complete[] = $store->save_action( $action );
 		}
 

--- a/tests/phpunit/migration/BatchFetcher_Test.php
+++ b/tests/phpunit/migration/BatchFetcher_Test.php
@@ -33,12 +33,12 @@ class BatchFetcher_Test extends ActionScheduler_UnitTestCase {
 		for ( $i = 0; $i < 5; $i ++ ) {
 			$time     = as_get_datetime_object( $i + 1 . ' minutes' );
 			$schedule = new ActionScheduler_SimpleSchedule( $time );
-			$action   = new ActionScheduler_Action( 'my_hook', [], $schedule );
+			$action   = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, [], $schedule );
 			$future[] = $store->save_action( $action );
 
 			$time     = as_get_datetime_object( $i + 1 . ' minutes ago' );
 			$schedule = new ActionScheduler_SimpleSchedule( $time );
-			$action   = new ActionScheduler_Action( 'my_hook', [], $schedule );
+			$action   = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, [], $schedule );
 			$due[]    = $store->save_action( $action );
 		}
 
@@ -58,12 +58,12 @@ class BatchFetcher_Test extends ActionScheduler_UnitTestCase {
 		for ( $i = 0; $i < 5; $i ++ ) {
 			$time     = as_get_datetime_object( $i + 1 . ' minutes' );
 			$schedule = new ActionScheduler_SimpleSchedule( $time );
-			$action   = new ActionScheduler_Action( 'my_hook', [], $schedule );
+			$action   = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, [], $schedule );
 			$future[] = $store->save_action( $action );
 
 			$time       = as_get_datetime_object( $i + 1 . ' minutes ago' );
 			$schedule   = new ActionScheduler_SimpleSchedule( $time );
-			$action     = new ActionScheduler_FinishedAction( 'my_hook', [], $schedule );
+			$action     = new ActionScheduler_FinishedAction( self::HOOK_WITH_CALLBACK, [], $schedule );
 			$complete[] = $store->save_action( $action );
 		}
 

--- a/tests/phpunit/migration/Runner_Test.php
+++ b/tests/phpunit/migration/Runner_Test.php
@@ -41,17 +41,17 @@ class Runner_Test extends ActionScheduler_UnitTestCase {
 		for ( $i = 0; $i < 5; $i ++ ) {
 			$time     = as_get_datetime_object( $i + 1 . ' minutes' );
 			$schedule = new ActionScheduler_SimpleSchedule( $time );
-			$action   = new ActionScheduler_Action( 'my_hook', [], $schedule );
+			$action   = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, [], $schedule );
 			$future[] = $source_store->save_action( $action );
 
 			$time     = as_get_datetime_object( $i + 1 . ' minutes ago' );
 			$schedule = new ActionScheduler_SimpleSchedule( $time );
-			$action   = new ActionScheduler_Action( 'my_hook', [], $schedule );
+			$action   = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, [], $schedule );
 			$due[]    = $source_store->save_action( $action );
 
 			$time       = as_get_datetime_object( $i + 1 . ' minutes ago' );
 			$schedule   = new ActionScheduler_SimpleSchedule( $time );
-			$action     = new ActionScheduler_FinishedAction( 'my_hook', [], $schedule );
+			$action     = new ActionScheduler_FinishedAction( self::HOOK_WITH_CALLBACK, [], $schedule );
 			$complete[] = $source_store->save_action( $action );
 		}
 
@@ -61,30 +61,30 @@ class Runner_Test extends ActionScheduler_UnitTestCase {
 		$runner->run( 10 );
 
 		// due actions should migrate in the first batch
-		$migrated = $destination_store->query_actions( [ 'per_page' => 0, 'hook' => 'my_hook' ] );
+		$migrated = $destination_store->query_actions( [ 'per_page' => 0, 'hook' => self::HOOK_WITH_CALLBACK ] );
 		$this->assertCount( 5, $migrated );
 
-		$remaining = $source_store->query_actions( [ 'per_page' => 0, 'hook' => 'my_hook' ] );
+		$remaining = $source_store->query_actions( [ 'per_page' => 0, 'hook' => self::HOOK_WITH_CALLBACK ] );
 		$this->assertCount( 10, $remaining );
 
 
 		$runner->run( 10 );
 
 		// pending actions should migrate in the second batch
-		$migrated = $destination_store->query_actions( [ 'per_page' => 0, 'hook' => 'my_hook' ] );
+		$migrated = $destination_store->query_actions( [ 'per_page' => 0, 'hook' => self::HOOK_WITH_CALLBACK ] );
 		$this->assertCount( 10, $migrated );
 
-		$remaining = $source_store->query_actions( [ 'per_page' => 0, 'hook' => 'my_hook' ] );
+		$remaining = $source_store->query_actions( [ 'per_page' => 0, 'hook' => self::HOOK_WITH_CALLBACK ] );
 		$this->assertCount( 5, $remaining );
 
 
 		$runner->run( 10 );
 
 		// completed actions should migrate in the third batch
-		$migrated = $destination_store->query_actions( [ 'per_page' => 0, 'hook' => 'my_hook' ] );
+		$migrated = $destination_store->query_actions( [ 'per_page' => 0, 'hook' => self::HOOK_WITH_CALLBACK ] );
 		$this->assertCount( 15, $migrated );
 
-		$remaining = $source_store->query_actions( [ 'per_page' => 0, 'hook' => 'my_hook' ] );
+		$remaining = $source_store->query_actions( [ 'per_page' => 0, 'hook' => self::HOOK_WITH_CALLBACK ] );
 		$this->assertCount( 0, $remaining );
 
 	}

--- a/tests/phpunit/migration/Runner_Test.php
+++ b/tests/phpunit/migration/Runner_Test.php
@@ -41,17 +41,17 @@ class Runner_Test extends ActionScheduler_UnitTestCase {
 		for ( $i = 0; $i < 5; $i ++ ) {
 			$time     = as_get_datetime_object( $i + 1 . ' minutes' );
 			$schedule = new ActionScheduler_SimpleSchedule( $time );
-			$action   = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, [], $schedule );
+			$action   = new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, [], $schedule );
 			$future[] = $source_store->save_action( $action );
 
 			$time     = as_get_datetime_object( $i + 1 . ' minutes ago' );
 			$schedule = new ActionScheduler_SimpleSchedule( $time );
-			$action   = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, [], $schedule );
+			$action   = new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, [], $schedule );
 			$due[]    = $source_store->save_action( $action );
 
 			$time       = as_get_datetime_object( $i + 1 . ' minutes ago' );
 			$schedule   = new ActionScheduler_SimpleSchedule( $time );
-			$action     = new ActionScheduler_FinishedAction( self::HOOK_WITH_CALLBACK, [], $schedule );
+			$action     = new ActionScheduler_FinishedAction( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, [], $schedule );
 			$complete[] = $source_store->save_action( $action );
 		}
 
@@ -61,30 +61,30 @@ class Runner_Test extends ActionScheduler_UnitTestCase {
 		$runner->run( 10 );
 
 		// due actions should migrate in the first batch
-		$migrated = $destination_store->query_actions( [ 'per_page' => 0, 'hook' => self::HOOK_WITH_CALLBACK ] );
+		$migrated = $destination_store->query_actions( [ 'per_page' => 0, 'hook' => ActionScheduler_Callbacks::HOOK_WITH_CALLBACK ] );
 		$this->assertCount( 5, $migrated );
 
-		$remaining = $source_store->query_actions( [ 'per_page' => 0, 'hook' => self::HOOK_WITH_CALLBACK ] );
+		$remaining = $source_store->query_actions( [ 'per_page' => 0, 'hook' => ActionScheduler_Callbacks::HOOK_WITH_CALLBACK ] );
 		$this->assertCount( 10, $remaining );
 
 
 		$runner->run( 10 );
 
 		// pending actions should migrate in the second batch
-		$migrated = $destination_store->query_actions( [ 'per_page' => 0, 'hook' => self::HOOK_WITH_CALLBACK ] );
+		$migrated = $destination_store->query_actions( [ 'per_page' => 0, 'hook' => ActionScheduler_Callbacks::HOOK_WITH_CALLBACK ] );
 		$this->assertCount( 10, $migrated );
 
-		$remaining = $source_store->query_actions( [ 'per_page' => 0, 'hook' => self::HOOK_WITH_CALLBACK ] );
+		$remaining = $source_store->query_actions( [ 'per_page' => 0, 'hook' => ActionScheduler_Callbacks::HOOK_WITH_CALLBACK ] );
 		$this->assertCount( 5, $remaining );
 
 
 		$runner->run( 10 );
 
 		// completed actions should migrate in the third batch
-		$migrated = $destination_store->query_actions( [ 'per_page' => 0, 'hook' => self::HOOK_WITH_CALLBACK ] );
+		$migrated = $destination_store->query_actions( [ 'per_page' => 0, 'hook' => ActionScheduler_Callbacks::HOOK_WITH_CALLBACK ] );
 		$this->assertCount( 15, $migrated );
 
-		$remaining = $source_store->query_actions( [ 'per_page' => 0, 'hook' => self::HOOK_WITH_CALLBACK ] );
+		$remaining = $source_store->query_actions( [ 'per_page' => 0, 'hook' => ActionScheduler_Callbacks::HOOK_WITH_CALLBACK ] );
 		$this->assertCount( 0, $remaining );
 
 	}

--- a/tests/phpunit/migration/Scheduler_Test.php
+++ b/tests/phpunit/migration/Scheduler_Test.php
@@ -63,12 +63,12 @@ class Scheduler_Test extends ActionScheduler_UnitTestCase {
 		for ( $i = 0; $i < 10; $i ++ ) {
 			$time     = as_get_datetime_object( $i + 1 . ' minutes' );
 			$schedule = new ActionScheduler_SimpleSchedule( $time );
-			$action   = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, [], $schedule );
+			$action   = new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, [], $schedule );
 			$future[] = $source_store->save_action( $action );
 
 			$time     = as_get_datetime_object( $i + 1 . ' minutes ago' );
 			$schedule = new ActionScheduler_SimpleSchedule( $time );
-			$action   = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, [], $schedule );
+			$action   = new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, [], $schedule );
 			$due[]    = $source_store->save_action( $action );
 		}
 
@@ -82,7 +82,7 @@ class Scheduler_Test extends ActionScheduler_UnitTestCase {
 		$queue_runner->run();
 
 		// 5 actions should have moved from the source store when the queue runner triggered the migration action
-		$this->assertCount( 15, $source_store->query_actions( [ 'per_page' => 0, 'hook' => self::HOOK_WITH_CALLBACK ] ) );
+		$this->assertCount( 15, $source_store->query_actions( [ 'per_page' => 0, 'hook' => ActionScheduler_Callbacks::HOOK_WITH_CALLBACK ] ) );
 
 		remove_filter( 'action_scheduler/migration_batch_size', $return_5 );
 		remove_filter( 'action_scheduler/migration_interval', $return_60 );
@@ -95,7 +95,7 @@ class Scheduler_Test extends ActionScheduler_UnitTestCase {
 		for ( $i = 0; $i < 5; $i ++ ) {
 			$time     = as_get_datetime_object( $i + 1 . ' minutes ago' );
 			$schedule = new ActionScheduler_SimpleSchedule( $time );
-			$action   = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, [], $schedule );
+			$action   = new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, [], $schedule );
 			$due[]    = $source_store->save_action( $action );
 		}
 
@@ -109,7 +109,7 @@ class Scheduler_Test extends ActionScheduler_UnitTestCase {
 		$queue_runner->run();
 
 		// All actions should have moved from the source store when the queue runner triggered the migration action
-		$this->assertCount( 0, $source_store->query_actions( [ 'per_page' => 0, 'hook' => self::HOOK_WITH_CALLBACK ] ) );
+		$this->assertCount( 0, $source_store->query_actions( [ 'per_page' => 0, 'hook' => ActionScheduler_Callbacks::HOOK_WITH_CALLBACK ] ) );
 
 		// schedule another so we can get it to run immediately
 		$scheduler->unschedule_migration();

--- a/tests/phpunit/migration/Scheduler_Test.php
+++ b/tests/phpunit/migration/Scheduler_Test.php
@@ -63,12 +63,12 @@ class Scheduler_Test extends ActionScheduler_UnitTestCase {
 		for ( $i = 0; $i < 10; $i ++ ) {
 			$time     = as_get_datetime_object( $i + 1 . ' minutes' );
 			$schedule = new ActionScheduler_SimpleSchedule( $time );
-			$action   = new ActionScheduler_Action( 'my_hook', [], $schedule );
+			$action   = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, [], $schedule );
 			$future[] = $source_store->save_action( $action );
 
 			$time     = as_get_datetime_object( $i + 1 . ' minutes ago' );
 			$schedule = new ActionScheduler_SimpleSchedule( $time );
-			$action   = new ActionScheduler_Action( 'my_hook', [], $schedule );
+			$action   = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, [], $schedule );
 			$due[]    = $source_store->save_action( $action );
 		}
 
@@ -82,7 +82,7 @@ class Scheduler_Test extends ActionScheduler_UnitTestCase {
 		$queue_runner->run();
 
 		// 5 actions should have moved from the source store when the queue runner triggered the migration action
-		$this->assertCount( 15, $source_store->query_actions( [ 'per_page' => 0, 'hook' => 'my_hook' ] ) );
+		$this->assertCount( 15, $source_store->query_actions( [ 'per_page' => 0, 'hook' => self::HOOK_WITH_CALLBACK ] ) );
 
 		remove_filter( 'action_scheduler/migration_batch_size', $return_5 );
 		remove_filter( 'action_scheduler/migration_interval', $return_60 );
@@ -95,7 +95,7 @@ class Scheduler_Test extends ActionScheduler_UnitTestCase {
 		for ( $i = 0; $i < 5; $i ++ ) {
 			$time     = as_get_datetime_object( $i + 1 . ' minutes ago' );
 			$schedule = new ActionScheduler_SimpleSchedule( $time );
-			$action   = new ActionScheduler_Action( 'my_hook', [], $schedule );
+			$action   = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, [], $schedule );
 			$due[]    = $source_store->save_action( $action );
 		}
 
@@ -109,7 +109,7 @@ class Scheduler_Test extends ActionScheduler_UnitTestCase {
 		$queue_runner->run();
 
 		// All actions should have moved from the source store when the queue runner triggered the migration action
-		$this->assertCount( 0, $source_store->query_actions( [ 'per_page' => 0, 'hook' => 'my_hook' ] ) );
+		$this->assertCount( 0, $source_store->query_actions( [ 'per_page' => 0, 'hook' => self::HOOK_WITH_CALLBACK ] ) );
 
 		// schedule another so we can get it to run immediately
 		$scheduler->unschedule_migration();

--- a/tests/phpunit/runner/ActionScheduler_QueueCleaner_Test.php
+++ b/tests/phpunit/runner/ActionScheduler_QueueCleaner_Test.php
@@ -14,7 +14,7 @@ class ActionScheduler_QueueCleaner_Test extends ActionScheduler_UnitTestCase {
 
 		$created_actions = array();
 		for ( $i = 0 ; $i < 5 ; $i++ ) {
-			$action = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, array($random), $schedule );
+			$action = new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, array($random), $schedule );
 			$created_actions[] = $store->save_action( $action );
 		}
 

--- a/tests/phpunit/runner/ActionScheduler_QueueCleaner_Test.php
+++ b/tests/phpunit/runner/ActionScheduler_QueueCleaner_Test.php
@@ -14,7 +14,7 @@ class ActionScheduler_QueueCleaner_Test extends ActionScheduler_UnitTestCase {
 
 		$created_actions = array();
 		for ( $i = 0 ; $i < 5 ; $i++ ) {
-			$action = new ActionScheduler_Action( $random, array($random), $schedule );
+			$action = new ActionScheduler_Action( self::HOOK_WITH_CALLBACK, array($random), $schedule );
 			$created_actions[] = $store->save_action( $action );
 		}
 


### PR DESCRIPTION
This change is geared toward handling of scheduled actions that do not have any callbacks and, more broadly, recurring actions that continually and consistently fail.

Example: imagine a plugin has scheduled an hourly recurring action, but that same plugin is subsequently deleted without any opportunity to perform clean-up (or, it is deactivated normally but does not contain uninstall logic). Currently, those recurring actions will continue to fire and:

- Each time the action status will be updated to `complete` (so it will seem like they are running successfully).
- A replacement action will be scheduled.

Therefore, we can end up with a category of repeating zombie actions, clogging up the queue unnecessarily. This change attempts to address that problem and closes #805.

### How it works

Just because an action fails once doesn't mean it will always fail: so, we need to bake in some amount of tolerance. The way I propose we handle this is two-fold:

- When an action does not have any callbacks, mark it as `failed`.
- If it is a recurring action, check to see if it is *consistently* failing and, if so, don't reschedule it.
    - By default, the criteria for *"consistent failure"* is when the most recent 5 actions with the same hook, argument set, and schedule have all failed.
    - This will be adjustable via a filter.

### Testing

To make testing easier, I suggest temporarily stopping Action Scheduler from being triggered automatically:

- Add `define( 'DISABLE_WP_CRON', true );` to your `wp-config.php` file.
- Add `add_filter( 'action_scheduler_allow_async_request_runner', '__return_false' );` to a suitable location, such as a mu-plugin file.
- If you have any crontab entries that provide alternative ways of running cron or the Action Scheduler queue, suspend them.
- Also, to give yourself a 'clean view' of things, you may also wish to delete all existing actions: `wp db query "DELETE FROM $(wp db prefix)actionscheduler_actions"`

Now, processing of the queue should be entirely manual. Next:

- Create a new recurring action without a callback: `wp eval "as_schedule_recurring_action( time() - 1, 2, 'no_callback' );"`
- Visit **Tools ▸ Scheduled Actions** and locate action `no_callback` (should be pending), then run it manually.
- It should fail, and a replacement should be scheduled.
- Rinse and repeat a few times.
- In the end, you should find you have 5 failed scheduled actions for the hook `no_callback` and no more pending actions of that name should have been scheduled.

### Notes

- This is one facet of an effort to address zombie actions; we need to follow-up with further work that prevents unintentional duplication of actions (via race conditions).
- You will notice a large number of updates to tests that seem to be unrelated: that's because those tests relied on the previous behavior of Action Scheduler, where actions would be marked complete even if they didn't have a callback. Most of these updates are isolated inside commits https://github.com/woocommerce/action-scheduler/pull/806/commits/8276036dd57d3ba8ec8249e55a386c5acb1bfc4c and https://github.com/woocommerce/action-scheduler/pull/806/commits/37b8a1efb8911efc657609c0aa11c3392e3a4b86. The assertions specific to the core change can be [found here](https://github.com/woocommerce/action-scheduler/pull/806/files#diff-2fd59945ebe22bbea56dd19195fec979d5ee027dc705ac6b6af4eb01defad288).

### Changelog

> Enhancement - If a recurring action is found to be consistently failing, it will stop being rescheduled.