### PR TITLE
throwing an exception if as_schedule_recurring_action interval param is not of type integer

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -122,7 +122,6 @@ function as_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, 
 		return 0;
 	}
 
-	// if you pass a string by mistake, it causes a flood of scheduled actions, recurring almost every minute or less
 	$interval = (int) $interval_in_seconds;
 
 	// We expect an integer and allow it to be passed using float and string types, but otherwise
@@ -130,13 +129,13 @@ function as_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, 
 	if ( ! is_numeric( $interval_in_seconds ) || $interval_in_seconds != $interval ) {
 		_doing_it_wrong(
 			__METHOD__,
-			sprintf( 
+			sprintf(
 				/* translators: 1: provided value 2: provided type. */
 				__( 'An integer was expected but "%1$s" (%2%s) was received.', 'action-scheduler' ),
 				$interval_in_seconds,
 				gettype( $interval_in_seconds )
 			),
-			ActionScheduler_Versions::instance()->latest_version()
+			'3.6.0'
 		);
 	}
 

--- a/functions.php
+++ b/functions.php
@@ -122,6 +122,11 @@ function as_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, 
 		return 0;
 	}
 
+	// if you pass a string by mistake, it causes a flood of scheduled actions, recurring almost every minute or less
+	if ( ! is_int( $interval_in_seconds ) ) {
+		throw new Exception( "Interval parameter should be of type integer, received" . gettype( $interval_in_seconds ) );
+	}
+
 	/**
 	 * Provides an opportunity to short-circuit the default process for enqueuing recurring
 	 * actions.

--- a/functions.php
+++ b/functions.php
@@ -128,7 +128,16 @@ function as_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, 
 	// We expect an integer and allow it to be passed using float and string types, but otherwise
 	// should reject unexpected values.
 	if ( ! is_numeric( $interval_in_seconds ) || $interval_in_seconds != $interval ) {
-		throw new Exception( "Interval parameter should be of type integer, received" . gettype( $interval_in_seconds ) );
+		_doing_it_wrong(
+			__METHOD__,
+			sprintf( 
+				/* translators: 1: provided value 2: provided type. */
+				__( 'An integer was expected but "%1$s" (%2%s) was received.', 'action-scheduler' ),
+				$interval_in_seconds,
+				gettype( $interval_in_seconds )
+			),
+			ActionScheduler_Versions::instance()->latest_version()
+		);
 	}
 
 	/**

--- a/functions.php
+++ b/functions.php
@@ -123,7 +123,11 @@ function as_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, 
 	}
 
 	// if you pass a string by mistake, it causes a flood of scheduled actions, recurring almost every minute or less
-	if ( ! is_int( $interval_in_seconds ) ) {
+	$interval = (int) $interval_in_seconds;
+
+	// We expect an integer and allow it to be passed using float and string types, but otherwise
+	// should reject unexpected values.
+	if ( ! is_numeric( $interval_in_seconds ) || $interval_in_seconds != $interval ) {
 		throw new Exception( "Interval parameter should be of type integer, received" . gettype( $interval_in_seconds ) );
 	}
 

--- a/functions.php
+++ b/functions.php
@@ -131,12 +131,14 @@ function as_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, 
 			__METHOD__,
 			sprintf(
 				/* translators: 1: provided value 2: provided type. */
-				__( 'An integer was expected but "%1$s" (%2%s) was received.', 'action-scheduler' ),
-				$interval_in_seconds,
-				gettype( $interval_in_seconds )
+				esc_html__( 'An integer was expected but "%1$s" (%2$s) was received.', 'action-scheduler' ),
+				esc_html( $interval_in_seconds ),
+				esc_html( gettype( $interval_in_seconds ) )
 			),
 			'3.6.0'
 		);
+
+		return 0;
 	}
 
 	/**


### PR DESCRIPTION
While working on a project, I passed in a string ( 'twicedaily' in particular ) as the interval parameter of as_schedule_recurring_action. ( mistaken for wp_schedule_event params, an older implementation in our project )

That did not throw any errors, but it was silently causing many actions to be scheduled and filling the database very quickly.

Suggested/implemented fix: check/assert the parameter to be an integer and otherwise throw an exception to warn the developer of such behavior. 

If you have any feedback please let me know, this is my first contribution to an open-source project ever.

### Testing instructions

I recommend testing via WP CLI. Try creating recurring actions: if the interval is a valid value the action will be created, otherwise it will not be created and a suitable warning emitted. Example `wp shell` session:

```
>>> as_schedule_recurring_action( time(), 10, 'valid' )
=> 5220

>>> as_schedule_recurring_action( time(), 100.0, 'valid' )
=> 5221

>>> as_schedule_recurring_action( time(), '1000', 'valid' )
=> 5222

>>> as_schedule_recurring_action( time(), 'accidental', 'invalid' )
PHP Notice:  Function as_schedule_recurring_action was called <strong>incorrectly</strong>. An integer was expected but &quot;accidental&quot; (string) was received. Please see <a href="https://wordpress.org/support/article/debugging-in-wordpress/">Debugging in WordPress</a> for more information. (This message was added in version 3.5.5.) in /data/var/www/lab.wordpress/public/wp-includes/functions.php on line 5835

>>> as_schedule_recurring_action( time(), -123.456, 'invalid' )
PHP Notice:  Function as_schedule_recurring_action was called <strong>incorrectly</strong>. An integer was expected but &quot;-123.456&quot; (double) was received. Please see <a href="https://wordpress.org/support/article/debugging-in-wordpress/">Debugging in WordPress</a> for more information. (This message was added in version 3.5.5.) in /data/var/www/lab.wordpress/public/wp-includes/functions.php on line 5835
```

### Changelog

> Add safety checks to the procedural API, relating to the interval for recurring actions.