### PR TITLE
Allow dealerdirect/phpcodesniffer-composer-installer plugin.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,9 @@
     "yoast/phpunit-polyfills": "^1.0"
   },
   "config": {
+    "allow-plugins": {
+      "dealerdirect/phpcodesniffer-composer-installer": true
+    },
     "platform": {
       "php": "7.3"
     }


### PR DESCRIPTION
Tests recently stopped working in CI (possibly because we are now using Composer 2.2 within GH Actions, and that is [a little stricter/adds extra safety](https://getcomposer.org/doc/06-config.md#allow-plugins) relating to the use of Composer plugins). 

The problem is that a Composer plugin needed by an indirect dependency does not have permission to run. Specifically, we need to allow the use of `dealerdirect/phpcodesniffer-composer-installer`, which is an [indirect dependency](https://github.com/woocommerce/action-scheduler/blob/3.4.2/composer.json#L13) (via [`woocomerce/woocommerce-sniffs`](https://github.com/woocommerce/woocommerce-sniffs/blob/0.1.0/composer.json#L21)).

*([Example here](https://github.com/woocommerce/action-scheduler/actions/runs/2617837812) of CI failing to run because of this problem.)*