### PR TITLE
Test/version update

### DIFF
--- a/action-scheduler.php
+++ b/action-scheduler.php
@@ -28,6 +28,8 @@
 
 if ( ! function_exists( 'action_scheduler_register_3_dot_5_dot_2' ) && function_exists( 'add_action' ) ) { // WRCS: DEFINED_VERSION.
 
+	define( 'ACTION_SCHEDULER_VERSION', '3.5.2' ); // WRCS: DEFINED_VERSION.
+
 	if ( ! class_exists( 'ActionScheduler_Versions', false ) ) {
 		require_once __DIR__ . '/classes/ActionScheduler_Versions.php';
 		add_action( 'plugins_loaded', array( 'ActionScheduler_Versions', 'initialize_latest_version' ), 1, 0 );
@@ -40,7 +42,7 @@ if ( ! function_exists( 'action_scheduler_register_3_dot_5_dot_2' ) && function_
 	 */
 	function action_scheduler_register_3_dot_5_dot_2() { // WRCS: DEFINED_VERSION.
 		$versions = ActionScheduler_Versions::instance();
-		$versions->register( '3.5.2', 'action_scheduler_initialize_3_dot_5_dot_2' ); // WRCS: DEFINED_VERSION.
+		$versions->register( ACTION_SCHEDULER_VERSION, 'action_scheduler_initialize_3_dot_5_dot_2' ); // WRCS: DEFINED_VERSION.
 	}
 
 	/**

--- a/action-scheduler.php
+++ b/action-scheduler.php
@@ -26,27 +26,27 @@
  * @package ActionScheduler
  */
 
-if ( ! function_exists( 'action_scheduler_register_3_dot_5_dot_2' ) && function_exists( 'add_action' ) ) {
+if ( ! function_exists( 'action_scheduler_register_3_dot_5_dot_2' ) && function_exists( 'add_action' ) ) { // WRCS: DEFINED_VERSION.
 
 	if ( ! class_exists( 'ActionScheduler_Versions', false ) ) {
 		require_once __DIR__ . '/classes/ActionScheduler_Versions.php';
 		add_action( 'plugins_loaded', array( 'ActionScheduler_Versions', 'initialize_latest_version' ), 1, 0 );
 	}
 
-	add_action( 'plugins_loaded', 'action_scheduler_register_3_dot_5_dot_2', 0, 0 );
+	add_action( 'plugins_loaded', 'action_scheduler_register_3_dot_5_dot_2', 0, 0 ); // WRCS: DEFINED_VERSION.
 
 	/**
 	 * Registers this version of Action Scheduler.
 	 */
-	function action_scheduler_register_3_dot_5_dot_2() {
+	function action_scheduler_register_3_dot_5_dot_2() { // WRCS: DEFINED_VERSION.
 		$versions = ActionScheduler_Versions::instance();
-		$versions->register( '3.5.2', 'action_scheduler_initialize_3_dot_5_dot_2' );
+		$versions->register( '3.5.2', 'action_scheduler_initialize_3_dot_5_dot_2' ); // WRCS: DEFINED_VERSION.
 	}
 
 	/**
 	 * Initializes this version of Action Scheduler.
 	 */
-	function action_scheduler_initialize_3_dot_5_dot_2() {
+	function action_scheduler_initialize_3_dot_5_dot_2() { // WRCS: DEFINED_VERSION.
 		// A final safety check is required even here, because historic versions of Action Scheduler
 		// followed a different pattern (in some unusual cases, we could reach this point and the
 		// ActionScheduler class is already defined—so we need to guard against that).
@@ -58,7 +58,7 @@ if ( ! function_exists( 'action_scheduler_register_3_dot_5_dot_2' ) && function_
 
 	// Support usage in themes - load this version if no plugin has loaded a version yet.
 	if ( did_action( 'plugins_loaded' ) && ! doing_action( 'plugins_loaded' ) && ! class_exists( 'ActionScheduler', false ) ) {
-		action_scheduler_initialize_3_dot_5_dot_2();
+		action_scheduler_initialize_3_dot_5_dot_2(); // WRCS: DEFINED_VERSION.
 		do_action( 'action_scheduler_pre_theme_init' );
 		ActionScheduler_Versions::initialize_latest_version();
 	}

--- a/action-scheduler.php
+++ b/action-scheduler.php
@@ -28,8 +28,6 @@
 
 if ( ! function_exists( 'action_scheduler_register_3_dot_5_dot_2' ) && function_exists( 'add_action' ) ) { // WRCS: DEFINED_VERSION.
 
-	define( 'ACTION_SCHEDULER_VERSION', '3.5.2' ); // WRCS: DEFINED_VERSION.
-
 	if ( ! class_exists( 'ActionScheduler_Versions', false ) ) {
 		require_once __DIR__ . '/classes/ActionScheduler_Versions.php';
 		add_action( 'plugins_loaded', array( 'ActionScheduler_Versions', 'initialize_latest_version' ), 1, 0 );
@@ -42,7 +40,7 @@ if ( ! function_exists( 'action_scheduler_register_3_dot_5_dot_2' ) && function_
 	 */
 	function action_scheduler_register_3_dot_5_dot_2() { // WRCS: DEFINED_VERSION.
 		$versions = ActionScheduler_Versions::instance();
-		$versions->register( ACTION_SCHEDULER_VERSION, 'action_scheduler_initialize_3_dot_5_dot_2' ); // WRCS: DEFINED_VERSION.
+		$versions->register( '3.5.2', 'action_scheduler_initialize_3_dot_5_dot_2' ); // WRCS: DEFINED_VERSION.
 	}
 
 	/**


### PR DESCRIPTION
Here is a first take on making version bump automation work for AS using Woorelease. With these changes, I am able to put in logic on Woorelease side to account for "letter" based versions to be able to bump them.

The resulting diff changes after running Woorelease would look like so:

```
diff --git a/action-scheduler.php b/action-scheduler.php
index 7549dbc..c04c35d 100644
--- a/action-scheduler.php
+++ b/action-scheduler.php
@@ -5,7 +5,7 @@
  * Description: A robust scheduling library for use in WordPress plugins.
  * Author: Automattic
  * Author URI: https://automattic.com/
- * Version: 3.5.2
+ * Version: 3.5.3
  * License: GPLv3
  *
  * Copyright 2019 Automattic, Inc.  (https://automattic.com/contact/)
@@ -26,29 +26,29 @@
  * @package ActionScheduler
  */

-if ( ! function_exists( 'action_scheduler_register_3_dot_5_dot_2' ) && function_exists( 'add_action' ) ) { // WRCS: DEFINED_VERSION.
+if ( ! function_exists( 'action_scheduler_register_3_dot_5_dot_3' ) && function_exists( 'add_action' ) ) { // WRCS: DEFINED_VERSION.

-	define( 'ACTION_SCHEDULER_VERSION', '3.5.2' ); // WRCS: DEFINED_VERSION.
+	define( 'ACTION_SCHEDULER_VERSION', '3.5.3' ); // WRCS: DEFINED_VERSION.

 	if ( ! class_exists( 'ActionScheduler_Versions', false ) ) {
 		require_once __DIR__ . '/classes/ActionScheduler_Versions.php';
 		add_action( 'plugins_loaded', array( 'ActionScheduler_Versions', 'initialize_latest_version' ), 1, 0 );
 	}

-	add_action( 'plugins_loaded', 'action_scheduler_register_3_dot_5_dot_2', 0, 0 ); // WRCS: DEFINED_VERSION.
+	add_action( 'plugins_loaded', 'action_scheduler_register_3_dot_5_dot_3', 0, 0 ); // WRCS: DEFINED_VERSION.

 	/**
 	 * Registers this version of Action Scheduler.
 	 */
-	function action_scheduler_register_3_dot_5_dot_2() { // WRCS: DEFINED_VERSION.
+	function action_scheduler_register_3_dot_5_dot_3() { // WRCS: DEFINED_VERSION.
 		$versions = ActionScheduler_Versions::instance();
-		$versions->register( ACTION_SCHEDULER_VERSION, 'action_scheduler_initialize_3_dot_5_dot_2' ); // WRCS: DEFINED_VERSION.
+		$versions->register( ACTION_SCHEDULER_VERSION, 'action_scheduler_initialize_3_dot_5_dot_3' ); // WRCS: DEFINED_VERSION.
 	}

 	/**
 	 * Initializes this version of Action Scheduler.
 	 */
-	function action_scheduler_initialize_3_dot_5_dot_2() { // WRCS: DEFINED_VERSION.
+	function action_scheduler_initialize_3_dot_5_dot_3() { // WRCS: DEFINED_VERSION.
 		// A final safety check is required even here, because historic versions of Action Scheduler
 		// followed a different pattern (in some unusual cases, we could reach this point and the
 		// ActionScheduler class is already defined—so we need to guard against that).
@@ -60,7 +60,7 @@ if ( ! function_exists( 'action_scheduler_register_3_dot_5_dot_2' ) && function_

 	// Support usage in themes - load this version if no plugin has loaded a version yet.
 	if ( did_action( 'plugins_loaded' ) && ! doing_action( 'plugins_loaded' ) && ! class_exists( 'ActionScheduler', false ) ) {
-		action_scheduler_initialize_3_dot_5_dot_2(); // WRCS: DEFINED_VERSION.
+		action_scheduler_initialize_3_dot_5_dot_3(); // WRCS: DEFINED_VERSION.
 		do_action( 'action_scheduler_pre_theme_init' );
 		ActionScheduler_Versions::initialize_latest_version();
 	}
```

So basically I am adding `// WRCS: DEFINED_VERSION.` so Woorelease knows these are the lines to look for version bumps. Note this is not new. We've been using this code sniff for most of our other extensions that we need Woorelease to deploy.