### PR TITLE
Async scheduling

### DIFF
--- a/classes/ActionScheduler_ActionFactory.php
+++ b/classes/ActionScheduler_ActionFactory.php
@@ -52,12 +52,9 @@ class ActionScheduler_ActionFactory {
 	/**
 	 * Enqueue an action to run one time, as soon as possible (rather a specific scheduled time).
 	 *
-	 * This method creates a new action with the NULLSchedule. This schedule maps to a MySQL datetime string of
-	 * 0000-00-00 00:00:00. This is done to create a psuedo "async action" type that is fully backward compatible.
-	 * Existing queries to claim actions claim by date, meaning actions scheduled for 0000-00-00 00:00:00 will
-	 * always be claimed prior to actions scheduled for a specific date. This makes sure that any async action is
-	 * given priority in queue processing. This has the added advantage of making sure async actions can be
-	 * claimed by both the existing WP Cron and WP CLI runners, as well as a new async request runner.
+	 * This method creates a new action using the NullSchedule. In practice, this results in an action scheduled to
+	 * execute "now". Therefore, it will generally run as soon as possible but is not prioritized ahead of other actions
+	 * that are already past-due.
 	 *
 	 * @param string $hook The hook to trigger when this action runs.
 	 * @param array  $args Args to pass when the hook is triggered.

--- a/classes/abstracts/ActionScheduler_Store.php
+++ b/classes/abstracts/ActionScheduler_Store.php
@@ -257,7 +257,7 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 	protected function get_scheduled_date_string( ActionScheduler_Action $action, DateTime $scheduled_date = NULL ) {
 		$next = null === $scheduled_date ? $action->get_schedule()->get_date() : $scheduled_date;
 		if ( ! $next ) {
-			return '0000-00-00 00:00:00';
+			$next = date_create();
 		}
 		$next->setTimezone( new DateTimeZone( 'UTC' ) );
 
@@ -274,7 +274,7 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 	protected function get_scheduled_date_string_local( ActionScheduler_Action $action, DateTime $scheduled_date = NULL ) {
 		$next = null === $scheduled_date ? $action->get_schedule()->get_date() : $scheduled_date;
 		if ( ! $next ) {
-			return '0000-00-00 00:00:00';
+			$next = date_create();
 		}
 
 		ActionScheduler_TimezoneHelper::set_local_timezone( $next );


### PR DESCRIPTION
Currently, async tasks are scheduled for "year zero", and so they will always be claimed and processed even ahead of regular single actions that are A) older B) past-due. This change rectifies this by storing async actions with a scheduled date of 'now'.

Closes #895.

---

### Scenario

One of the problems this solves is an issue where the number of async actions being added to the queue matches or exceeds the claim size—which potentially stops all other actions from being processed, even if they become overdue. For example, consider a queue looking something like this (ordered by oldest waiting action):

| ID | Type | Scheduled date | Note |
| --- | --- | --- | --- |
| 103 | Single | `2023-06-30 20:40:00` | Over-due |
| 102 | Single | `2023-06-30 23:05:00` | Over-due |
| 101 | Single | `2023-07-01 09:00:00` | Pending |
| 100 | Single | `2023-07-02 12:30:00` | Pending |

Pretend the current time is `2023-07-01 00:00:00` ... we already have two single actions that are overdue. If immediately before the next batch is claimed, four more async actions are added, the queue (again ordered by longest waiting) will look like this:

| ID | Type | Scheduled date | Note |
| --- | --- | --- | --- |
| 107 | Async | `0000-00-00 00:00:00` | Over-due |
| 106 | Async | `0000-00-00 00:00:00` | Over-due |
| 105 | Async | `0000-00-00 00:00:00` | Over-due |
| 104 | Async | `0000-00-00 00:00:00` | Over-due |
| 103 | Single | `2023-06-30 20:40:00` | Over-due |
| 102 | Single | `2023-06-30 23:05:00` | Over-due |
| 101 | Single | `2023-07-01 09:00:00` | Pending |
| 100 | Single | `2023-07-02 12:30:00` | Pending |

Those new async actions have leapt to the top of the queue. If the claim size is 4, and a steady flow of new async actions is incoming, there is an ever-increasing chance of those over-due single actions becoming even more over-due ... and other pending single actions will soon join them.

### Rationale

In the [API reference](https://actionscheduler.org/api/) we state that `as_enqueue_async_action()` will enqueue an action to run one time, **as soon as possible**. However, 'as soon as possible' is not a strict guarantee–we are not stating that they will run ahead of any other waiting/overdue actions—and I would suggest that it is not a given that they should be prioritized ahead of regular scheduled actions.

Additionally, if we also move ahead with and merge https://github.com/woocommerce/action-scheduler/pull/897, it will be possible to quite easily write a snippet that 'undoes' this (should it be problematic for anyone).