### PR TITLE
feat(disable): constant to disable it

### DIFF
--- a/classes/ActionScheduler_AsyncRequest_QueueRunner.php
+++ b/classes/ActionScheduler_AsyncRequest_QueueRunner.php
@@ -49,7 +49,7 @@ class ActionScheduler_AsyncRequest_QueueRunner extends WP_Async_Request {
 	 * if there are still pending actions after completing a queue in this request.
 	 */
 	protected function handle() {
-		if ( !defined( 'AS_DISABLE_QUEUE_RUNNERS' ) || !AS_DISABLE_QUEUE_RUNNERS ) {
+		if ( ! defined( 'AS_DISABLE_QUEUE_RUNNERS' ) || ! AS_DISABLE_QUEUE_RUNNERS ) {
 			do_action( 'action_scheduler_run_queue', 'Async Request' ); // run a queue in the same way as WP Cron, but declare the Async Request context
 		}
 

--- a/classes/ActionScheduler_AsyncRequest_QueueRunner.php
+++ b/classes/ActionScheduler_AsyncRequest_QueueRunner.php
@@ -49,7 +49,9 @@ class ActionScheduler_AsyncRequest_QueueRunner extends WP_Async_Request {
 	 * if there are still pending actions after completing a queue in this request.
 	 */
 	protected function handle() {
-		do_action( 'action_scheduler_run_queue', 'Async Request' ); // run a queue in the same way as WP Cron, but declare the Async Request context
+		if ( !defined( 'AS_DISABLE_QUEUE_RUNNERS' ) || !AS_DISABLE_QUEUE_RUNNERS ) {
+			do_action( 'action_scheduler_run_queue', 'Async Request' ); // run a queue in the same way as WP Cron, but declare the Async Request context
+		}
 
 		$sleep_seconds = $this->get_sleep_seconds();
 
@@ -79,7 +81,7 @@ class ActionScheduler_AsyncRequest_QueueRunner extends WP_Async_Request {
 	 */
 	protected function allow() {
 
-		if ( ! has_action( 'action_scheduler_run_queue' ) || ActionScheduler::runner()->has_maximum_concurrent_batches() || ! $this->store->has_pending_actions_due() ) {
+		if ( defined( 'AS_DISABLE_QUEUE_RUNNERS' ) && AS_DISABLE_QUEUE_RUNNERS || ! has_action( 'action_scheduler_run_queue' ) || ActionScheduler::runner()->has_maximum_concurrent_batches() || ! $this->store->has_pending_actions_due() ) {
 			$allow = false;
 		} else {
 			$allow = true;

--- a/classes/ActionScheduler_QueueRunner.php
+++ b/classes/ActionScheduler_QueueRunner.php
@@ -47,6 +47,9 @@ class ActionScheduler_QueueRunner extends ActionScheduler_Abstract_QueueRunner {
 	 * @codeCoverageIgnore
 	 */
 	public function init() {
+		if ( defined( 'AS_DISABLE_QUEUE_RUNNERS' ) && AS_DISABLE_QUEUE_RUNNERS ) {
+			return;
+		}
 
 		add_filter( 'cron_schedules', array( self::instance(), 'add_wp_cron_schedule' ) );
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -6,6 +6,14 @@ Action Scheduler is designed to be used and released in plugins. It avoids redec
 
 To use it in your plugin (or theme), simply require the `action-scheduler/action-scheduler.php` file. Action Scheduler will take care of the rest. __Note:__ Action Scheduler is only loaded from a theme if it is not included in any active plugins.
 
+### How to disable Action Scheduler?
+
+Disabled it is helpful for automated testing and it is enough to add a constant in your `wp-config.php` as:
+
+```
+define( 'AS_DISABLE_QUEUE_RUNNERS', true );
+```
+
 ### I don't want to use WP-Cron. Does Action Scheduler depend on WP-Cron?
 
 By default, Action Scheduler is initiated by WP-Cron (and the `'shutdown'` hook on admin requests). However, it has no dependency on the WP-Cron system. You can initiate the Action Scheduler queue in other ways with just one or two lines of code.


### PR DESCRIPTION
Ref: https://github.com/woocommerce/action-scheduler/issues/857

I am not sure if it is enough to not initialize the class (check for tables etc) but for sure disable the cron and the queue.