### PR TITLE
Include PHP 8.2 in the test matrix.

### DIFF
--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         # We test against the earliest and latest PHP versions for each major supported version.
-        php: [ '5.6', '7.0', '7.4', '8.0' ]
+        php: [ '5.6', '7.0', '7.4', '8.0', '8.2' ]
         wp: [ '5.2', '5.3', '5.4', '5.5', '5.6', 'latest' ]
         multisite: [ '0', '1' ]
         exclude:


### PR DESCRIPTION
PHP 8.2 was released in December 2022. This change adds it to the test matrix so we can more readily detect problems when Action Scheduler is running against that version.