### PR TITLE
PHP 8.2: declare property to fix creation of dynamic property warning

### DIFF
--- a/classes/schedules/ActionScheduler_NullSchedule.php
+++ b/classes/schedules/ActionScheduler_NullSchedule.php
@@ -6,7 +6,7 @@
 class ActionScheduler_NullSchedule extends ActionScheduler_SimpleSchedule {
 
 	/** @var DateTime|null */
-	public $scheduled_date;
+	protected $scheduled_date;
 
 	/**
 	 * Make the $date param optional and default to null.

--- a/classes/schedules/ActionScheduler_NullSchedule.php
+++ b/classes/schedules/ActionScheduler_NullSchedule.php
@@ -5,6 +5,9 @@
  */
 class ActionScheduler_NullSchedule extends ActionScheduler_SimpleSchedule {
 
+	/** @var DateTime|null */
+	public $scheduled_date;
+
 	/**
 	 * Make the $date param optional and default to null.
 	 *


### PR DESCRIPTION
This PR fixes the following deprecation warning that is being thrown by PHP 8.2 since this version of PHP deprecated dynamic properties:

```
Creation of dynamic property ActionScheduler_NullSchedule::$scheduled_date is deprecated /wp-core/wp-content/plugins/mailpoet/vendor/woocommerce/action-scheduler/classes/schedules/ActionScheduler_NullSchedule.php:14
```

I opted to declare the property as public to avoid introducing a backward incompatible change, but I'm not sure if this is the best approach or not.

### Changelog

> Fix - Prevent dynamic property warnings in relation to Null Schedule instances.