### PR TITLE
Calculate timeouts based on total actions

### DIFF
--- a/classes/ActionScheduler_QueueRunner.php
+++ b/classes/ActionScheduler_QueueRunner.php
@@ -139,7 +139,7 @@ class ActionScheduler_QueueRunner extends ActionScheduler_Abstract_QueueRunner {
 		}
 
 		do_action( 'action_scheduler_after_process_queue' );
-		return $processed_actions;
+		return $this->processed_actions_count;
 	}
 
 	/**

--- a/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php
+++ b/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php
@@ -223,9 +223,14 @@ abstract class ActionScheduler_Abstract_QueueRunner extends ActionScheduler_Abst
 	 * @return bool
 	 */
 	protected function time_likely_to_be_exceeded( $processed_actions ) {
+		$execution_time     = $this->get_execution_time();
+		$max_execution_time = $this->get_time_limit();
 
-		$execution_time        = $this->get_execution_time();
-		$max_execution_time    = $this->get_time_limit();
+		// Safety against division by zero errors.
+		if ( 0 === $processed_actions ) {
+			return $execution_time >= $max_execution_time;
+		}
+
 		$time_per_action       = $execution_time / $processed_actions;
 		$estimated_time        = $execution_time + ( $time_per_action * 3 );
 		$likely_to_be_exceeded = $estimated_time > $max_execution_time;


### PR DESCRIPTION
### Description

Before `run()` starts up a new batch, it checks if the timeout is likely to be exceeded based on how many actions have been processed so far in the given amount of time. So if 120 actions are processed in 60minutes, it thinks 2 seconds per action. It'll decide if it's safe to do another batch based on that. This is sound.

But after each action is processed inside of `do_batch()`, it does the same calculation. Except it tells the logic how many actions that batch itself has processed. So if we're on the 1st action the logic will see that 1 action has been processed in the given 60seconds. Clearly, a much different result and it will determine to bail inside of `do_batch()` far before it wants to bail inside of `run()`.

As a result, typically once you get towards the end of a queue's life, `run()` will keep creating new batches/claims but after the first action in the claim is processed it will bail and unclaim. This process can repeat A LOT before `run()` also decides it is time to bail.

This means there are tons of claim and unclaim queries flying about, heavily increasing the odds of deadlocks currently. So when things get really mess and the unclaim query starts failing, you can end up with 100s of different claim_ids that are each holding onto their own set of actions. So the system ends up blocked up until the cleanup is triggered once the claims grow stale. Overall, not great.

Preventing the deadlocks altogether is another issue, but here we help avoid it and just make the logic smarter so that if do_batch() aborts due to resources/time that means run() will also abort rather than starting off the vicious cycle.

### Testing

Can really showcase the issue if you set batch size to 10, set timeout to 120seconds, and register a few thousand dummy actions that will complete immediately. Then watch the queue process, and note that after a few batches in, `do_batch()` will start to abort after the 1st action whilst `run()` will just keep looping and making new claims.

### Considerations

This is going to result in queues running closer to the configured timeout limit. That's ideal, but incorrectly configured sites may find that problematic. The effects are particularly more notable on environments with larger time limits that are set to process multiple batches per queue/run (which I would wager is not super common).

### Changelog

> Fix - Prevent batches from ending prematurely, which can result in additional unnecessary claims.