### PR TITLE
update: Added Action scheduler completed action hook

### DIFF
--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -841,7 +841,7 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 		}
 
 		/**
-		 * Fires after an action schedule is being completed.
+		 * Fires after a scheduled action has been completed.
 		 *
 		 * @since 3.4.2
 		 *

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -839,6 +839,7 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 		if ( empty( $updated ) ) {
 			throw new \InvalidArgumentException( sprintf( __( 'Unidentified action %s', 'action-scheduler' ), $action_id ) ); //phpcs:ignore WordPress.WP.I18n.MissingTranslatorsComment
 		}
+		do_action( 'action_scheduler_completed_action', $action_id );
 	}
 
 	/**

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -839,6 +839,14 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 		if ( empty( $updated ) ) {
 			throw new \InvalidArgumentException( sprintf( __( 'Unidentified action %s', 'action-scheduler' ), $action_id ) ); //phpcs:ignore WordPress.WP.I18n.MissingTranslatorsComment
 		}
+
+		/**
+		 * Fires after an action schedule is being completed.
+		 *
+		 * @since 3.4.2
+		 *
+		 * @param int $action_id Action ID.
+		 */
 		do_action( 'action_scheduler_completed_action', $action_id );
 	}
 

--- a/classes/data-stores/ActionScheduler_wpPostStore.php
+++ b/classes/data-stores/ActionScheduler_wpPostStore.php
@@ -989,7 +989,7 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 		}
 
 		/**
-		 * Fires after an action schedule is being completed.
+		 * Fires after a scheduled action has been completed.
 		 *
 		 * @since 3.4.2
 		 *

--- a/classes/data-stores/ActionScheduler_wpPostStore.php
+++ b/classes/data-stores/ActionScheduler_wpPostStore.php
@@ -987,6 +987,15 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 		if ( is_wp_error( $result ) ) {
 			throw new RuntimeException( $result->get_error_message() );
 		}
+
+		/**
+		 * Fires after an action schedule is being completed.
+		 *
+		 * @since 3.4.2
+		 *
+		 * @param int $action_id Action ID.
+		 */
+		do_action( 'action_scheduler_completed_action', $action_id );
 	}
 
 	/**


### PR DESCRIPTION
- [Enhancement] Added Action scheduler completed action hook.

I think added a simple hook when completed an action would solve many use cases pretty much simpler. And as there is no normal way to detect if actions is completed, this hook could be integrated.

Discussion in #729 

And for reference, same way, there is already a hook for `Canceled action` on `line-460`
```php
do_action( 'action_scheduler_canceled_action', $action_id );
```

So, it would be awesome if the new hook is integrated for completed action.

### Changelog 

> Enhancement - Add new action hook `action_scheduler_completed_action`.