### PR TITLE
 Add support for scheduling unique actions.

### DIFF
--- a/classes/ActionScheduler_ActionFactory.php
+++ b/classes/ActionScheduler_ActionFactory.php
@@ -80,7 +80,7 @@ class ActionScheduler_ActionFactory {
 	 * @return int The ID of the stored action.
 	 */
 	public function single( $hook, $args = array(), $when = null, $group = '' ) {
-		return $this->single_with_unique( $hook, false, $args, $when, $group );
+		return $this->single_unique( $hook, false, $args, $when, $group );
 	}
 
 	/**

--- a/classes/ActionScheduler_ActionFactory.php
+++ b/classes/ActionScheduler_ActionFactory.php
@@ -66,20 +66,20 @@ class ActionScheduler_ActionFactory {
 	 * @return int The ID of the stored action.
 	 */
 	public function async( $hook, $args = array(), $group = '' ) {
-		return $this->async_unique( $hook, false, $args, $group );
+		return $this->async_unique( $hook, $args, $group, false );
 	}
 
 	/**
 	 * Same as async, but also supports $unique param.
 	 *
 	 * @param string $hook The hook to trigger when this action runs.
-	 * @param bool   $unique Whether to ensure the action is unique.
 	 * @param array  $args Args to pass when the hook is triggered.
 	 * @param string $group A group to put the action in.
+	 * @param bool   $unique Whether to ensure the action is unique.
 	 *
 	 * @return int The ID of the stored action.
 	 */
-	public function async_unique( $hook, $unique, $args = array(), $group = '' ) {
+	public function async_unique( $hook, $args = array(), $group = '', $unique = true ) {
 		$schedule = new ActionScheduler_NullSchedule();
 		$action   = new ActionScheduler_Action( $hook, $args, $schedule, $group );
 		return $unique ? $this->store_unique_action( $action, $unique ) : $this->store( $action );
@@ -96,21 +96,21 @@ class ActionScheduler_ActionFactory {
 	 * @return int The ID of the stored action.
 	 */
 	public function single( $hook, $args = array(), $when = null, $group = '' ) {
-		return $this->single_unique( $hook, false, $args, $when, $group );
+		return $this->single_unique( $hook, $args, $when, $group, false );
 	}
 
 	/**
 	 * Create single action only if there is no pending or running action with same name and params.
 	 *
 	 * @param string $hook The hook to trigger when this action runs.
-	 * @param bool   $unique Whether action scheduled should be unique.
 	 * @param array  $args Args to pass when the hook is triggered.
 	 * @param int    $when Unix timestamp when the action will run.
 	 * @param string $group A group to put the action in.
+	 * @param bool   $unique Whether action scheduled should be unique.
 	 *
 	 * @return int The ID of the stored action.
 	 */
-	public function single_unique( $hook, $unique, $args = array(), $when = null, $group = '' ) {
+	public function single_unique( $hook, $args = array(), $when = null, $group = '', $unique = true ) {
 		$date     = as_get_datetime_object( $when );
 		$schedule = new ActionScheduler_SimpleSchedule( $date );
 		$action   = new ActionScheduler_Action( $hook, $args, $schedule, $group );
@@ -129,22 +129,22 @@ class ActionScheduler_ActionFactory {
 	 * @return int The ID of the stored action.
 	 */
 	public function recurring( $hook, $args = array(), $first = null, $interval = null, $group = '' ) {
-		return $this->recurring_unique( $hook, false, $args, $first, $interval, $group );
+		return $this->recurring_unique( $hook, $args, $first, $interval, $group, false );
 	}
 
 	/**
 	 * Create the first instance of an action recurring on a given interval only if there is no pending or running action with same name and params.
 	 *
 	 * @param string $hook The hook to trigger when this action runs.
-	 * @param bool   $unique Whether action scheduled should be unique.
 	 * @param array  $args Args to pass when the hook is triggered.
 	 * @param int    $first Unix timestamp for the first run.
 	 * @param int    $interval Seconds between runs.
 	 * @param string $group A group to put the action in.
+	 * @param bool   $unique Whether action scheduled should be unique.
 	 *
 	 * @return int The ID of the stored action.
 	 */
-	public function recurring_unique( $hook, $unique, $args = array(), $first = null, $interval = null, $group = '' ) {
+	public function recurring_unique( $hook, $args = array(), $first = null, $interval = null, $group = '', $unique = true ) {
 		if ( empty( $interval ) ) {
 			return $this->single_unique( $hook, $unique, $args, $first, $group );
 		}
@@ -168,24 +168,25 @@ class ActionScheduler_ActionFactory {
 	 * @return int The ID of the stored action.
 	 */
 	public function cron( $hook, $args = array(), $base_timestamp = null, $schedule = null, $group = '' ) {
-		return $this->cron_unique( $hook, false, $args, $base_timestamp, $schedule, $group );
+		return $this->cron_unique( $hook, $args, $base_timestamp, $schedule, $group, false );
 	}
+
 
 	/**
 	 * Create the first instance of an action recurring on a Cron schedule only if there is no pending or running action with same name and params.
 	 *
 	 * @param string $hook The hook to trigger when this action runs.
-	 * @param bool   $unique Whether action scheduled should be unique.
 	 * @param array  $args Args to pass when the hook is triggered.
 	 * @param int    $base_timestamp The first instance of the action will be scheduled
 	 *        to run at a time calculated after this timestamp matching the cron
 	 *        expression. This can be used to delay the first instance of the action.
 	 * @param int    $schedule A cron definition string.
 	 * @param string $group A group to put the action in.
+	 * @param bool   $unique Whether action scheduled should be unique.
 	 *
 	 * @return int The ID of the stored action.
 	 **/
-	public function cron_unique( $hook, $unique, $args = array(), $base_timestamp = null, $schedule = null, $group = '' ) {
+	public function cron_unique( $hook, $args = array(), $base_timestamp = null, $schedule = null, $group = '', $unique = true ) {
 		if ( empty( $schedule ) ) {
 			return $this->single_unique( $hook, $unique, $args, $base_timestamp, $group );
 		}

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -104,6 +104,9 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 			if ( is_wp_error( $action_id ) ) {
 				throw new \RuntimeException( $action_id->get_error_message() );
 			} elseif ( empty( $action_id ) ) {
+				if ( $unique ) {
+					return 0;
+				}
 				throw new \RuntimeException( $wpdb->last_error ? $wpdb->last_error : __( 'Database error.', 'action-scheduler' ) );
 			}
 
@@ -175,13 +178,13 @@ WHERE ( $where_clause ) IS NULL",
 SELECT action_id FROM $table_name
 WHERE status IN ( $pending_status_placeholders )
 AND hook = %s
-AND `group` = %s
+AND `group_id` = %s
 ",
 			array_merge(
 				$pending_statuses,
 				array(
 					$data['hook'],
-					$data['group'],
+					$data['group_id'],
 				)
 			)
 		);

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -178,7 +178,7 @@ WHERE ( $where_clause ) IS NULL",
 SELECT action_id FROM $table_name
 WHERE status IN ( $pending_status_placeholders )
 AND hook = %s
-AND `group_id` = %s
+AND `group_id` = %d
 ",
 			array_merge(
 				$pending_statuses,

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -190,7 +190,7 @@ AND `group_id` = %d
 		);
 		// phpcs:enable
 
-		if ( $data['args'] ) {
+		if ( ! empty( $data['args'] ) && wp_json_encode( array() ) !== $data['args'] ) {
 			$where_clause .= $wpdb->prepare( 'AND args = %s', $data['args'] );
 		}
 

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -66,13 +66,13 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 	 * Save an action.
 	 *
 	 * @param ActionScheduler_Action $action Action object.
-	 * @param \DateTime              $date Optional schedule date. Default null.
+	 * @param ?DateTime              $date Optional schedule date. Default null.
 	 * @param bool                   $unique Whether the action should be unique.
 	 *
 	 * @return int Action ID.
-	 * @throws \RuntimeException     Throws exception when saving the action fails.
+	 * @throws RuntimeException     Throws exception when saving the action fails.
 	 */
-	private function save_action_to_db( ActionScheduler_Action $action, \DateTime $date = null, $unique = false ) {
+	private function save_action_to_db( ActionScheduler_Action $action, DateTime $date = null, $unique = false ) {
 		global $wpdb;
 
 		try {
@@ -135,11 +135,11 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 
 		$table_name = ! empty( $wpdb->actionscheduler_actions ) ? $wpdb->actionscheduler_actions : $wpdb->prefix . 'actionscheduler_actions';
 
-		$column_sql                  = '`' . implode( '`, `', $columns ) . '`';
-		$placeholder_sql             = implode( ', ', $placeholders );
-		$where_clause = $this->build_where_clause_for_insert( $data, $table_name, $unique );
+		$column_sql      = '`' . implode( '`, `', $columns ) . '`';
+		$placeholder_sql = implode( ', ', $placeholders );
+		$where_clause    = $this->build_where_clause_for_insert( $data, $table_name, $unique );
 		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $column_sql and $where_clause are already prepared. $placeholder_sql is hardcoded.
-		$insert_query                = $wpdb->prepare(
+		$insert_query    = $wpdb->prepare(
 			"
 INSERT INTO $table_name ( $column_sql )
 SELECT $placeholder_sql FROM DUAL

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -190,10 +190,6 @@ AND `group_id` = %d
 		);
 		// phpcs:enable
 
-		if ( ! empty( $data['args'] ) && wp_json_encode( array() ) !== $data['args'] ) {
-			$where_clause .= $wpdb->prepare( 'AND args = %s', $data['args'] );
-		}
-
 		return "$where_clause" . ' LIMIT 1';
 	}
 

--- a/functions.php
+++ b/functions.php
@@ -19,7 +19,7 @@ function as_enqueue_async_action( $hook, $args = array(), $group = '', $unique =
 	if ( ! ActionScheduler::is_initialized( __FUNCTION__ ) ) {
 		return 0;
 	}
-	return ActionScheduler::factory()->async_unique( $hook, $unique, $args, $group );
+	return ActionScheduler::factory()->async_unique( $hook, $args, $group, $unique );
 }
 
 /**
@@ -37,7 +37,7 @@ function as_schedule_single_action( $timestamp, $hook, $args = array(), $group =
 	if ( ! ActionScheduler::is_initialized( __FUNCTION__ ) ) {
 		return 0;
 	}
-	return ActionScheduler::factory()->single_unique( $hook, $unique, $args, $timestamp, $group );
+	return ActionScheduler::factory()->single_unique( $hook, $args, $timestamp, $group, $unique );
 }
 
 /**
@@ -56,7 +56,7 @@ function as_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, 
 	if ( ! ActionScheduler::is_initialized( __FUNCTION__ ) ) {
 		return 0;
 	}
-	return ActionScheduler::factory()->recurring_unique( $hook, $unique, $args, $timestamp, $interval_in_seconds, $group );
+	return ActionScheduler::factory()->recurring_unique( $hook, $args, $timestamp, $interval_in_seconds, $group, $unique );
 }
 
 /**
@@ -87,7 +87,7 @@ function as_schedule_cron_action( $timestamp, $schedule, $hook, $args = array(),
 	if ( ! ActionScheduler::is_initialized( __FUNCTION__ ) ) {
 		return 0;
 	}
-	return ActionScheduler::factory()->cron_unique( $hook, $unique, $args, $timestamp, $schedule, $group );
+	return ActionScheduler::factory()->cron_unique( $hook, $args, $timestamp, $schedule, $group, $unique );
 }
 
 /**

--- a/functions.php
+++ b/functions.php
@@ -26,14 +26,15 @@ function as_enqueue_async_action( $hook, $args = array(), $group = '' ) {
  * @param string $hook The hook to trigger.
  * @param array $args Arguments to pass when the hook triggers.
  * @param string $group The group to assign this job to.
+ * @param bool $unique Whether the action should be unique.
  *
  * @return int The action ID.
  */
-function as_schedule_single_action( $timestamp, $hook, $args = array(), $group = '' ) {
+function as_schedule_single_action( $timestamp, $hook, $args = array(), $group = '', $unique = false ) {
 	if ( ! ActionScheduler::is_initialized( __FUNCTION__ ) ) {
 		return 0;
 	}
-	return ActionScheduler::factory()->single( $hook, $args, $timestamp, $group );
+	return ActionScheduler::factory()->single_unique( $hook, $unique, $args, $timestamp, $group );
 }
 
 /**
@@ -44,10 +45,11 @@ function as_schedule_single_action( $timestamp, $hook, $args = array(), $group =
  * @param string $hook The hook to trigger.
  * @param array $args Arguments to pass when the hook triggers.
  * @param string $group The group to assign this job to.
+ * @param bool $unique Whether the action should be unique.
  *
  * @return int The action ID.
  */
-function as_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, $args = array(), $group = '' ) {
+function as_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, $args = array(), $group = '', $unique = false ) {
 	if ( ! ActionScheduler::is_initialized( __FUNCTION__ ) ) {
 		return 0;
 	}
@@ -74,10 +76,11 @@ function as_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, 
  * @param string $hook The hook to trigger.
  * @param array $args Arguments to pass when the hook triggers.
  * @param string $group The group to assign this job to.
+ * @param bool $unique Whether the action should be unique.
  *
  * @return int The action ID.
  */
-function as_schedule_cron_action( $timestamp, $schedule, $hook, $args = array(), $group = '' ) {
+function as_schedule_cron_action( $timestamp, $schedule, $hook, $args = array(), $group = '', $unique = false ) {
 	if ( ! ActionScheduler::is_initialized( __FUNCTION__ ) ) {
 		return 0;
 	}

--- a/functions.php
+++ b/functions.php
@@ -1,7 +1,8 @@
 <?php
-
 /**
  * General API functions for scheduling actions
+ *
+ * @package ActionScheduler.
  */
 
 /**
@@ -10,23 +11,25 @@
  * @param string $hook The hook to trigger.
  * @param array  $args Arguments to pass when the hook triggers.
  * @param string $group The group to assign this job to.
+ * @param bool   $unique Whether the action should be unique.
+ *
  * @return int The action ID.
  */
-function as_enqueue_async_action( $hook, $args = array(), $group = '' ) {
+function as_enqueue_async_action( $hook, $args = array(), $group = '', $unique = false ) {
 	if ( ! ActionScheduler::is_initialized( __FUNCTION__ ) ) {
 		return 0;
 	}
-	return ActionScheduler::factory()->async( $hook, $args, $group );
+	return ActionScheduler::factory()->async_unique( $hook, $unique, $args, $group );
 }
 
 /**
  * Schedule an action to run one time
  *
- * @param int $timestamp When the job will run.
+ * @param int    $timestamp When the job will run.
  * @param string $hook The hook to trigger.
- * @param array $args Arguments to pass when the hook triggers.
+ * @param array  $args Arguments to pass when the hook triggers.
  * @param string $group The group to assign this job to.
- * @param bool $unique Whether the action should be unique.
+ * @param bool   $unique Whether the action should be unique.
  *
  * @return int The action ID.
  */
@@ -40,12 +43,12 @@ function as_schedule_single_action( $timestamp, $hook, $args = array(), $group =
 /**
  * Schedule a recurring action
  *
- * @param int $timestamp When the first instance of the job will run.
- * @param int $interval_in_seconds How long to wait between runs.
+ * @param int    $timestamp When the first instance of the job will run.
+ * @param int    $interval_in_seconds How long to wait between runs.
  * @param string $hook The hook to trigger.
- * @param array $args Arguments to pass when the hook triggers.
+ * @param array  $args Arguments to pass when the hook triggers.
  * @param string $group The group to assign this job to.
- * @param bool $unique Whether the action should be unique.
+ * @param bool   $unique Whether the action should be unique.
  *
  * @return int The action ID.
  */
@@ -53,16 +56,16 @@ function as_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, 
 	if ( ! ActionScheduler::is_initialized( __FUNCTION__ ) ) {
 		return 0;
 	}
-	return ActionScheduler::factory()->recurring( $hook, $args, $timestamp, $interval_in_seconds, $group );
+	return ActionScheduler::factory()->recurring_unique( $hook, $unique, $args, $timestamp, $interval_in_seconds, $group );
 }
 
 /**
  * Schedule an action that recurs on a cron-like schedule.
  *
- * @param int $base_timestamp The first instance of the action will be scheduled
- *        to run at a time calculated after this timestamp matching the cron
- *        expression. This can be used to delay the first instance of the action.
- * @param string $schedule A cron-link schedule string
+ * @param int    $timestamp The first instance of the action will be scheduled
+ *           to run at a time calculated after this timestamp matching the cron
+ *           expression. This can be used to delay the first instance of the action.
+ * @param string $schedule A cron-link schedule string.
  * @see http://en.wikipedia.org/wiki/Cron
  *   *    *    *    *    *    *
  *   ┬    ┬    ┬    ┬    ┬    ┬
@@ -74,9 +77,9 @@ function as_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, 
  *   |    +-------------------- hour (0 - 23)
  *   +------------------------- min (0 - 59)
  * @param string $hook The hook to trigger.
- * @param array $args Arguments to pass when the hook triggers.
+ * @param array  $args Arguments to pass when the hook triggers.
  * @param string $group The group to assign this job to.
- * @param bool $unique Whether the action should be unique.
+ * @param bool   $unique Whether the action should be unique.
  *
  * @return int The action ID.
  */
@@ -84,7 +87,7 @@ function as_schedule_cron_action( $timestamp, $schedule, $hook, $args = array(),
 	if ( ! ActionScheduler::is_initialized( __FUNCTION__ ) ) {
 		return 0;
 	}
-	return ActionScheduler::factory()->cron( $hook, $args, $timestamp, $schedule, $group );
+	return ActionScheduler::factory()->cron_unique( $hook, $unique, $args, $timestamp, $schedule, $group );
 }
 
 /**
@@ -98,7 +101,7 @@ function as_schedule_cron_action( $timestamp, $schedule, $hook, $args = array(),
  * by this method also.
  *
  * @param string $hook The hook that the job will trigger.
- * @param array $args Args that would have been passed to the job.
+ * @param array  $args Args that would have been passed to the job.
  * @param string $group The group the job is assigned to.
  *
  * @return int|null The scheduled action ID if a scheduled action was found, or null if no matching action found.
@@ -144,7 +147,7 @@ function as_unschedule_action( $hook, $args = array(), $group = '' ) {
  * Cancel all occurrences of a scheduled action.
  *
  * @param string $hook The hook that the job will trigger.
- * @param array $args Args that would have been passed to the job.
+ * @param array  $args Args that would have been passed to the job.
  * @param string $group The group the job is assigned to.
  */
 function as_unschedule_all_actions( $hook, $args = array(), $group = '' ) {
@@ -175,9 +178,9 @@ function as_unschedule_all_actions( $hook, $args = array(), $group = '' ) {
  * returned. Or there may be no async, in-progress or pending action for this hook, in which case,
  * boolean false will be the return value.
  *
- * @param string $hook
- * @param array $args
- * @param string $group
+ * @param string $hook Name of the hook to search for.
+ * @param array  $args Arguments of the action to be searched.
+ * @param string $group Group of the action to be searched.
  *
  * @return int|bool The timestamp for the next occurrence of a pending scheduled action, true for an async or in-progress action or false if there is no matching action.
  */
@@ -213,7 +216,7 @@ function as_next_scheduled_action( $hook, $args = null, $group = '' ) {
 	$scheduled_date = $action->get_schedule()->get_date();
 	if ( $scheduled_date ) {
 		return (int) $scheduled_date->format( 'U' );
-	} elseif ( null === $scheduled_date ) { // pending async action with NullSchedule
+	} elseif ( null === $scheduled_date ) { // pending async action with NullSchedule.
 		return true;
 	}
 
@@ -240,10 +243,10 @@ function as_has_scheduled_action( $hook, $args = null, $group = '' ) {
 	}
 
 	$query_args = array(
-		'hook'     => $hook,
-		'status'   => array( ActionScheduler_Store::STATUS_RUNNING, ActionScheduler_Store::STATUS_PENDING ),
-		'group'    => $group,
-		'orderby'  => 'none',
+		'hook'    => $hook,
+		'status'  => array( ActionScheduler_Store::STATUS_RUNNING, ActionScheduler_Store::STATUS_PENDING ),
+		'group'   => $group,
+		'orderby' => 'none',
 	);
 
 	if ( null !== $args ) {
@@ -252,26 +255,26 @@ function as_has_scheduled_action( $hook, $args = null, $group = '' ) {
 
 	$action_id = ActionScheduler::store()->query_action( $query_args );
 
-	return $action_id !== null;
+	return null !== $action_id;
 }
 
 /**
  * Find scheduled actions
  *
- * @param array $args Possible arguments, with their default values:
- *        'hook' => '' - the name of the action that will be triggered
- *        'args' => NULL - the args array that will be passed with the action
- *        'date' => NULL - the scheduled date of the action. Expects a DateTime object, a unix timestamp, or a string that can parsed with strtotime(). Used in UTC timezone.
- *        'date_compare' => '<=' - operator for testing "date". accepted values are '!=', '>', '>=', '<', '<=', '='
- *        'modified' => NULL - the date the action was last updated. Expects a DateTime object, a unix timestamp, or a string that can parsed with strtotime(). Used in UTC timezone.
- *        'modified_compare' => '<=' - operator for testing "modified". accepted values are '!=', '>', '>=', '<', '<=', '='
- *        'group' => '' - the group the action belongs to
- *        'status' => '' - ActionScheduler_Store::STATUS_COMPLETE or ActionScheduler_Store::STATUS_PENDING
- *        'claimed' => NULL - TRUE to find claimed actions, FALSE to find unclaimed actions, a string to find a specific claim ID
- *        'per_page' => 5 - Number of results to return
- *        'offset' => 0
- *        'orderby' => 'date' - accepted values are 'hook', 'group', 'modified', 'date' or 'none'
- *        'order' => 'ASC'
+ * @param array  $args Possible arguments, with their default values.
+ *         'hook' => '' - the name of the action that will be triggered.
+ *         'args' => NULL - the args array that will be passed with the action.
+ *         'date' => NULL - the scheduled date of the action. Expects a DateTime object, a unix timestamp, or a string that can parsed with strtotime(). Used in UTC timezone.
+ *         'date_compare' => '<=' - operator for testing "date". accepted values are '!=', '>', '>=', '<', '<=', '='.
+ *         'modified' => NULL - the date the action was last updated. Expects a DateTime object, a unix timestamp, or a string that can parsed with strtotime(). Used in UTC timezone.
+ *         'modified_compare' => '<=' - operator for testing "modified". accepted values are '!=', '>', '>=', '<', '<=', '='.
+ *         'group' => '' - the group the action belongs to.
+ *         'status' => '' - ActionScheduler_Store::STATUS_COMPLETE or ActionScheduler_Store::STATUS_PENDING.
+ *         'claimed' => NULL - TRUE to find claimed actions, FALSE to find unclaimed actions, a string to find a specific claim ID.
+ *         'per_page' => 5 - Number of results to return.
+ *         'offset' => 0.
+ *         'orderby' => 'date' - accepted values are 'hook', 'group', 'modified', 'date' or 'none'.
+ *         'order' => 'ASC'.
  *
  * @param string $return_format OBJECT, ARRAY_A, or ids.
  *
@@ -282,25 +285,25 @@ function as_get_scheduled_actions( $args = array(), $return_format = OBJECT ) {
 		return array();
 	}
 	$store = ActionScheduler::store();
-	foreach ( array('date', 'modified') as $key ) {
-		if ( isset($args[$key]) ) {
-			$args[$key] = as_get_datetime_object($args[$key]);
+	foreach ( array( 'date', 'modified' ) as $key ) {
+		if ( isset( $args[ $key ] ) ) {
+			$args[ $key ] = as_get_datetime_object( $args[ $key ] );
 		}
 	}
 	$ids = $store->query_actions( $args );
 
-	if ( $return_format == 'ids' || $return_format == 'int' ) {
+	if ( 'ids' === $return_format || 'int' === $return_format ) {
 		return $ids;
 	}
 
 	$actions = array();
 	foreach ( $ids as $action_id ) {
-		$actions[$action_id] = $store->fetch_action( $action_id );
+		$actions[ $action_id ] = $store->fetch_action( $action_id );
 	}
 
-	if ( $return_format == ARRAY_A ) {
+	if ( ARRAY_A == $return_format ) {
 		foreach ( $actions as $action_id => $action_object ) {
-			$actions[$action_id] = get_object_vars($action_object);
+			$actions[ $action_id ] = get_object_vars( $action_object );
 		}
 	}
 
@@ -319,7 +322,7 @@ function as_get_scheduled_actions( $args = array(), $return_format = OBJECT ) {
  * timezone when instantiating datetimes rather than leaving it up to
  * the PHP default.
  *
- * @param mixed $date_string A date/time string. Valid formats are explained in http://php.net/manual/en/datetime.formats.php.
+ * @param mixed  $date_string A date/time string. Valid formats are explained in http://php.net/manual/en/datetime.formats.php.
  * @param string $timezone A timezone identifier, like UTC or Europe/Lisbon. The list of valid identifiers is available http://php.net/manual/en/timezones.php.
  *
  * @return ActionScheduler_DateTime

--- a/tests/phpunit/jobstore/ActionScheduler_DBStore_Test.php
+++ b/tests/phpunit/jobstore/ActionScheduler_DBStore_Test.php
@@ -446,4 +446,23 @@ class ActionScheduler_DBStore_Test extends AbstractStoreTest {
 		$this->assertEquals( (int) ( $now->format( 'U' ) ) + HOUR_IN_SECONDS, $store->get_date( $new_action_id )->format( 'U' ) );
 	}
 
+	/**
+	 * Test creating a unique action.
+	 */
+	public function test_create_action_unique() {
+		$time     = as_get_datetime_object();
+		$hook     = md5( rand() );
+		$schedule = new ActionScheduler_SimpleSchedule( $time );
+		$store    = new ActionScheduler_DBStore();
+		$action   = new ActionScheduler_Action( $hook, array(), $schedule );
+
+		$action_id = $store->save_action( $action );
+		$this->assertNotEquals( 0, $action_id );
+		$action_from_db = $store->fetch_action( $action_id );
+		$this->assertTrue( is_a( $action_from_db, ActionScheduler_Action::class ) );
+
+		$action_id_duplicate = $store->save_unique_action( $action );
+		$this->assertEquals( 0, $action_id_duplicate );
+	}
+
 }

--- a/tests/phpunit/jobstore/ActionScheduler_DBStore_Test.php
+++ b/tests/phpunit/jobstore/ActionScheduler_DBStore_Test.php
@@ -461,6 +461,7 @@ class ActionScheduler_DBStore_Test extends AbstractStoreTest {
 		$action_from_db = $store->fetch_action( $action_id );
 		$this->assertTrue( is_a( $action_from_db, ActionScheduler_Action::class ) );
 
+		$action = new ActionScheduler_Action( $hook, array(), $schedule );
 		$action_id_duplicate = $store->save_unique_action( $action );
 		$this->assertEquals( 0, $action_id_duplicate );
 	}
@@ -489,4 +490,25 @@ class ActionScheduler_DBStore_Test extends AbstractStoreTest {
 		$this->assertEquals( 0, $action_id_group2_double );
 	}
 
+	/**
+	 * Test saving a unique action first, and then successfully scheduling a non-unique action.
+	 */
+	public function test_create_action_unique_and_then_non_unique() {
+		$time     = as_get_datetime_object();
+		$hook     = md5( rand() );
+		$schedule = new ActionScheduler_SimpleSchedule( $time );
+		$store    = new ActionScheduler_DBStore();
+		$action   = new ActionScheduler_Action( $hook, array(), $schedule );
+
+		$action_id = $store->save_unique_action( $action );
+		$this->assertNotEquals( 0, $action_id );
+		$action_from_db = $store->fetch_action( $action_id );
+		$this->assertTrue( is_a( $action_from_db, ActionScheduler_Action::class ) );
+
+		// Non unique action is scheduled even if the previous one was unique.
+		$action = new ActionScheduler_Action( $hook, array(), $schedule );
+		$action_id_duplicate = $store->save_action( $action );
+		$action_from_db_duplicate = $store->fetch_action( $action_id_duplicate );
+		$this->assertTrue( is_a( $action_from_db_duplicate, ActionScheduler_Action::class ) );
+	}
 }

--- a/tests/phpunit/jobstore/ActionScheduler_DBStore_Test.php
+++ b/tests/phpunit/jobstore/ActionScheduler_DBStore_Test.php
@@ -465,4 +465,28 @@ class ActionScheduler_DBStore_Test extends AbstractStoreTest {
 		$this->assertEquals( 0, $action_id_duplicate );
 	}
 
+	/**
+	 * Test saving unique actions across different groups. Different groups should be saved, same groups shouldn't.
+	 */
+	public function test_create_action_unique_with_different_groups() {
+		$time     = as_get_datetime_object();
+		$hook    = md5( rand() );
+		$schedule = new ActionScheduler_SimpleSchedule( $time );
+		$store    = new ActionScheduler_DBStore();
+		$action   = new ActionScheduler_Action( $hook, array(), $schedule, 'group1' );
+
+		$action_id = $store->save_action( $action );
+		$action_from_db = $store->fetch_action( $action_id );
+		$this->assertTrue( is_a( $action_from_db, ActionScheduler_Action::class ) );
+
+		$action2 = new ActionScheduler_Action( $hook, array(), $schedule, 'group2' );
+		$action_id_group2 = $store->save_unique_action( $action2 );
+		$action_2_from_db = $store->fetch_action( $action_id_group2 );
+		$this->assertTrue( is_a( $action_2_from_db, ActionScheduler_Action::class ) );
+
+		$action3 = new ActionScheduler_Action( $hook, array(), $schedule, 'group2' );
+		$action_id_group2_double = $store->save_unique_action( $action3 );
+		$this->assertEquals( 0, $action_id_group2_double );
+	}
+
 }

--- a/tests/phpunit/jobstore/ActionScheduler_DBStore_Test.php
+++ b/tests/phpunit/jobstore/ActionScheduler_DBStore_Test.php
@@ -471,7 +471,7 @@ class ActionScheduler_DBStore_Test extends AbstractStoreTest {
 	 */
 	public function test_create_action_unique_with_different_groups() {
 		$time     = as_get_datetime_object();
-		$hook    = md5( rand() );
+		$hook     = md5( rand() );
 		$schedule = new ActionScheduler_SimpleSchedule( $time );
 		$store    = new ActionScheduler_DBStore();
 		$action   = new ActionScheduler_Action( $hook, array(), $schedule, 'group1' );

--- a/tests/phpunit/jobstore/ActionScheduler_DBStore_Test.php
+++ b/tests/phpunit/jobstore/ActionScheduler_DBStore_Test.php
@@ -511,4 +511,29 @@ class ActionScheduler_DBStore_Test extends AbstractStoreTest {
 		$action_from_db_duplicate = $store->fetch_action( $action_id_duplicate );
 		$this->assertTrue( is_a( $action_from_db_duplicate, ActionScheduler_Action::class ) );
 	}
+
+	/**
+	 * Test asserting that action when an action is created with empty args, it matches with actions created with args for uniqueness.
+	 */
+	public function test_create_action_unique_with_empty_array() {
+		$time     = as_get_datetime_object();
+		$hook     = md5( rand() );
+		$schedule = new ActionScheduler_SimpleSchedule( $time );
+		$store    = new ActionScheduler_DBStore();
+		$action   = new ActionScheduler_Action( $hook, array( 'foo' => 'bar' ), $schedule );
+
+		$action_id = $store->save_unique_action( $action );
+		$this->assertNotEquals( 0, $action_id );
+		$action_from_db = $store->fetch_action( $action_id );
+		$this->assertTrue( is_a( $action_from_db, ActionScheduler_Action::class ) );
+
+		$action_with_empty_args = new ActionScheduler_Action( $hook, array(), $schedule );
+		$action_id_duplicate = $store->save_unique_action( $action_with_empty_args );
+		$this->assertEquals( 0, $action_id_duplicate );
+
+		$action_with_different_args = new ActionScheduler_Action( $hook, array( 'foo' => 'bazz' ), $schedule );
+		$action_id_duplicate = $store->save_unique_action( $action_with_different_args );
+		$action_from_db = $store->fetch_action( $action_id_duplicate );
+		$this->assertTrue( is_a( $action_from_db, ActionScheduler_Action::class ) );
+	}
 }

--- a/tests/phpunit/procedural_api/procedural_api_Test.php
+++ b/tests/phpunit/procedural_api/procedural_api_Test.php
@@ -3,39 +3,40 @@
 /**
  * Class procedural_api_Test
  */
-class procedural_api_Test extends ActionScheduler_UnitTestCase {
+class Procedural_API_Test extends ActionScheduler_UnitTestCase {
 
+	// phpcs:disable Squiz.Commenting.FunctionComment.Missing, Squiz.Commenting.FunctionComment.MissingParamTag
 	public function test_schedule_action() {
-		$time = time();
-		$hook = md5(rand());
+		$time      = time();
+		$hook      = md5( rand() );
 		$action_id = as_schedule_single_action( $time, $hook );
 
-		$store = ActionScheduler::store();
-		$action = $store->fetch_action($action_id);
+		$store  = ActionScheduler::store();
+		$action = $store->fetch_action( $action_id );
 		$this->assertEquals( $time, $action->get_schedule()->get_date()->getTimestamp() );
 		$this->assertEquals( $hook, $action->get_hook() );
 	}
 
 	public function test_recurring_action() {
-		$time = time();
-		$hook = md5(rand());
+		$time      = time();
+		$hook      = md5( rand() );
 		$action_id = as_schedule_recurring_action( $time, HOUR_IN_SECONDS, $hook );
 
-		$store = ActionScheduler::store();
-		$action = $store->fetch_action($action_id);
+		$store  = ActionScheduler::store();
+		$action = $store->fetch_action( $action_id );
 		$this->assertEquals( $time, $action->get_schedule()->get_date()->getTimestamp() );
-		$this->assertEquals( $time + HOUR_IN_SECONDS + 2, $action->get_schedule()->get_next(as_get_datetime_object($time + 2))->getTimestamp());
+		$this->assertEquals( $time + HOUR_IN_SECONDS + 2, $action->get_schedule()->get_next( as_get_datetime_object( $time + 2 ) )->getTimestamp() );
 		$this->assertEquals( $hook, $action->get_hook() );
 	}
 
 	public function test_cron_schedule() {
-		$time = as_get_datetime_object('2014-01-01');
-		$hook = md5(rand());
+		$time      = as_get_datetime_object( '2014-01-01' );
+		$hook      = md5( rand() );
 		$action_id = as_schedule_cron_action( $time->getTimestamp(), '0 0 10 10 *', $hook );
 
-		$store = ActionScheduler::store();
-		$action = $store->fetch_action($action_id);
-		$expected_date = as_get_datetime_object('2014-10-10');
+		$store         = ActionScheduler::store();
+		$action        = $store->fetch_action( $action_id );
+		$expected_date = as_get_datetime_object( '2014-10-10' );
 		$this->assertEquals( $expected_date->getTimestamp(), $action->get_schedule()->get_date()->getTimestamp() );
 		$this->assertEquals( $hook, $action->get_hook() );
 
@@ -44,8 +45,8 @@ class procedural_api_Test extends ActionScheduler_UnitTestCase {
 	}
 
 	public function test_get_next() {
-		$time = as_get_datetime_object('tomorrow');
-		$hook = md5(rand());
+		$time = as_get_datetime_object( 'tomorrow' );
+		$hook = md5( rand() );
 		as_schedule_recurring_action( $time->getTimestamp(), HOUR_IN_SECONDS, $hook );
 
 		$next = as_next_scheduled_action( $hook );
@@ -54,7 +55,7 @@ class procedural_api_Test extends ActionScheduler_UnitTestCase {
 	}
 
 	public function test_get_next_async() {
-		$hook = md5(rand());
+		$hook      = md5( rand() );
 		$action_id = as_enqueue_async_action( $hook );
 
 		$next = as_next_scheduled_action( $hook );
@@ -63,17 +64,17 @@ class procedural_api_Test extends ActionScheduler_UnitTestCase {
 
 		$store = ActionScheduler::store();
 
-		// Completed async actions should still return false
+		// Completed async actions should still return false.
 		$store->mark_complete( $action_id );
 		$next = as_next_scheduled_action( $hook );
 		$this->assertFalse( $next );
 
-		// Failed async actions should still return false
+		// Failed async actions should still return false.
 		$store->mark_failure( $action_id );
 		$next = as_next_scheduled_action( $hook );
 		$this->assertFalse( $next );
 
-		// Cancelled async actions should still return false
+		// Cancelled async actions should still return false.
 		$store->cancel_action( $action_id );
 		$next = as_next_scheduled_action( $hook );
 		$this->assertFalse( $next );
@@ -87,7 +88,7 @@ class procedural_api_Test extends ActionScheduler_UnitTestCase {
 
 		return array(
 
-			// Test with no args or group
+			// Test with no args or group.
 			array(
 				'time'  => $time,
 				'hook'  => $hook,
@@ -95,7 +96,7 @@ class procedural_api_Test extends ActionScheduler_UnitTestCase {
 				'group' => '',
 			),
 
-			// Test with args but no group
+			// Test with args but no group.
 			array(
 				'time'  => $time,
 				'hook'  => $hook,
@@ -103,7 +104,7 @@ class procedural_api_Test extends ActionScheduler_UnitTestCase {
 				'group' => '',
 			),
 
-			// Test with group but no args
+			// Test with group but no args.
 			array(
 				'time'  => $time,
 				'hook'  => $hook,
@@ -111,7 +112,7 @@ class procedural_api_Test extends ActionScheduler_UnitTestCase {
 				'group' => $group,
 			),
 
-			// Test with args & group
+			// Test with args & group.
 			array(
 				'time'  => $time,
 				'hook'  => $hook,
@@ -135,16 +136,16 @@ class procedural_api_Test extends ActionScheduler_UnitTestCase {
 		$next = as_next_scheduled_action( $hook, $args, $group );
 		$this->assertEquals( $action_scheduled_time, $next );
 
-		$store = ActionScheduler::store();
+		$store              = ActionScheduler::store();
 		$unscheduled_action = $store->fetch_action( $action_id_unscheduled );
 
-		// Make sure the next scheduled action is unscheduled
+		// Make sure the next scheduled action is unscheduled.
 		$this->assertEquals( $hook, $unscheduled_action->get_hook() );
-		$this->assertEquals( as_get_datetime_object($time), $unscheduled_action->get_schedule()->get_date() );
+		$this->assertEquals( as_get_datetime_object( $time ), $unscheduled_action->get_schedule()->get_date() );
 		$this->assertEquals( ActionScheduler_Store::STATUS_CANCELED, $store->get_status( $action_id_unscheduled ) );
 		$this->assertNull( $unscheduled_action->get_schedule()->get_next( as_get_datetime_object() ) );
 
-		// Make sure other scheduled actions are not unscheduled
+		// Make sure other scheduled actions are not unscheduled.
 		$this->assertEquals( ActionScheduler_Store::STATUS_PENDING, $store->get_status( $action_id_scheduled ) );
 		$scheduled_action = $store->fetch_action( $action_id_scheduled );
 
@@ -167,7 +168,7 @@ class procedural_api_Test extends ActionScheduler_UnitTestCase {
 		as_unschedule_all_actions( $hook, $args, $group );
 
 		$next = as_next_scheduled_action( $hook );
-		$this->assertFalse($next);
+		$this->assertFalse( $next );
 
 		$after = as_get_datetime_object( $time );
 		$after->modify( '+1 minute' );
@@ -175,7 +176,7 @@ class procedural_api_Test extends ActionScheduler_UnitTestCase {
 		$store = ActionScheduler::store();
 
 		foreach ( $action_ids as $action_id ) {
-			$action = $store->fetch_action($action_id);
+			$action = $store->fetch_action( $action_id );
 
 			$this->assertEquals( $hook, $action->get_hook() );
 			$this->assertEquals( as_get_datetime_object( $time ), $action->get_schedule()->get_date() );
@@ -186,37 +187,37 @@ class procedural_api_Test extends ActionScheduler_UnitTestCase {
 
 	public function test_as_get_datetime_object_default() {
 
-		$utc_now = new ActionScheduler_DateTime(null, new DateTimeZone('UTC'));
+		$utc_now = new ActionScheduler_DateTime( null, new DateTimeZone( 'UTC' ) );
 		$as_now  = as_get_datetime_object();
 
-		// Don't want to use 'U' as timestamps will always be in UTC
-		$this->assertEquals($utc_now->format('Y-m-d H:i:s'),$as_now->format('Y-m-d H:i:s'));
+		// Don't want to use 'U' as timestamps will always be in UTC.
+		$this->assertEquals( $utc_now->format( 'Y-m-d H:i:s' ), $as_now->format( 'Y-m-d H:i:s' ) );
 	}
 
 	public function test_as_get_datetime_object_relative() {
 
-		$utc_tomorrow = new ActionScheduler_DateTime('tomorrow', new DateTimeZone('UTC'));
-		$as_tomorrow  = as_get_datetime_object('tomorrow');
+		$utc_tomorrow = new ActionScheduler_DateTime( 'tomorrow', new DateTimeZone( 'UTC' ) );
+		$as_tomorrow  = as_get_datetime_object( 'tomorrow' );
 
-		$this->assertEquals($utc_tomorrow->format('Y-m-d H:i:s'),$as_tomorrow->format('Y-m-d H:i:s'));
+		$this->assertEquals( $utc_tomorrow->format( 'Y-m-d H:i:s' ), $as_tomorrow->format( 'Y-m-d H:i:s' ) );
 
-		$utc_tomorrow = new ActionScheduler_DateTime('yesterday', new DateTimeZone('UTC'));
-		$as_tomorrow  = as_get_datetime_object('yesterday');
+		$utc_tomorrow = new ActionScheduler_DateTime( 'yesterday', new DateTimeZone( 'UTC' ) );
+		$as_tomorrow  = as_get_datetime_object( 'yesterday' );
 
-		$this->assertEquals($utc_tomorrow->format('Y-m-d H:i:s'),$as_tomorrow->format('Y-m-d H:i:s'));
+		$this->assertEquals( $utc_tomorrow->format( 'Y-m-d H:i:s' ), $as_tomorrow->format( 'Y-m-d H:i:s' ) );
 	}
 
 	public function test_as_get_datetime_object_fixed() {
 
-		$utc_tomorrow = new ActionScheduler_DateTime('29 February 2016', new DateTimeZone('UTC'));
-		$as_tomorrow  = as_get_datetime_object('29 February 2016');
+		$utc_tomorrow = new ActionScheduler_DateTime( '29 February 2016', new DateTimeZone( 'UTC' ) );
+		$as_tomorrow  = as_get_datetime_object( '29 February 2016' );
 
-		$this->assertEquals($utc_tomorrow->format('Y-m-d H:i:s'),$as_tomorrow->format('Y-m-d H:i:s'));
+		$this->assertEquals( $utc_tomorrow->format( 'Y-m-d H:i:s' ), $as_tomorrow->format( 'Y-m-d H:i:s' ) );
 
-		$utc_tomorrow = new ActionScheduler_DateTime('1st January 2024', new DateTimeZone('UTC'));
-		$as_tomorrow  = as_get_datetime_object('1st January 2024');
+		$utc_tomorrow = new ActionScheduler_DateTime( '1st January 2024', new DateTimeZone( 'UTC' ) );
+		$as_tomorrow  = as_get_datetime_object( '1st January 2024' );
 
-		$this->assertEquals($utc_tomorrow->format('Y-m-d H:i:s'),$as_tomorrow->format('Y-m-d H:i:s'));
+		$this->assertEquals( $utc_tomorrow->format( 'Y-m-d H:i:s' ), $as_tomorrow->format( 'Y-m-d H:i:s' ) );
 	}
 
 	public function test_as_get_datetime_object_timezone() {
@@ -224,26 +225,27 @@ class procedural_api_Test extends ActionScheduler_UnitTestCase {
 		$timezone_au      = 'Australia/Brisbane';
 		$timezone_default = date_default_timezone_get();
 
+		// phpcs:ignore
 		date_default_timezone_set( $timezone_au );
 
-		$au_now = new ActionScheduler_DateTime(null);
+		$au_now = new ActionScheduler_DateTime( null );
 		$as_now = as_get_datetime_object();
 
-		// Make sure they're for the same time
-		$this->assertEquals($au_now->getTimestamp(),$as_now->getTimestamp());
+		// Make sure they're for the same time.
+		$this->assertEquals( $au_now->getTimestamp(), $as_now->getTimestamp() );
 
-		// But not in the same timezone, as $as_now should be using UTC
-		$this->assertNotEquals($au_now->format('Y-m-d H:i:s'),$as_now->format('Y-m-d H:i:s'));
+		// But not in the same timezone, as $as_now should be using UTC.
+		$this->assertNotEquals( $au_now->format( 'Y-m-d H:i:s' ), $as_now->format( 'Y-m-d H:i:s' ) );
 
-		$au_now    = new ActionScheduler_DateTime(null);
+		$au_now    = new ActionScheduler_DateTime( null );
 		$as_au_now = as_get_datetime_object();
 
 		$this->assertEquals( $au_now->getTimestamp(), $as_now->getTimestamp(), '', 2 );
 
-		// But not in the same timezone, as $as_now should be using UTC
-		$this->assertNotEquals($au_now->format('Y-m-d H:i:s'),$as_now->format('Y-m-d H:i:s'));
+		// But not in the same timezone, as $as_now should be using UTC.
+		$this->assertNotEquals( $au_now->format( 'Y-m-d H:i:s' ), $as_now->format( 'Y-m-d H:i:s' ) );
 
-		// Just in cases
+		// phpcs:ignore
 		date_default_timezone_set( $timezone_default );
 	}
 
@@ -252,29 +254,29 @@ class procedural_api_Test extends ActionScheduler_UnitTestCase {
 		$now = as_get_datetime_object();
 		$this->assertInstanceOf( 'ActionScheduler_DateTime', $now );
 
-		$dateTime   = new DateTime( 'now', new DateTimeZone( 'UTC' ) );
-		$asDateTime = as_get_datetime_object( $dateTime );
-		$this->assertEquals( $dateTime->format( $f ), $asDateTime->format( $f ) );
+		$datetime   = new DateTime( 'now', new DateTimeZone( 'UTC' ) );
+		$as_datetime = as_get_datetime_object( $datetime );
+		$this->assertEquals( $datetime->format( $f ), $as_datetime->format( $f ) );
 	}
 
 	public function test_as_has_scheduled_action() {
 		$store = ActionScheduler::store();
 
-		$time = as_get_datetime_object( 'tomorrow' );
+		$time      = as_get_datetime_object( 'tomorrow' );
 		$action_id = as_schedule_single_action( $time->getTimestamp(), 'hook_1' );
 
 		$this->assertTrue( as_has_scheduled_action( 'hook_1' ) );
 		$this->assertFalse( as_has_scheduled_action( 'hook_2' ) );
 
-		// Go to in-progress
+		// Go to in-progress.
 		$store->log_execution( $action_id );
 		$this->assertTrue( as_has_scheduled_action( 'hook_1' ) );
 
-		// Go to complete
+		// Go to complete.
 		$store->mark_complete( $action_id );
 		$this->assertFalse( as_has_scheduled_action( 'hook_1' ) );
 
-		// Go to failed
+		// Go to failed.
 		$store->mark_failure( $action_id );
 		$this->assertFalse( as_has_scheduled_action( 'hook_1' ) );
 	}
@@ -285,7 +287,7 @@ class procedural_api_Test extends ActionScheduler_UnitTestCase {
 		$this->assertTrue( as_has_scheduled_action( 'hook_1' ) );
 		$this->assertFalse( as_has_scheduled_action( 'hook_1', array( 'b' ) ) );
 
-		// Test for any args
+		// Test for any args.
 		$this->assertTrue( as_has_scheduled_action( 'hook_1', array( 'a' ) ) );
 	}
 
@@ -294,5 +296,80 @@ class procedural_api_Test extends ActionScheduler_UnitTestCase {
 
 		$this->assertTrue( as_has_scheduled_action( 'hook_1', null, 'group_1' ) );
 		$this->assertTrue( as_has_scheduled_action( 'hook_1', array(), 'group_1' ) );
+	}
+	// phpcs:enable
+
+	/**
+	 * Test as_enqueue_async_action with unique param.
+	 */
+	public function test_as_enqueue_async_action_unique() {
+		$this->set_action_scheduler_store( new ActionScheduler_DBStore() );
+
+		$action_id = as_enqueue_async_action( 'hook_1', array( 'a' ), 'dummy', true );
+		$this->assertValidAction( $action_id );
+
+		$action_id_duplicate = as_enqueue_async_action( 'hook_1', array( 'a' ), 'dummy', true );
+		$this->assertEquals( 0, $action_id_duplicate );
+	}
+
+	/**
+	 * Test as_schedule_single_action with unique param.
+	 */
+	public function test_as_schedule_single_action_unique() {
+		$this->set_action_scheduler_store( new ActionScheduler_DBStore() );
+
+		$action_id = as_schedule_single_action( time(), 'hook_1', array( 'a' ), 'dummy', true );
+		$this->assertValidAction( $action_id );
+
+		$action_id_duplicate = as_schedule_single_action( time(), 'hook_1', array( 'a' ), 'dummy', true );
+		$this->assertEquals( 0, $action_id_duplicate );
+	}
+
+	/**
+	 * Test as_schedule_recurring_action with unique param.
+	 */
+	public function test_as_schedule_recurring_action_unique() {
+		$this->set_action_scheduler_store( new ActionScheduler_DBStore() );
+
+		$action_id = as_schedule_recurring_action( time(), MINUTE_IN_SECONDS, 'hook_1', array( 'a' ), 'dummy', true );
+		$this->assertValidAction( $action_id );
+
+		$action_id_duplicate = as_schedule_recurring_action( time(), MINUTE_IN_SECONDS, 'hook_1', array( 'a' ), 'dummy', true );
+		$this->assertEquals( 0, $action_id_duplicate );
+	}
+
+	/**
+	 * Test as_schedule_cron with unique param.
+	 */
+	public function test_as_schedule_cron_action() {
+		$this->set_action_scheduler_store( new ActionScheduler_DBStore() );
+
+		$action_id = as_schedule_cron_action( time(), '0 0 * * *', 'hook_1', array( 'a' ), 'dummy', true );
+		$this->assertValidAction( $action_id );
+
+		$action_id_duplicate = as_schedule_cron_action( time(), '0 0 * * *', 'hook_1', array( 'a' ), 'dummy', true );
+		$this->assertEquals( 0, $action_id_duplicate );
+	}
+
+	/**
+	 * Helper method to set actions scheduler store.
+	 *
+	 * @param ActionScheduler_Store $store Store instance to set.
+	 */
+	private function set_action_scheduler_store( $store ) {
+		$store_factory_setter = function() use ( $store ) {
+			self::$store = $store;
+		};
+		Closure::bind( $store_factory_setter, null, ActionScheduler_Store::class )();
+	}
+
+	/**
+	 * Helper method to assert valid action.
+	 *
+	 * @param int $action_id Action ID to assert.
+	 */
+	private function assertValidAction( $action_id ) {
+		$action = ActionScheduler::store()->fetch_action( $action_id );
+		$this->assertInstanceOf( 'ActionScheduler_Action', $action );
 	}
 }

--- a/tests/phpunit/procedural_api/procedural_api_Test.php
+++ b/tests/phpunit/procedural_api/procedural_api_Test.php
@@ -370,6 +370,7 @@ class Procedural_API_Test extends ActionScheduler_UnitTestCase {
 	 * @param int $action_id Action ID to assert.
 	 */
 	private function assertValidAction( $action_id ) {
+		$this->assertNotEquals( 0, $action_id );
 		$action = ActionScheduler::store()->fetch_action( $action_id );
 		$this->assertInstanceOf( 'ActionScheduler_Action', $action );
 	}

--- a/tests/phpunit/procedural_api/procedural_api_Test.php
+++ b/tests/phpunit/procedural_api/procedural_api_Test.php
@@ -360,7 +360,8 @@ class Procedural_API_Test extends ActionScheduler_UnitTestCase {
 		$store_factory_setter = function() use ( $store ) {
 			self::$store = $store;
 		};
-		Closure::bind( $store_factory_setter, null, ActionScheduler_Store::class )();
+		$binded_store_factory_setter = Closure::bind( $store_factory_setter, null, ActionScheduler_Store::class );
+		$binded_store_factory_setter();
 	}
 
 	/**


### PR DESCRIPTION
As outlined in #828, we want to add support for scheduling unique actions in the action scheduler. This PR implements the second approach by adding another param in scheduling functions that specify whether the actions should be unique or not. 
For backward compatibility, the default value of that param is `false`.

Fixes #828.

### Changelog

> Enhancement - Added the ability to schedule unique actions via an atomic operation.