### PR TITLE
Correctly order the parameters for `ActionScheduler_ActionFactory`'s calls to `single_unique`

### DIFF
--- a/classes/ActionScheduler_ActionFactory.php
+++ b/classes/ActionScheduler_ActionFactory.php
@@ -146,7 +146,7 @@ class ActionScheduler_ActionFactory {
 	 */
 	public function recurring_unique( $hook, $args = array(), $first = null, $interval = null, $group = '', $unique = true ) {
 		if ( empty( $interval ) ) {
-			return $this->single_unique( $hook, $unique, $args, $first, $group );
+			return $this->single_unique( $hook, $args, $first, $group, $unique );
 		}
 		$date     = as_get_datetime_object( $first );
 		$schedule = new ActionScheduler_IntervalSchedule( $date, $interval );
@@ -188,7 +188,7 @@ class ActionScheduler_ActionFactory {
 	 **/
 	public function cron_unique( $hook, $args = array(), $base_timestamp = null, $schedule = null, $group = '', $unique = true ) {
 		if ( empty( $schedule ) ) {
-			return $this->single_unique( $hook, $unique, $args, $base_timestamp, $group );
+			return $this->single_unique( $hook, $args, $base_timestamp, $group, $unique );
 		}
 		$date     = as_get_datetime_object( $base_timestamp );
 		$cron     = CronExpression::factory( $schedule );


### PR DESCRIPTION
I found three calls to the `single_unique` method and two of them had parameters that didn't match the documented order. This fixes them.

In doing a search, I only found one other use of this object's `single_unique` method, and its parameters were already in the documented order. If that's correct, I think this fixes #881.