### PR TITLE
Add pre filters during action registration

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -98,6 +98,22 @@ function as_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, 
 		return 0;
 	}
 
+	/**
+	 * Provides an opportunity to short-circuit the default process for enqueuing recurring
+	 * actions.
+	 *
+	 * Returning a value other than null from the filter will short-circuit the normal
+	 * process. The expectation in such a scenario is that callbacks will return an integer
+	 * representing the scheduled action ID (scheduled using some alternative process) or else
+	 * zero.
+	 *
+	 * @param int|null $pre_option          The value to return instead of the option value.
+	 * @param int      $timestamp           When the action will run.
+	 * @param int      $interval_in_seconds How long to wait between runs.
+	 * @param string   $hook                Action hook.
+	 * @param array    $args                Action arguments.
+	 * @param string   $group               Action group.
+	 */
 	$pre = apply_filters( 'pre_as_schedule_recurring_action', null, $timestamp, $interval_in_seconds, $hook, $args, $group );
 	if ( null !== $pre ) {
 		return is_int( $pre ) ? $pre : 0;
@@ -135,6 +151,22 @@ function as_schedule_cron_action( $timestamp, $schedule, $hook, $args = array(),
 		return 0;
 	}
 
+	/**
+	 * Provides an opportunity to short-circuit the default process for enqueuing cron
+	 * actions.
+	 *
+	 * Returning a value other than null from the filter will short-circuit the normal
+	 * process. The expectation in such a scenario is that callbacks will return an integer
+	 * representing the scheduled action ID (scheduled using some alternative process) or else
+	 * zero.
+	 *
+	 * @param int|null $pre_option The value to return instead of the option value.
+	 * @param int      $timestamp  When the action will run.
+	 * @param string   $schedule   Cron-like schedule string.
+	 * @param string   $hook       Action hook.
+	 * @param array    $args       Action arguments.
+	 * @param string   $group      Action group.
+	 */
 	$pre = apply_filters( 'pre_as_schedule_cron_action', null, $timestamp, $schedule, $hook, $args, $group );
 	if ( null !== $pre ) {
 		return is_int( $pre ) ? $pre : 0;

--- a/functions.php
+++ b/functions.php
@@ -20,6 +20,20 @@ function as_enqueue_async_action( $hook, $args = array(), $group = '', $unique =
 		return 0;
 	}
 
+	/**
+	 * Provides an opportunity to short-circuit the default process for enqueuing async
+	 * actions.
+	 *
+	 * Returning a value other than null from the filter will short-circuit the normal
+	 * process. The expectation in such a scenario is that callbacks will return an integer
+	 * representing the enqueued action ID (enqueued using some alternative process) or else
+	 * zero.
+	 *
+	 * @param int|null $pre_option The value to return instead of the option value.
+	 * @param string   $hook       Action hook.
+	 * @param array    $args       Action arguments.
+	 * @param string   $group      Action group.
+	 */
 	$pre = apply_filters( 'pre_as_enqueue_async_action', null, $hook, $args, $group );
 	if ( null !== $pre ) {
 		return is_int( $pre ) ? $pre : 0;
@@ -44,6 +58,21 @@ function as_schedule_single_action( $timestamp, $hook, $args = array(), $group =
 		return 0;
 	}
 
+	/**
+	 * Provides an opportunity to short-circuit the default process for enqueuing single
+	 * actions.
+	 *
+	 * Returning a value other than null from the filter will short-circuit the normal
+	 * process. The expectation in such a scenario is that callbacks will return an integer
+	 * representing the scheduled action ID (scheduled using some alternative process) or else
+	 * zero.
+	 *
+	 * @param int|null $pre_option The value to return instead of the option value.
+	 * @param int      $timestamp  When the action will run.
+	 * @param string   $hook       Action hook.
+	 * @param array    $args       Action arguments.
+	 * @param string   $group      Action group.
+	 */
 	$pre = apply_filters( 'pre_as_schedule_single_action', null, $timestamp, $hook, $args, $group );
 	if ( null !== $pre ) {
 		return is_int( $pre ) ? $pre : 0;

--- a/functions.php
+++ b/functions.php
@@ -19,6 +19,12 @@ function as_enqueue_async_action( $hook, $args = array(), $group = '', $unique =
 	if ( ! ActionScheduler::is_initialized( __FUNCTION__ ) ) {
 		return 0;
 	}
+
+	$pre = apply_filters( 'pre_as_enqueue_async_action', null, $hook, $args, $group );
+	if ( null !== $pre ) {
+		return is_int( $pre ) ? $pre : 0;
+	}
+
 	return ActionScheduler::factory()->async_unique( $hook, $args, $group, $unique );
 }
 
@@ -37,6 +43,12 @@ function as_schedule_single_action( $timestamp, $hook, $args = array(), $group =
 	if ( ! ActionScheduler::is_initialized( __FUNCTION__ ) ) {
 		return 0;
 	}
+
+	$pre = apply_filters( 'pre_as_schedule_single_action', null, $timestamp, $hook, $args, $group );
+	if ( null !== $pre ) {
+		return is_int( $pre ) ? $pre : 0;
+	}
+
 	return ActionScheduler::factory()->single_unique( $hook, $args, $timestamp, $group, $unique );
 }
 
@@ -56,6 +68,12 @@ function as_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, 
 	if ( ! ActionScheduler::is_initialized( __FUNCTION__ ) ) {
 		return 0;
 	}
+
+	$pre = apply_filters( 'pre_as_schedule_recurring_action', null, $timestamp, $interval_in_seconds, $hook, $args, $group );
+	if ( null !== $pre ) {
+		return is_int( $pre ) ? $pre : 0;
+	}
+
 	return ActionScheduler::factory()->recurring_unique( $hook, $args, $timestamp, $interval_in_seconds, $group, $unique );
 }
 
@@ -87,6 +105,12 @@ function as_schedule_cron_action( $timestamp, $schedule, $hook, $args = array(),
 	if ( ! ActionScheduler::is_initialized( __FUNCTION__ ) ) {
 		return 0;
 	}
+
+	$pre = apply_filters( 'pre_as_schedule_cron_action', null, $timestamp, $schedule, $hook, $args, $group );
+	if ( null !== $pre ) {
+		return is_int( $pre ) ? $pre : 0;
+	}
+
 	return ActionScheduler::factory()->cron_unique( $hook, $args, $timestamp, $schedule, $group, $unique );
 }
 


### PR DESCRIPTION
Add some filters that will allow interjecting yourself into the registration of certain actions.

Main use case is that this will give a level of control over to sites to "nerf" certain plugins that are registering actions they would like to handle differently. For example, the new filter would allow a site to just handle `wc-admin_import_customers` inline rather than having it schedule an action.

Kind of mirror-ed from core's cron api: https://github.com/WordPress/WordPress/blob/6b06c73cd7b8af0e0b92a19b0bad370a5747750c/wp-includes/cron.php#L267-L282, except keeping the api the same and ensuring the filters are going to return under the same contract that is currently in place. Also unlike core, we don't need the `pre_` filters under all the public methods because AS already provides a mean for registering a custom data store.

### Changelog

> Dev - Added a set of action hooks that can be used to short circuit the scheduling process.