### PR TITLE
Fix past-due with Async actions

### DIFF
--- a/classes/ActionScheduler_ListTable.php
+++ b/classes/ActionScheduler_ListTable.php
@@ -2,6 +2,7 @@
 
 /**
  * Implements the admin view of the actions.
+ *
  * @codeCoverageIgnore
  */
 class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
@@ -50,8 +51,7 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 
 	/**
 	 * Bulk actions. The key of the array is the method name of the implementation:
-	 *
-	 *     bulk_<key>(array $ids, string $sql_in).
+	 * bulk_<key>(array $ids, string $sql_in).
 	 *
 	 * See the comments in the parent class for further details
 	 *
@@ -76,9 +76,9 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 	/**
 	 * Sets the current data store object into `store->action` and initialises the object.
 	 *
-	 * @param ActionScheduler_Store $store
-	 * @param ActionScheduler_Logger $logger
-	 * @param ActionScheduler_QueueRunner $runner
+	 * @param ActionScheduler_Store       $store Store object.
+	 * @param ActionScheduler_Logger      $logger Logger object.
+	 * @param ActionScheduler_QueueRunner $runner QueueRunner object.
 	 */
 	public function __construct( ActionScheduler_Store $store, ActionScheduler_Logger $logger, ActionScheduler_QueueRunner $runner ) {
 
@@ -226,7 +226,9 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 
 		$output = '';
 
-		for ( $time_period_index = 0, $periods_included = 0, $seconds_remaining = $interval; $time_period_index < count( self::$time_periods ) && $seconds_remaining > 0 && $periods_included < $periods_to_include; $time_period_index++ ) {
+		$time_periods_count = count( self::$time_periods );
+
+		for ( $time_period_index = 0, $periods_included = 0, $seconds_remaining = $interval; $time_period_index < $time_periods_count && $seconds_remaining > 0 && $periods_included < $periods_to_include; $time_period_index++ ) {
 
 			$periods_in_interval = floor( $seconds_remaining / self::$time_periods[ $time_period_index ]['seconds'] );
 
@@ -234,7 +236,15 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 				if ( ! empty( $output ) ) {
 					$output .= ' ';
 				}
-				$output .= sprintf( _n( self::$time_periods[ $time_period_index ]['names'][0], self::$time_periods[ $time_period_index ]['names'][1], $periods_in_interval, 'action-scheduler' ), $periods_in_interval );
+				$output .= sprintf(
+					_n(
+						self::$time_periods[ $time_period_index ]['names'][0], // phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralSingle
+						self::$time_periods[ $time_period_index ]['names'][1], // phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralPlural
+						$periods_in_interval,
+						'action-scheduler'
+					),
+					$periods_in_interval
+				);
 				$seconds_remaining -= $periods_in_interval * self::$time_periods[ $time_period_index ]['seconds'];
 				$periods_included++;
 			}
@@ -246,7 +256,7 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 	/**
 	 * Returns the recurrence of an action or 'Non-repeating'. The output is human readable.
 	 *
-	 * @param ActionScheduler_Action $action
+	 * @param ActionScheduler_Action $action Action to work with.
 	 *
 	 * @return string
 	 */
@@ -269,7 +279,7 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 	/**
 	 * Serializes the argument of an action to render it in a human friendly format.
 	 *
-	 * @param array $row The array representation of the current row of the table
+	 * @param array $row The array representation of the current row of the table.
 	 *
 	 * @return string
 	 */
@@ -311,8 +321,9 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 	/**
 	 * Prints the logs entries inline. We do so to avoid loading Javascript and other hacks to show it in a modal.
 	 *
-	 * @param ActionScheduler_LogEntry $log_entry
-	 * @param DateTimezone $timezone
+	 * @param ActionScheduler_LogEntry $log_entry Log Entry object.
+	 * @param DateTimezone             $timezone Timezone.
+	 *
 	 * @return string
 	 */
 	protected function get_log_entry_html( ActionScheduler_LogEntry $log_entry, DateTimezone $timezone ) {
@@ -324,13 +335,13 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 	/**
 	 * Only display row actions for pending actions.
 	 *
-	 * @param array  $row         Row to render
-	 * @param string $column_name Current row
+	 * @param array  $row         Row to render.
+	 * @param string $column_name Current row.
 	 *
 	 * @return string
 	 */
 	protected function maybe_render_actions( $row, $column_name ) {
-		if ( 'pending' === strtolower( $row[ 'status_name' ] ) ) {
+		if ( 'pending' === strtolower( $row['status_name'] ) ) {
 			return parent::maybe_render_actions( $row, $column_name );
 		}
 
@@ -361,7 +372,7 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 				if ( ! in_array( $wpdb->prefix . $table_name, $found_tables ) ) {
 					$this->admin_notices[] = array(
 						'class'   => 'error',
-						'message' => __( 'It appears one or more database tables were missing. Attempting to re-create the missing table(s).' , 'action-scheduler' ),
+						'message' => __( 'It appears one or more database tables were missing. Attempting to re-create the missing table(s).', 'action-scheduler' ),
 					);
 					$this->recreate_tables();
 					parent::display_admin_notices();
@@ -390,7 +401,7 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 
 			$async_request_lock_expiration = ActionScheduler::lock()->get_expiration( 'async-request-runner' );
 
-			// No lock set or lock expired
+			// No lock set or lock expired.
 			if ( false === $async_request_lock_expiration || $async_request_lock_expiration < time() ) {
 				$in_progress_url       = add_query_arg( 'status', 'in-progress', remove_query_arg( 'status' ) );
 				/* translators: %s: process URL */
@@ -416,15 +427,15 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 			if ( 1 == $notification['success'] ) {
 				$class = 'updated';
 				switch ( $notification['row_action_type'] ) {
-					case 'run' :
+					case 'run':
 						/* translators: %s: action HTML */
 						$action_message_html = sprintf( __( 'Successfully executed action: %s', 'action-scheduler' ), $action_hook_html );
 						break;
-					case 'cancel' :
+					case 'cancel':
 						/* translators: %s: action HTML */
 						$action_message_html = sprintf( __( 'Successfully canceled action: %s', 'action-scheduler' ), $action_hook_html );
 						break;
-					default :
+					default:
 						/* translators: %s: action HTML */
 						$action_message_html = sprintf( __( 'Successfully processed change for action: %s', 'action-scheduler' ), $action_hook_html );
 						break;
@@ -449,7 +460,7 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 	/**
 	 * Prints the scheduled date in a human friendly format.
 	 *
-	 * @param array $row The array representation of the current row of the table
+	 * @param array $row The array representation of the current row of the table.
 	 *
 	 * @return string
 	 */
@@ -460,7 +471,8 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 	/**
 	 * Get the scheduled date in a human friendly format.
 	 *
-	 * @param ActionScheduler_Schedule $schedule
+	 * @param ActionScheduler_Schedule $schedule Schedule object.
+	 *
 	 * @return string
 	 */
 	protected function get_schedule_display_string( ActionScheduler_Schedule $schedule ) {
@@ -497,8 +509,8 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 	 * Deletes actions based on their ID. This is the handler for the bulk delete. It assumes the data
 	 * properly validated by the callee and it will delete the actions without any extra validation.
 	 *
-	 * @param array $ids
-	 * @param string $ids_sql Inherited and unused
+	 * @param array  $ids Array of action IDs.
+	 * @param string $ids_sql Inherited and unused.
 	 */
 	protected function bulk_delete( array $ids, $ids_sql ) {
 		foreach ( $ids as $id ) {
@@ -510,7 +522,7 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 	 * Implements the logic behind running an action. ActionScheduler_Abstract_ListTable validates the request and their
 	 * parameters are valid.
 	 *
-	 * @param int $action_id
+	 * @param int $action_id Action ID.
 	 */
 	protected function row_action_cancel( $action_id ) {
 		$this->process_row_action( $action_id, 'cancel' );
@@ -520,7 +532,7 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 	 * Implements the logic behind running an action. ActionScheduler_Abstract_ListTable validates the request and their
 	 * parameters are valid.
 	 *
-	 * @param int $action_id
+	 * @param int $action_id Action ID.
 	 */
 	protected function row_action_run( $action_id ) {
 		$this->process_row_action( $action_id, 'run' );
@@ -547,16 +559,16 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 	/**
 	 * Implements the logic behind processing an action once an action link is clicked on the list table.
 	 *
-	 * @param int $action_id
+	 * @param int    $action_id Action ID.
 	 * @param string $row_action_type The type of action to perform on the action.
 	 */
 	protected function process_row_action( $action_id, $row_action_type ) {
 		try {
 			switch ( $row_action_type ) {
-				case 'run' :
+				case 'run':
 					$this->runner->process_action( $action_id, 'Admin List Table' );
 					break;
-				case 'cancel' :
+				case 'cancel':
 					$this->store->cancel_action( $action_id );
 					break;
 			}
@@ -593,8 +605,9 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 		 * This is needed because registering 'past-due' as a status is overkill.
 		 */
 		if ( 'past-due' === $this->get_request_status() ) {
-			$query['status'] = ActionScheduler_Store::STATUS_PENDING;
-			$query['date']   = as_get_datetime_object();
+			$query['status']                = ActionScheduler_Store::STATUS_PENDING;
+			$query['date']                  = as_get_datetime_object();
+			$query['include_async_actions'] = false;
 		}
 
 		$this->items = array();
@@ -626,11 +639,13 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 			);
 		}
 
-		$this->set_pagination_args( array(
-			'total_items' => $total_items,
-			'per_page'    => $per_page,
-			'total_pages' => ceil( $total_items / $per_page ),
-		) );
+		$this->set_pagination_args(
+			array(
+				'total_items' => $total_items,
+				'per_page'    => $per_page,
+				'total_pages' => ceil( $total_items / $per_page ),
+			)
+		);
 	}
 
 	/**

--- a/classes/abstracts/ActionScheduler_Store.php
+++ b/classes/abstracts/ActionScheduler_Store.php
@@ -2,6 +2,7 @@
 
 /**
  * Class ActionScheduler_Store
+ *
  * @codeCoverageIgnore
  */
 abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
@@ -12,24 +13,34 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 	const STATUS_CANCELED = 'canceled';
 	const DEFAULT_CLASS   = 'ActionScheduler_wpPostStore';
 
-	/** @var ActionScheduler_Store */
-	private static $store = NULL;
+	/**
+	 * Current Store single instance.
+	 *
+	 * @var ActionScheduler_Store
+	 */
+	private static $store = null;
 
-	/** @var int */
+	/**
+	 * Maximum length for arguments.
+	 *
+	 * @var int
+	 */
 	protected static $max_args_length = 191;
 
 	/**
-	 * @param ActionScheduler_Action $action
-	 * @param DateTime $scheduled_date Optional Date of the first instance
-	 *        to store. Otherwise uses the first date of the action's
-	 *        schedule.
+	 * Save an action. Can save duplicate action as well, prefer using `save_unique_action` instead.
 	 *
-	 * @return int The action ID
+	 * @param ActionScheduler_Action $action Action object.
+	 * @param DateTime|null          $scheduled_date Optional schedule date. Default null.
+	 *
+	 * @return int Action ID.
 	 */
-	abstract public function save_action( ActionScheduler_Action $action, DateTime $scheduled_date = NULL );
+	abstract public function save_action( ActionScheduler_Action $action, DateTime $scheduled_date = null );
 
 	/**
-	 * @param string $action_id
+	 * Retrieve an action.
+	 *
+	 * @param int $action_id Action ID.
 	 *
 	 * @return ActionScheduler_Action
 	 */
@@ -141,10 +152,14 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 	public function extra_action_counts() {
 		$extra_actions = array();
 
-		$pastdue_action_counts = ( int ) $this->query_actions( array(
-			'status' => self::STATUS_PENDING,
-			'date'   => as_get_datetime_object(),
-		), 'count' );
+		$pastdue_action_counts = (int) $this->query_actions(
+			array(
+				'status'                => self::STATUS_PENDING,
+				'date'                  => as_get_datetime_object(),
+				'include_async_actions' => false,
+			),
+			'count'
+		);
 
 		if ( $pastdue_action_counts ) {
 			$extra_actions['past-due'] = $pastdue_action_counts;
@@ -160,17 +175,23 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 	}
 
 	/**
-	 * @param string $action_id
+	 * Cancel an action.
+	 *
+	 * @param int $action_id Action ID.
 	 */
 	abstract public function cancel_action( $action_id );
 
 	/**
-	 * @param string $action_id
+	 * Delete an action.
+	 *
+	 * @param int $action_id Action ID.
 	 */
 	abstract public function delete_action( $action_id );
 
 	/**
-	 * @param string $action_id
+	 * Get the schedule date for an action.
+	 *
+	 * @param string $action_id Action ID.
 	 *
 	 * @return DateTime The date the action is schedule to run, or the date that it ran.
 	 */
@@ -178,7 +199,9 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 
 
 	/**
-	 * @param int      $max_actions
+	 * Stake a claim on actions.
+	 *
+	 * @param int      $max_actions Maximum number of action to include in claim.
 	 * @param DateTime $before_date Claim only actions schedule before the given date. Defaults to now.
 	 * @param array    $hooks       Claim only actions with a hook or hooks.
 	 * @param string   $group       Claim only actions in the given group.
@@ -188,60 +211,87 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 	abstract public function stake_claim( $max_actions = 10, DateTime $before_date = null, $hooks = array(), $group = '' );
 
 	/**
+	 * Get the number of active claims.
+	 *
 	 * @return int
 	 */
 	abstract public function get_claim_count();
 
 	/**
-	 * @param ActionScheduler_ActionClaim $claim
+	 * Release actions from a claim and delete the claim.
+	 *
+	 * @param ActionScheduler_ActionClaim $claim Claim object.
 	 */
 	abstract public function release_claim( ActionScheduler_ActionClaim $claim );
 
 	/**
-	 * @param string $action_id
+	 * Remove the claim from an action.
+	 *
+	 * @param int $action_id Action ID.
 	 */
 	abstract public function unclaim_action( $action_id );
 
 	/**
-	 * @param string $action_id
+	 * Mark an action as failed.
+	 *
+	 * @param int $action_id Action ID.
 	 */
 	abstract public function mark_failure( $action_id );
 
 	/**
-	 * @param string $action_id
+	 * Add execution message to action log.
+	 *
+	 * @param int $action_id Action ID.
+	 *
+	 * @return void
 	 */
 	abstract public function log_execution( $action_id );
 
 	/**
-	 * @param string $action_id
+	 * Mark an action as complete.
+	 *
+	 * @param int $action_id Action ID.
+	 *
+	 * @return void
 	 */
 	abstract public function mark_complete( $action_id );
 
 	/**
-	 * @param string $action_id
+	 * Get an action's status.
+	 *
+	 * @param int $action_id Action ID.
 	 *
 	 * @return string
 	 */
 	abstract public function get_status( $action_id );
 
 	/**
-	 * @param string $action_id
+	 * Return an action's claim ID.
+	 *
+	 * @param string $action_id Action ID.
+	 *
 	 * @return mixed
 	 */
 	abstract public function get_claim_id( $action_id );
 
 	/**
-	 * @param string $claim_id
+	 * Retrieve the action IDs of action in a claim.
+	 *
+	 * @param  int $claim_id Claim ID.
+	 *
 	 * @return array
 	 */
 	abstract public function find_actions_by_claim_id( $claim_id );
 
 	/**
-	 * @param string $comparison_operator
+	 * Validate comparison comparator for sql.
+	 *
+	 * @param string $comparison_operator Comparison operator to check.
+	 *
 	 * @return string
 	 */
 	protected function validate_sql_comparator( $comparison_operator ) {
-		if ( in_array( $comparison_operator, array('!=', '>', '>=', '<', '<=', '=') ) ) {
+		if ( in_array( $comparison_operator, array( '!=', '>', '>=', '<', '<=', '=' ) ) ) {
 			return $comparison_operator;
 		}
 		return '=';
@@ -250,11 +300,12 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 	/**
 	 * Get the time MySQL formated date/time string for an action's (next) scheduled date.
 	 *
-	 * @param ActionScheduler_Action $action
-	 * @param DateTime $scheduled_date (optional)
+	 * @param ActionScheduler_Action $action Action to work with.
+	 * @param DateTime|null          $scheduled_date (optional) Scheduled date.
+	 *
 	 * @return string
 	 */
-	protected function get_scheduled_date_string( ActionScheduler_Action $action, DateTime $scheduled_date = NULL ) {
+	protected function get_scheduled_date_string( ActionScheduler_Action $action, DateTime $scheduled_date = null ) {
 		$next = null === $scheduled_date ? $action->get_schedule()->get_date() : $scheduled_date;
 		if ( ! $next ) {
 			return '0000-00-00 00:00:00';
@@ -267,11 +318,12 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 	/**
 	 * Get the time MySQL formated date/time string for an action's (next) scheduled date.
 	 *
-	 * @param ActionScheduler_Action $action
-	 * @param DateTime $scheduled_date (optional)
+	 * @param ActionScheduler_Action $action Action to work with.
+	 * @param DateTime|null          $scheduled_date (optional) Scheduled date.
+	 *
 	 * @return string
 	 */
-	protected function get_scheduled_date_string_local( ActionScheduler_Action $action, DateTime $scheduled_date = NULL ) {
+	protected function get_scheduled_date_string_local( ActionScheduler_Action $action, DateTime $scheduled_date = null ) {
 		$next = null === $scheduled_date ? $action->get_schedule()->get_date() : $scheduled_date;
 		if ( ! $next ) {
 			return '0000-00-00 00:00:00';
@@ -326,7 +378,13 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 	 */
 	protected function validate_action( ActionScheduler_Action $action ) {
 		if ( strlen( json_encode( $action->get_args() ) ) > static::$max_args_length ) {
-			throw new InvalidArgumentException( sprintf( __( 'ActionScheduler_Action::$args too long. To ensure the args column can be indexed, action args should not be more than %d characters when encoded as JSON.', 'action-scheduler' ), static::$max_args_length ) );
+			throw new InvalidArgumentException(
+				sprintf(
+					/* translators: %d: Maximum length for arguments */
+					__( 'ActionScheduler_Action::$args too long. To ensure the args column can be indexed, action args should not be more than %d characters when encoded as JSON.', 'action-scheduler' ),
+					static::$max_args_length
+				)
+			);
 		}
 	}
 
@@ -398,6 +456,8 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 	}
 
 	/**
+	 * Get status labels.
+	 *
 	 * @return array
 	 */
 	public function get_status_labels() {
@@ -413,16 +473,16 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 	/**
 	 * Check if there are any pending scheduled actions due to run.
 	 *
-	 * @param ActionScheduler_Action $action
-	 * @param DateTime $scheduled_date (optional)
 	 * @return string
 	 */
 	public function has_pending_actions_due() {
-		$pending_actions = $this->query_actions( array(
-			'date'    => as_get_datetime_object(),
-			'status'  => ActionScheduler_Store::STATUS_PENDING,
-			'orderby' => 'none',
-		) );
+		$pending_actions = $this->query_actions(
+			array(
+				'date'    => as_get_datetime_object(),
+				'status'  => self::STATUS_PENDING,
+				'orderby' => 'none',
+			)
+		);
 
 		return ! empty( $pending_actions );
 	}
@@ -434,10 +494,14 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 
 	/**
 	 * Callable function to mark an action as migrated optionally overridden in derived classes.
+	 *
+	 * @param int $action_id Action ID.
 	 */
 	public function mark_migrated( $action_id ) {}
 
 	/**
+	 * Get single instance of store.
+	 *
 	 * @return ActionScheduler_Store
 	 */
 	public static function instance() {

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -19,10 +19,18 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 	 */
 	private $claim_before_date = null;
 
-	/** @var int */
+	/**
+	 * Maximum length for arguments.
+	 *
+	 * @var int
+	 */
 	protected static $max_args_length = 8000;
 
-	/** @var int */
+	/**
+	 * Maximum database index length.
+	 *
+	 * @var int
+	 */
 	protected static $max_index_length = 191;
 
 	/**
@@ -70,7 +78,7 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 	 * @param bool                   $unique Whether the action should be unique.
 	 *
 	 * @return int Action ID.
-	 * @throws RuntimeException     Throws exception when saving the action fails.
+	 * @throws \RuntimeException     Throws exception when saving the action fails.
 	 */
 	private function save_action_to_db( ActionScheduler_Action $action, DateTime $date = null, $unique = false ) {
 		global $wpdb;
@@ -251,7 +259,11 @@ AND `group_id` = %d
 		if ( empty( $slug ) ) {
 			return 0;
 		}
-		/** @var \wpdb $wpdb */
+		/**
+		 * Global object of wpdb.
+		 *
+		 * @var \wpdb $wpdb
+		 */
 		global $wpdb;
 		$group_id = (int) $wpdb->get_var( $wpdb->prepare( "SELECT group_id FROM {$wpdb->actionscheduler_groups} WHERE slug=%s", $slug ) );
 		if ( empty( $group_id ) && $create_if_not_exists ) {
@@ -269,7 +281,11 @@ AND `group_id` = %d
 	 * @return int Group ID.
 	 */
 	protected function create_group( $slug ) {
-		/** @var \wpdb $wpdb */
+		/**
+		 * Global object of wpdb.
+		 *
+		 * @var \wpdb $wpdb
+		 */
 		global $wpdb;
 		$wpdb->insert( $wpdb->actionscheduler_groups, array( 'slug' => $slug ) );
 
@@ -284,7 +300,11 @@ AND `group_id` = %d
 	 * @return ActionScheduler_Action
 	 */
 	public function fetch_action( $action_id ) {
-		/** @var \wpdb $wpdb */
+		/**
+		 * Global object of wpdb.
+		 *
+		 * @var \wpdb $wpdb
+		 */
 		global $wpdb;
 		$data = $wpdb->get_row(
 			$wpdb->prepare(
@@ -378,23 +398,28 @@ AND `group_id` = %d
 		$query = wp_parse_args(
 			$query,
 			array(
-				'hook'             => '',
-				'args'             => null,
-				'date'             => null,
-				'date_compare'     => '<=',
-				'modified'         => null,
-				'modified_compare' => '<=',
-				'group'            => '',
-				'status'           => '',
-				'claimed'          => null,
-				'per_page'         => 5,
-				'offset'           => 0,
-				'orderby'          => 'date',
-				'order'            => 'ASC',
+				'hook'                  => '',
+				'args'                  => null,
+				'date'                  => null,
+				'date_compare'          => '<=',
+				'modified'              => null,
+				'modified_compare'      => '<=',
+				'group'                 => '',
+				'status'                => '',
+				'claimed'               => null,
+				'per_page'              => 5,
+				'offset'                => 0,
+				'orderby'               => 'date',
+				'order'                 => 'ASC',
+				'include_async_actions' => true,
 			)
 		);
 
-		/** @var \wpdb $wpdb */
+		/**
+		 * Global object of wpdb.
+		 *
+		 * @var \wpdb $wpdb
+		 */
 		global $wpdb;
 		$sql        = ( 'count' === $select_or_count ) ? 'SELECT count(a.action_id)' : 'SELECT a.action_id';
 		$sql       .= " FROM {$wpdb->actionscheduler_actions} a";
@@ -443,6 +468,10 @@ AND `group_id` = %d
 			$comparator   = $this->validate_sql_comparator( $query['modified_compare'] );
 			$sql         .= " AND a.last_attempt_gmt $comparator %s";
 			$sql_params[] = $date_string;
+		}
+
+		if ( ! $query['include_async_actions'] ) {
+			$sql .= ' AND a.scheduled_date_gmt != 0 ';
 		}
 
 		if ( true === $query['claimed'] ) {
@@ -523,7 +552,11 @@ AND `group_id` = %d
 	 * @return string|array|null The IDs of actions matching the query. Null on failure.
 	 */
 	public function query_actions( $query = array(), $query_type = 'select' ) {
-		/** @var wpdb $wpdb */
+		/**
+		 * Global object of wpdb.
+		 *
+		 * @var \wpdb $wpdb
+		 */
 		global $wpdb;
 
 		$sql = $this->get_query_actions_sql( $query, $query_type );
@@ -565,7 +598,11 @@ AND `group_id` = %d
 	 * @throws \InvalidArgumentException If the action update failed.
 	 */
 	public function cancel_action( $action_id ) {
-		/** @var \wpdb $wpdb */
+		/**
+		 * Global object of wpdb.
+		 *
+		 * @var \wpdb $wpdb
+		 */
 		global $wpdb;
 
 		$updated = $wpdb->update(
@@ -614,7 +651,11 @@ AND `group_id` = %d
 	 * @param array $query_args Query parameters.
 	 */
 	protected function bulk_cancel_actions( $query_args ) {
-		/** @var \wpdb $wpdb */
+		/**
+		 * Global object of wpdb.
+		 *
+		 * @var \wpdb $wpdb
+		 */
 		global $wpdb;
 
 		if ( ! is_array( $query_args ) ) {
@@ -665,7 +706,11 @@ AND `group_id` = %d
 	 * @throws \InvalidArgumentException If the action deletion failed.
 	 */
 	public function delete_action( $action_id ) {
-		/** @var \wpdb $wpdb */
+		/**
+		 * Global object of wpdb.
+		 *
+		 * @var \wpdb $wpdb
+		 */
 		global $wpdb;
 		$deleted = $wpdb->delete( $wpdb->actionscheduler_actions, array( 'action_id' => $action_id ), array( '%d' ) );
 		if ( empty( $deleted ) ) {
@@ -696,7 +741,11 @@ AND `group_id` = %d
 	 * @return \DateTime The GMT date the action is scheduled to run, or the date that it ran.
 	 */
 	protected function get_date_gmt( $action_id ) {
-		/** @var \wpdb $wpdb */
+		/**
+		 * Global object of wpdb.
+		 *
+		 * @var \wpdb $wpdb
+		 */
 		global $wpdb;
 		$record = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$wpdb->actionscheduler_actions} WHERE action_id=%d", $action_id ) );
 		if ( empty( $record ) ) {
@@ -736,7 +785,11 @@ AND `group_id` = %d
 	 * @return int Claim ID.
 	 */
 	protected function generate_claim_id() {
-		/** @var \wpdb $wpdb */
+		/**
+		 * Global object of wpdb.
+		 *
+		 * @var \wpdb $wpdb
+		 */
 		global $wpdb;
 		$now = as_get_datetime_object();
 		$wpdb->insert( $wpdb->actionscheduler_claims, array( 'date_created_gmt' => $now->format( 'Y-m-d H:i:s' ) ) );
@@ -758,7 +811,11 @@ AND `group_id` = %d
 	 * @throws \RuntimeException Throws RuntimeException if unable to claim action.
 	 */
 	protected function claim_actions( $claim_id, $limit, \DateTime $before_date = null, $hooks = array(), $group = '' ) {
-		/** @var \wpdb $wpdb */
+		/**
+		 * Global object of wpdb.
+		 *
+		 * @var \wpdb $wpdb
+		 */
 		global $wpdb;
 
 		$now  = as_get_datetime_object();
@@ -821,6 +878,11 @@ AND `group_id` = %d
 	 * @return int
 	 */
 	public function get_claim_count() {
+		/**
+		 * Global object of wpdb.
+		 *
+		 * @var \wpdb $wpdb
+		 */
 		global $wpdb;
 
 		$sql = "SELECT COUNT(DISTINCT claim_id) FROM {$wpdb->actionscheduler_actions} WHERE claim_id != 0 AND status IN ( %s, %s)";
@@ -836,7 +898,11 @@ AND `group_id` = %d
 	 * @return mixed
 	 */
 	public function get_claim_id( $action_id ) {
-		/** @var \wpdb $wpdb */
+		/**
+		 * Global object of wpdb.
+		 *
+		 * @var \wpdb $wpdb
+		 */
 		global $wpdb;
 
 		$sql = "SELECT claim_id FROM {$wpdb->actionscheduler_actions} WHERE action_id=%d";
@@ -852,7 +918,11 @@ AND `group_id` = %d
 	 * @return int[]
 	 */
 	public function find_actions_by_claim_id( $claim_id ) {
-		/** @var \wpdb $wpdb */
+		/**
+		 * Global object of wpdb.
+		 *
+		 * @var \wpdb $wpdb
+		 */
 		global $wpdb;
 
 		$action_ids  = array();
@@ -881,7 +951,11 @@ AND `group_id` = %d
 	 * @param ActionScheduler_ActionClaim $claim Claim object.
 	 */
 	public function release_claim( ActionScheduler_ActionClaim $claim ) {
-		/** @var \wpdb $wpdb */
+		/**
+		 * Global object of wpdb.
+		 *
+		 * @var \wpdb $wpdb
+		 */
 		global $wpdb;
 		$wpdb->update( $wpdb->actionscheduler_actions, array( 'claim_id' => 0 ), array( 'claim_id' => $claim->get_id() ), array( '%d' ), array( '%d' ) );
 		$wpdb->delete( $wpdb->actionscheduler_claims, array( 'claim_id' => $claim->get_id() ), array( '%d' ) );
@@ -895,7 +969,11 @@ AND `group_id` = %d
 	 * @return void
 	 */
 	public function unclaim_action( $action_id ) {
-		/** @var \wpdb $wpdb */
+		/**
+		 * Global object of wpdb.
+		 *
+		 * @var \wpdb $wpdb
+		 */
 		global $wpdb;
 		$wpdb->update(
 			$wpdb->actionscheduler_actions,
@@ -913,7 +991,11 @@ AND `group_id` = %d
 	 * @throws \InvalidArgumentException Throw an exception if action was not updated.
 	 */
 	public function mark_failure( $action_id ) {
-		/** @var \wpdb $wpdb */
+		/**
+		 * Global object of wpdb.
+		 *
+		 * @var \wpdb $wpdb
+		 */
 		global $wpdb;
 		$updated = $wpdb->update(
 			$wpdb->actionscheduler_actions,
@@ -935,7 +1017,11 @@ AND `group_id` = %d
 	 * @return void
 	 */
 	public function log_execution( $action_id ) {
-		/** @var \wpdb $wpdb */
+		/**
+		 * Global object of wpdb.
+		 *
+		 * @var \wpdb $wpdb
+		 */
 		global $wpdb;
 
 		$sql = "UPDATE {$wpdb->actionscheduler_actions} SET attempts = attempts+1, status=%s, last_attempt_gmt = %s, last_attempt_local = %s WHERE action_id = %d";
@@ -952,7 +1038,11 @@ AND `group_id` = %d
 	 * @throws \InvalidArgumentException Throw an exception if action was not updated.
 	 */
 	public function mark_complete( $action_id ) {
-		/** @var \wpdb $wpdb */
+		/**
+		 * Global object of wpdb.
+		 *
+		 * @var \wpdb $wpdb
+		 */
 		global $wpdb;
 		$updated = $wpdb->update(
 			$wpdb->actionscheduler_actions,
@@ -989,7 +1079,11 @@ AND `group_id` = %d
 	 * @throws \RuntimeException Throw an exception if action status could not be retrieved.
 	 */
 	public function get_status( $action_id ) {
-		/** @var \wpdb $wpdb */
+		/**
+		 * Global object of wpdb.
+		 *
+		 * @var \wpdb $wpdb
+		 */
 		global $wpdb;
 		$sql    = "SELECT status FROM {$wpdb->actionscheduler_actions} WHERE action_id=%d";
 		$sql    = $wpdb->prepare( $sql, $action_id ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared


### PR DESCRIPTION
Fixes: https://github.com/woocommerce/action-scheduler/issues/860

Here we created a new query argument `include_async_actions` with true as a default value not to break any current functionality as mentioned in the issue's description.

I passed this new argument three times as follows:
1. In AdminView class: in the part that controls the past-due admin notice.
2. In Store class: in the part of showing the status filter.
3. In ListTable class: in the part of showing the status filtered page.

Plz note that I fixed most of PHPCS formatting issues that were not related to this PR.

This is my first contribution to Action Scheduler and won't be the last one, I can see more rooms to enhance inside this amazing tool.