### PR TITLE
PHP 8.2: fix "Using ${var} in strings is deprecated, use {$var} instead"

### DIFF
--- a/classes/schema/ActionScheduler_StoreSchema.php
+++ b/classes/schema/ActionScheduler_StoreSchema.php
@@ -47,14 +47,14 @@ class ActionScheduler_StoreSchema extends ActionScheduler_Abstract_Schema {
 				        action_id bigint(20) unsigned NOT NULL auto_increment,
 				        hook varchar(191) NOT NULL,
 				        status varchar(20) NOT NULL,
-				        scheduled_date_gmt datetime NULL default '${default_date}',
-				        scheduled_date_local datetime NULL default '${default_date}',
+				        scheduled_date_gmt datetime NULL default '{$default_date}',
+				        scheduled_date_local datetime NULL default '{$default_date}',
 				        args varchar($max_index_length),
 				        schedule longtext,
 				        group_id bigint(20) unsigned NOT NULL default '0',
 				        attempts int(11) NOT NULL default '0',
-				        last_attempt_gmt datetime NULL default '${default_date}',
-				        last_attempt_local datetime NULL default '${default_date}',
+				        last_attempt_gmt datetime NULL default '{$default_date}',
+				        last_attempt_local datetime NULL default '{$default_date}',
 				        claim_id bigint(20) unsigned NOT NULL default '0',
 				        extended_args varchar(8000) DEFAULT NULL,
 				        PRIMARY KEY  (action_id),
@@ -71,7 +71,7 @@ class ActionScheduler_StoreSchema extends ActionScheduler_Abstract_Schema {
 
 				return "CREATE TABLE {$table_name} (
 				        claim_id bigint(20) unsigned NOT NULL auto_increment,
-				        date_created_gmt datetime NULL default '${default_date}',
+				        date_created_gmt datetime NULL default '{$default_date}',
 				        PRIMARY KEY  (claim_id),
 				        KEY date_created_gmt (date_created_gmt)
 				        ) $charset_collate";
@@ -111,16 +111,16 @@ class ActionScheduler_StoreSchema extends ActionScheduler_Abstract_Schema {
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		$table_name   = $wpdb->prefix . 'actionscheduler_actions';
-		$table_list   = $wpdb->get_col( "SHOW TABLES LIKE '${table_name}'" );
+		$table_list   = $wpdb->get_col( "SHOW TABLES LIKE '{$table_name}'" );
 		$default_date = self::DEFAULT_DATE;
 
 		if ( ! empty( $table_list ) ) {
 			$query = "
-				ALTER TABLE ${table_name}
-				MODIFY COLUMN scheduled_date_gmt datetime NULL default '${default_date}',
-				MODIFY COLUMN scheduled_date_local datetime NULL default '${default_date}',
-				MODIFY COLUMN last_attempt_gmt datetime NULL default '${default_date}',
-				MODIFY COLUMN last_attempt_local datetime NULL default '${default_date}'
+				ALTER TABLE {$table_name}
+				MODIFY COLUMN scheduled_date_gmt datetime NULL default '{$default_date}',
+				MODIFY COLUMN scheduled_date_local datetime NULL default '{$default_date}',
+				MODIFY COLUMN last_attempt_gmt datetime NULL default '{$default_date}',
+				MODIFY COLUMN last_attempt_local datetime NULL default '{$default_date}'
 		";
 			$wpdb->query( $query ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 		}


### PR DESCRIPTION
PHP 8.2 deprecated using ${var} in strings (https://kinsta.com/blog/php-8-2/#deprecate--string-interpolation). {$var} should be used instead. This commit fixes the occurrences of ${var} inside ActionScheduler_StoreSchema.php to prepare for the next version of PHP which is scheduled to be released early in December.

I found this in the context of testing MailPoet with PHP 8.2. I'm not familiar with the Action Scheduler so I might be missing something. I tested these changes briefly in a MailPoet environment that uses AS.

### Changelog

> Dev - Update code using a deprecated style of variable interpolation, for improved compatibility with PHP 8.2.