### PR TITLE
Update functions.php

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -321,7 +321,7 @@ function as_get_scheduled_actions( $args = array(), $return_format = OBJECT ) {
  *
  * @return ActionScheduler_DateTime
  */
-function as_get_datetime_object( $date_string = null, $timezone = 'UTC' ) {
+function as_get_datetime_object( $date_string = '', $timezone = 'UTC' ) {
 	if ( is_object( $date_string ) && $date_string instanceof DateTime ) {
 		$date = new ActionScheduler_DateTime( $date_string->format( 'Y-m-d H:i:s' ), new DateTimeZone( $timezone ) );
 	} elseif ( is_numeric( $date_string ) ) {


### PR DESCRIPTION
Fixing PHP deprecated notices when using PHP 8.1

```
[06-Jun-2022 11:19:25 UTC] PHP Deprecated:  Return type of ActionScheduler_DateTime::setTimezone($timezone) should either be compatible with DateTime::setTimezone(DateTimeZone $timezone): DateTime, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /chroot/home/a083c05f/79bd385548.nxcli.net/html/wp-content/plugins/sfwd-lms/includes/lib/action-scheduler/classes/ActionScheduler_DateTime.php on line 60
[06-Jun-2022 11:19:25 UTC] PHP Deprecated:  Return type of ActionScheduler_DateTime::getOffset() should either be compatible with DateTime::getOffset(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /chroot/home/a083c05f/79bd385548.nxcli.net/html/wp-content/plugins/sfwd-lms/includes/lib/action-scheduler/classes/ActionScheduler_DateTime.php on line 48
[06-Jun-2022 11:19:25 UTC] PHP Deprecated:  Return type of ActionScheduler_DateTime::getTimestamp() should either be compatible with DateTime::getTimestamp(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /chroot/home/a083c05f/79bd385548.nxcli.net/html/wp-content/plugins/sfwd-lms/includes/lib/action-scheduler/classes/ActionScheduler_DateTime.php on line 27
[06-Jun-2022 11:19:25 UTC] PHP Deprecated:  DateTime::__construct(): Passing null to parameter #1 ($datetime) of type string is deprecated in /chroot/home/a083c05f/79bd385548.nxcli.net/html/wp-content/plugins/sfwd-lms/includes/lib/action-scheduler/functions.php on line 316
[06-Jun-2022 11:20:34 UTC] PHP Deprecated:  Return type of ActionScheduler_DateTime::setTimezone($timezone) should either be compatible with DateTime::setTimezone(DateTimeZone $timezone): DateTime, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /chroot/home/a083c05f/79bd385548.nxcli.net/html/wp-content/plugins/sfwd-lms/includes/lib/action-scheduler/classes/ActionScheduler_DateTime.php on line 60
[06-Jun-2022 11:20:34 UTC] PHP Deprecated:  Return type of ActionScheduler_DateTime::getOffset() should either be compatible with DateTime::getOffset(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /chroot/home/a083c05f/79bd385548.nxcli.net/html/wp-content/plugins/sfwd-lms/includes/lib/action-scheduler/classes/ActionScheduler_DateTime.php on line 48
[06-Jun-2022 11:20:34 UTC] PHP Deprecated:  Return type of ActionScheduler_DateTime::getTimestamp() should either be compatible with DateTime::getTimestamp(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /chroot/home/a083c05f/79bd385548.nxcli.net/html/wp-content/plugins/sfwd-lms/includes/lib/action-scheduler/classes/ActionScheduler_DateTime.php on line 27
[06-Jun-2022 11:20:34 UTC] PHP Deprecated:  DateTime::__construct(): Passing null to parameter #1 ($datetime) of type string is deprecated in /chroot/home/a083c05f/79bd385548.nxcli.net/html/wp-content/plugins/sfwd-lms/includes/lib/action-scheduler/functions.php on line 316
[06-Jun-2022 11:20:34 UTC] PHP Deprecated:  DateTime::__construct(): Passing null to parameter #1 ($datetime) of type string is deprecated in /chroot/home/a083c05f/79bd385548.nxcli.net/html/wp-content/plugins/sfwd-lms/includes/lib/action-scheduler/functions.php on line 316
[06-Jun-2022 11:20:34 UTC] PHP Deprecated:  DateTime::__construct(): Passing null to parameter #1 ($datetime) of type string is deprecated in /chroot/home/a083c05f/79bd385548.nxcli.net/html/wp-content/plugins/sfwd-lms/includes/lib/action-scheduler/functions.php on line 316
[06-Jun-2022 11:21:25 UTC] PHP Deprecated:  explode(): Passing null to parameter #2 ($string) of type string is deprecated in /chroot/home/a083c05f/79bd385548.nxcli.net/html/wp-content/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php on line 371
[06-Jun-2022 11:21:25 UTC] PHP Deprecated:  Return type of ActionScheduler_DateTime::setTimezone($timezone) should either be compatible with DateTime::setTimezone(DateTimeZone $timezone): DateTime, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /chroot/home/a083c05f/79bd385548.nxcli.net/html/wp-content/plugins/sfwd-lms/includes/lib/action-scheduler/classes/ActionScheduler_DateTime.php on line 60
[06-Jun-2022 11:21:25 UTC] PHP Deprecated:  Return type of ActionScheduler_DateTime::getOffset() should either be compatible with DateTime::getOffset(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /chroot/home/a083c05f/79bd385548.nxcli.net/html/wp-content/plugins/sfwd-lms/includes/lib/action-scheduler/classes/ActionScheduler_DateTime.php on line 48
[06-Jun-2022 11:21:25 UTC] PHP Deprecated:  Return type of ActionScheduler_DateTime::getTimestamp() should either be compatible with DateTime::getTimestamp(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /chroot/home/a083c05f/79bd385548.nxcli.net/html/wp-content/plugins/sfwd-lms/includes/lib/action-scheduler/classes/ActionScheduler_DateTime.php on line 27
[06-Jun-2022 11:21:25 UTC] PHP Deprecated:  DateTime::__construct(): Passing null to parameter #1 ($datetime) of type string is deprecated in /chroot/home/a083c05f/79bd385548.nxcli.net/html/wp-content/plugins/sfwd-lms/includes/lib/action-scheduler/functions.php on line 316
```