### PR TITLE
References to `master` should be updated to `trunk`.

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -22,7 +22,7 @@ Or trigger the `'action_scheduler_run_queue'` hook and let Action Scheduler do i
 do_action( 'action_scheduler_run_queue', $context_identifier );
 ```
 
-Further customization can be done by extending the `ActionScheduler_Abstract_QueueRunner` class to create a custom Queue Runner. For an example of a customized queue runner, see the [`ActionScheduler_WPCLI_QueueRunner`](https://github.com/woocommerce/action-scheduler/blob/master/classes/WP_CLI/ActionScheduler_WPCLI_QueueRunner.php), which is used when running WP CLI.
+Further customization can be done by extending the `ActionScheduler_Abstract_QueueRunner` class to create a custom Queue Runner. For an example of a customized queue runner, see the [`ActionScheduler_WPCLI_QueueRunner`](https://github.com/woocommerce/action-scheduler/blob/trunk/classes/WP_CLI/ActionScheduler_WPCLI_QueueRunner.php), which is used when running WP CLI.
 
 Want to create some other method for initiating Action Scheduler? [Open a new issue](https://github.com/woocommerce/action-scheduler/issues/new), we'd love to help you with it.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -53,20 +53,20 @@ Adding the subtree as a remote allows us to refer to it in short from via the na
 #### Step 2. Add the Repo as a Subtree
 
 ```
-git subtree add --prefix libraries/action-scheduler subtree-action-scheduler master --squash
+git subtree add --prefix libraries/action-scheduler subtree-action-scheduler trunk --squash
 ```
 
-This will add the `master` branch of Action Scheduler to your repository in the folder `libraries/action-scheduler`.
+This will add the `trunk` branch of Action Scheduler to your repository in the folder `libraries/action-scheduler`.
 
-You can change the `--prefix` to change where the code is included. Or change the `master` branch to a tag, like `2.1.0` to include only a stable version.
+You can change the `--prefix` to change where the code is included. Or change the `trunk` branch to a tag, like `2.1.0` to include only a stable version.
 
 #### Step 3. Update the Subtree
 
 To update Action Scheduler to a new version, use the commands:
 
 ```
-git fetch subtree-action-scheduler master
-git subtree pull --prefix libraries/action-scheduler subtree-action-scheduler master --squash
+git fetch subtree-action-scheduler trunk
+git subtree pull --prefix libraries/action-scheduler subtree-action-scheduler trunk --squash
 ```
 
 ### Loading Action Scheduler


### PR DESCRIPTION
We no longer use a `master` branch: this change updates some references in our docs to point to `trunk`, instead.

Closes #854.