### PR TITLE
Make Action status links clickable

### DIFF
--- a/classes/abstracts/ActionScheduler_Abstract_ListTable.php
+++ b/classes/abstracts/ActionScheduler_Abstract_ListTable.php
@@ -683,7 +683,7 @@ abstract class ActionScheduler_Abstract_ListTable extends WP_List_Table {
 			}
 
 			if ( $status_name === $request_status || ( empty( $request_status ) && 'all' === $status_name ) ) {
-				$status_list_item = '<li class="%1$s"><strong>%3$s</strong> (%4$d)</li>';
+				$status_list_item = '<li class="%1$s"><a href="%2$s"><strong>%3$s</strong></a> (%4$d)</li>';
 			} else {
 				$status_list_item = '<li class="%1$s"><a href="%2$s">%3$s</a> (%4$d)</li>';
 			}

--- a/classes/abstracts/ActionScheduler_Abstract_ListTable.php
+++ b/classes/abstracts/ActionScheduler_Abstract_ListTable.php
@@ -683,7 +683,7 @@ abstract class ActionScheduler_Abstract_ListTable extends WP_List_Table {
 			}
 
 			if ( $status_name === $request_status || ( empty( $request_status ) && 'all' === $status_name ) ) {
-				$status_list_item = '<li class="%1$s"><a href="%2$s"><strong>%3$s</strong></a> (%4$d)</li>';
+				$status_list_item = '<li class="%1$s"><a href="%2$s" class="current">%3$s</a> (%4$d)</li>';
 			} else {
 				$status_list_item = '<li class="%1$s"><a href="%2$s">%3$s</a> (%4$d)</li>';
 			}


### PR DESCRIPTION
## Motivation
Adds a clickable link for all the statuses, pending, failed, in-progress etc.
Fixes https://github.com/woocommerce/action-scheduler/issues/685

## Screenshots
### Pre-patch
![Screenshot(10)](https://user-images.githubusercontent.com/7713923/171803733-f93134ca-055e-4fb2-b638-09e1422c4a6d.png)

### Post Patch
![Screenshot(11)](https://user-images.githubusercontent.com/7713923/171803758-7bedb994-9783-48d8-ae4d-e5a44f80598e.png)

## Other issues for discussion
- Do we remove the strong tag that highlights the current link and use the grey pre-patch instead of the default blue?

## Changelog

> Add - The active view link within the "Tools > Scheduled Actions" screen is now clickable.