### PR TITLE
Fetch action in memory first before releasing claim to avoid deadlock.

### DIFF
--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -943,14 +943,19 @@ AND `group_id` = %d
 		 * We resolve this by getting all the actions_id that we want to release claim from in a separate query, and then releasing the claim on each of them. This way, our lock is acquired on the action_id index instead of the claim_id index. Note that the lock on claim_id will still be acquired, but it will only when we actually make the update, rather than when we select the actions.
 		 */
 		$action_ids = $wpdb->get_col( $wpdb->prepare( "SELECT action_id FROM {$wpdb->actionscheduler_actions} WHERE claim_id = %d", $claim->get_id() ) );
-		if ( 0 === count( $action_ids ) ) {
-			$wpdb->delete( $wpdb->actionscheduler_claims, array( 'claim_id' => $claim->get_id() ), array( '%d' ) );
+
+		if ( count( $action_ids ) > 0 ) {
+			$action_id_string = implode( ',', array_map( 'absint', $action_ids ) );
+			$row_updates = $wpdb->query( "UPDATE {$wpdb->actionscheduler_actions} SET claim_id = 0 WHERE action_id IN ({$action_id_string})" ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+			if ( $row_updates < count( $action_ids ) ) {
+				throw new RuntimeException(
+					sprintf(
+						__( 'Unable to release actions from claim id %d.', 'woocommerce' ),
+						$claim->get_id()
+					)
+				);
+			}
 			return;
-		}
-		$action_id_string = implode( ',', array_map( 'absint', $action_ids ) );
-		$row_updates = $wpdb->query( "UPDATE {$wpdb->actionscheduler_actions} SET claim_id = 0 WHERE action_id IN ({$action_id_string})" ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-		if ( $row_updates < count( $action_ids ) ) {
-			throw new RuntimeException( __( 'Unable to release actions from claim. Database error.', 'woocommerce' ) );
 		}
 		$wpdb->delete( $wpdb->actionscheduler_claims, array( 'claim_id' => $claim->get_id() ), array( '%d' ) );
 	}

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -944,20 +944,22 @@ AND `group_id` = %d
 		 */
 		$action_ids = $wpdb->get_col( $wpdb->prepare( "SELECT action_id FROM {$wpdb->actionscheduler_actions} WHERE claim_id = %d", $claim->get_id() ) );
 
+		$row_updates = 0;
 		if ( count( $action_ids ) > 0 ) {
 			$action_id_string = implode( ',', array_map( 'absint', $action_ids ) );
 			$row_updates = $wpdb->query( "UPDATE {$wpdb->actionscheduler_actions} SET claim_id = 0 WHERE action_id IN ({$action_id_string})" ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-			if ( $row_updates < count( $action_ids ) ) {
-				throw new RuntimeException(
-					sprintf(
-						__( 'Unable to release actions from claim id %d.', 'woocommerce' ),
-						$claim->get_id()
-					)
-				);
-			}
-			return;
 		}
+
 		$wpdb->delete( $wpdb->actionscheduler_claims, array( 'claim_id' => $claim->get_id() ), array( '%d' ) );
+
+		if ( $row_updates < count( $action_ids ) ) {
+			throw new RuntimeException(
+				sprintf(
+					__( 'Unable to release actions from claim id %d.', 'woocommerce' ),
+					$claim->get_id()
+				)
+			);
+		}
 	}
 
 	/**

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -935,7 +935,23 @@ AND `group_id` = %d
 	public function release_claim( ActionScheduler_ActionClaim $claim ) {
 		/** @var \wpdb $wpdb */
 		global $wpdb;
-		$wpdb->update( $wpdb->actionscheduler_actions, array( 'claim_id' => 0 ), array( 'claim_id' => $claim->get_id() ), array( '%d' ), array( '%d' ) );
+		/**
+		 * Deadlock warning: This function modifies actions to release them from claims that have been processed. Earlier, we used to it in a atomic query, i.e. we would update all actions belonging to a particular claim_id with claim_id = 0.
+		 * While this was functionally correct, it would cause deadlock, since this update query will hold a lock on the claim_id_.. index on the action table.
+		 * This allowed the possibility of a race condition, where the claimer query is also running at the same time, then the claimer query will also try to acquire a lock on the claim_id_.. index, and in this case if claim release query has already progressed to the point of acquiring the lock, but have not updated yet, it would cause a deadlock.
+		 *
+		 * We resolve this by getting all the actions_id that we want to release claim from in a separate query, and then releasing the claim on each of them. This way, our lock is acquired on the action_id index instead of the claim_id index. Note that the lock on claim_id will still be acquired, but it will only when we actually make the update, rather than when we select the actions.
+		 */
+		$action_ids = $wpdb->get_col( $wpdb->prepare( "SELECT action_id FROM {$wpdb->actionscheduler_actions} WHERE claim_id = %d", $claim->get_id() ) );
+		if ( 0 === count( $action_ids ) ) {
+			$wpdb->delete( $wpdb->actionscheduler_claims, array( 'claim_id' => $claim->get_id() ), array( '%d' ) );
+			return;
+		}
+		$action_id_string = implode( ',', array_map( 'absint', $action_ids ) );
+		$row_updates = $wpdb->query( "UPDATE {$wpdb->actionscheduler_actions} SET claim_id = 0 WHERE action_id IN ({$action_id_string})" ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		if ( $row_updates < count( $action_ids ) ) {
+			throw new RuntimeException( __( 'Unable to release actions from claim. Database error.', 'woocommerce' ) );
+		}
 		$wpdb->delete( $wpdb->actionscheduler_claims, array( 'claim_id' => $claim->get_id() ), array( '%d' ) );
 	}
 

--- a/tests/phpunit/jobstore/ActionScheduler_DBStore_Test.php
+++ b/tests/phpunit/jobstore/ActionScheduler_DBStore_Test.php
@@ -385,9 +385,13 @@ class ActionScheduler_DBStore_Test extends AbstractStoreTest {
 		$claim1 = $store->stake_claim();
 
 		$store->release_claim( $claim1 );
+		$this->assertCount( 0, $store->find_actions_by_claim_id( $claim1->get_id() ) );
 
 		$claim2 = $store->stake_claim();
 		$this->assertCount( 3, $claim2->get_actions() );
+		$store->release_claim( $claim2 );
+		$this->assertCount( 0, $store->find_actions_by_claim_id( $claim1->get_id() ) );
+
 	}
 
 	public function test_search() {


### PR DESCRIPTION
Earlier, we used to release claim in a atomic query, i.e. we would update all actions belonging to a particular claim_id with claim_id = 0. While this was functionally correct, it would cause deadlock since the update query will hold a lock on the claim_id_.. index on the action table.

This allowed the possibility of a race condition, if the claimer query is also running at the same time, then the claimer query will also try to acquire a lock on the claim_id_.. index, and in this case, if claim release query has already progressed to the point of acquiring the lock, but have not updated yet, it would cause a deadlock.

We resolve this by getting all the actions_id that we want to release the claim in a separate query and then releasing the claim on each of them. This way, our lock is acquired on the action_id index instead of the claim_id index. Note that the lock on claim_id will still be acquired, but only when we make the update rather than when we select the actions.