### PR TITLE
Prevent `undefined variable` warning for `$num_pastdue_actions`

### DIFF
--- a/classes/ActionScheduler_AdminView.php
+++ b/classes/ActionScheduler_AdminView.php
@@ -147,6 +147,11 @@ class ActionScheduler_AdminView extends ActionScheduler_AdminView_Deprecated {
 		$threshold_seconds = ( int ) apply_filters( 'action_scheduler_pastdue_actions_seconds', DAY_IN_SECONDS );
 		$threshhold_min    = ( int ) apply_filters( 'action_scheduler_pastdue_actions_min', 1 );
 
+		# Set fallback value for past-due actions count.
+		if ( ! isset( $num_pastdue_actions ) ) {
+			$num_pastdue_actions = 0;
+		}
+
 		# Allow third-parties to preempt the default check logic.
 		$check = apply_filters( 'action_scheduler_pastdue_actions_check_pre', null );
 

--- a/classes/ActionScheduler_AdminView.php
+++ b/classes/ActionScheduler_AdminView.php
@@ -147,13 +147,16 @@ class ActionScheduler_AdminView extends ActionScheduler_AdminView_Deprecated {
 		$threshold_seconds = ( int ) apply_filters( 'action_scheduler_pastdue_actions_seconds', DAY_IN_SECONDS );
 		$threshhold_min    = ( int ) apply_filters( 'action_scheduler_pastdue_actions_min', 1 );
 
-		# Set fallback value for past-due actions count.
-		if ( ! isset( $num_pastdue_actions ) ) {
-			$num_pastdue_actions = 0;
-		}
+		// Set fallback value for past-due actions count.
+		$num_pastdue_actions = 0;
 
-		# Allow third-parties to preempt the default check logic.
+		// Allow third-parties to preempt the default check logic.
 		$check = apply_filters( 'action_scheduler_pastdue_actions_check_pre', null );
+
+		// If no third-party preempted and there are no past-due actions, return early.
+		if ( ! is_null( $check ) ) {
+			return;
+		}
 
 		# Scheduled actions query arguments.
 		$query_args = array(


### PR DESCRIPTION
Closes #865

> This is happening because `$num_pastdue_actions` is defined only if the filter is not in use, but later in the code the variable is used regardless of the filter being used or not.

Sets a fallback value of 0 to prevent the `Undefined variable $num_pastdue_actions` warnings when `$num_pastdue_actions` is referenced lower in the document after the initial `$check`

### Changelog

> Fix - Prevents an undefined variable error in relation to the past-due actions notice.