### PR TITLE
Fix the documented return type.

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -98,7 +98,7 @@ function as_schedule_cron_action( $timestamp, $schedule, $hook, $args = array(),
  * @param array $args Args that would have been passed to the job.
  * @param string $group The group the job is assigned to.
  *
- * @return string|null The scheduled action ID if a scheduled action was found, or null if no matching action found.
+ * @return int|null The scheduled action ID if a scheduled action was found, or null if no matching action found.
  */
 function as_unschedule_action( $hook, $args = array(), $group = '' ) {
 	if ( ! ActionScheduler::is_initialized( __FUNCTION__ ) ) {


### PR DESCRIPTION
Minor fix, corrects the return type declared in the docblock for `as_unschedule_action()` (per notes in the linked issue, it can only ever return an `int` or `null`, never a `string`).

Closes #792.

### How to test

Non-functional change, so no testing instructions.

### Changelog

> Dev - Correct docblock for `as_unschedule_string()`.