### PR TITLE
Maintenance on A/S docs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -194,7 +194,7 @@ as_next_scheduled_action( $hook, $args, $group );
 
 ### Return value
 
-`(integer|boolean)` The timestamp for the next occurrence, or false if nothing was found.
+`(integer|boolean)` The timestamp for the next occurrence of a pending scheduled action, true for an async or in-progress action or false if there is no matching action.
 
 
 ## Function Reference / `as_has_scheduled_action()`

--- a/docs/api.md
+++ b/docs/api.md
@@ -46,7 +46,7 @@ as_enqueue_async_action( $hook, $args, $group );
 
 ### Return value
 
-(integer) the action's ID.
+`(integer)` the action's ID.
 
 
 ## Function Reference / `as_schedule_single_action()`
@@ -70,7 +70,7 @@ as_schedule_single_action( $timestamp, $hook, $args, $group );
 
 ### Return value
 
-(integer) the action's ID.
+`(integer)` the action's ID.
 
 
 ## Function Reference / `as_schedule_recurring_action()`
@@ -95,7 +95,7 @@ as_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, $args, $g
 
 ### Return value
 
-(integer) the action's ID.
+`(integer)` the action's ID.
 
 
 ## Function Reference / `as_schedule_cron_action()`
@@ -122,7 +122,7 @@ as_schedule_cron_action( $timestamp, $schedule, $hook, $args, $group );
 
 ### Return value
 
-(integer) the action's ID.
+`(integer)` the action's ID.
 
 
 ## Function Reference / `as_unschedule_action()`
@@ -145,7 +145,7 @@ as_unschedule_action( $hook, $args, $group );
 
 ### Return value
 
-(null)
+`(null)`
 
 ## Function Reference / `as_unschedule_all_actions()`
 
@@ -167,7 +167,7 @@ as_unschedule_all_actions( $hook, $args, $group )
 
 ### Return value
 
-(string|null) The scheduled action ID if a scheduled action was found, or null if no matching action found.
+`(string|null)` The scheduled action ID if a scheduled action was found, or null if no matching action found.
 
 
 ## Function Reference / `as_next_scheduled_action()`
@@ -190,7 +190,7 @@ as_next_scheduled_action( $hook, $args, $group );
 
 ### Return value
 
-(integer|boolean) The timestamp for the next occurrence, or false if nothing was found.
+`(integer|boolean)` The timestamp for the next occurrence, or false if nothing was found.
 
 
 ## Function Reference / `as_has_scheduled_action()`
@@ -213,7 +213,7 @@ as_has_scheduled_action( $hook, $args, $group );
 
 ### Return value
 
-(boolean) True if a matching action is pending or in-progress, false otherwise.
+`(boolean)` True if a matching action is pending or in-progress, false otherwise.
 
 
 ## Function Reference / `as_get_scheduled_actions()`
@@ -248,4 +248,4 @@ as_get_scheduled_actions( $args, $return_format );
 
 ### Return value
 
-(array) Array of action rows matching the criteria specified with `$args`.
+`(array)` Array of action rows matching the criteria specified with `$args`.

--- a/docs/api.md
+++ b/docs/api.md
@@ -43,6 +43,7 @@ as_enqueue_async_action( $hook, $args, $group );
 - **$hook** (string)(required) Name of the action hook.
 - **$args** (array) Arguments to pass to callbacks when the hook triggers. Default: _`array()`_.
 - **$group** (string) The group to assign this job to. Default: _''_.
+- **$unique** (boolean) Whether the action should be unique. Default: _`false`_.
 
 ### Return value
 
@@ -67,6 +68,7 @@ as_schedule_single_action( $timestamp, $hook, $args, $group );
 - **$hook** (string)(required) Name of the action hook.
 - **$args** (array) Arguments to pass to callbacks when the hook triggers. Default: _`array()`_.
 - **$group** (string) The group to assign this job to. Default: _''_.
+- **$unique** (boolean) Whether the action should be unique. Default: _`false`_.
 
 ### Return value
 
@@ -92,6 +94,7 @@ as_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, $args, $g
 - **$hook** (string)(required) Name of the action hook.
 - **$args** (array) Arguments to pass to callbacks when the hook triggers. Default: _`array()`_.
 - **$group** (string) The group to assign this job to. Default: _''_.
+- **$unique** (boolean) Whether the action should be unique. Default: _`false`_.
 
 ### Return value
 
@@ -119,6 +122,7 @@ as_schedule_cron_action( $timestamp, $schedule, $hook, $args, $group );
 - **$hook** (string)(required) Name of the action hook.
 - **$args** (array) Arguments to pass to callbacks when the hook triggers. Default: _`array()`_.
 - **$group** (string) The group to assign this job to. Default: _''_.
+- **$unique** (boolean) Whether the action should be unique. Default: _`false`_.
 
 ### Return value
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -109,7 +109,7 @@ require_once( plugin_dir_path( __FILE__ ) . '/libraries/action-scheduler/action-
  */
 function eg_schedule_midnight_log() {
 	if ( false === as_has_scheduled_action( 'eg_midnight_log' ) ) {
-		as_schedule_recurring_action( strtotime( 'tomorrow' ), DAY_IN_SECONDS, 'eg_midnight_log' );
+		as_schedule_recurring_action( strtotime( 'tomorrow' ), DAY_IN_SECONDS, 'eg_midnight_log', array(), '', true );
 	}
 }
 add_action( 'init', 'eg_schedule_midnight_log' );


### PR DESCRIPTION
Updates the library docs. Partly triggered by [this observation](https://github.com/woocommerce/action-scheduler/issues/848#issuecomment-1238987973), though I then noticed a few things needing adjustment.

### What I changed and why

- **as_next_scheduled_action() return type** → As highlighted in the issue linked above, the description missed a key detail about in-progress and async actions. I have updated it to match the text in the source docblock.
- **All return types** → These have been wrapped in backticks, so they render as inline code. That's because, without backticks, any union types written as `(integer|boolean)` are rendered by Jekyll as simple tables...which looks a little broken.
- **Added optional unique param** → An optional `$unique` param is available for various functions but we forgot to update these docs.
- **Improved usage example** → I updated a code snippet to take advantage of the `$unique` param, but in a backwards compatible way.