### PR TITLE
Change the include for better linting.

### DIFF
--- a/classes/abstracts/ActionScheduler.php
+++ b/classes/abstracts/ActionScheduler.php
@@ -118,8 +118,8 @@ abstract class ActionScheduler {
 			return;
 		}
 
-		if ( file_exists( "{$dir}{$class}.php" ) ) {
-			include( "{$dir}{$class}.php" );
+		if ( file_exists( $dir . "{$class}.php" ) ) {
+			include( $dir . "{$class}.php" );
 			return;
 		}
 	}


### PR DESCRIPTION
There is no functional change.

This PR changes include style so that static linters detect the $dir in order to determine that this include path is not relative.
Otherwise, on WPCOM deploy linter complaints.

## Testing instructions

Automated tests