### PR TITLE
Do not process an action if it cannot be set to `in-progress`

### DIFF
--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -1019,7 +1019,9 @@ AND `group_id` = %d
 		$sql = $wpdb->prepare( $sql, self::STATUS_RUNNING, current_time( 'mysql', true ), current_time( 'mysql' ), $action_id ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-		if ( ! $wpdb->query( $sql ) ) {
+		$status_updated = $wpdb->query( $sql );
+
+		if ( ! $status_updated ) {
 			throw new Exception(
 				sprintf(
 					/* translators: 1: action ID. 2: status slug. */

--- a/classes/data-stores/ActionScheduler_wpPostStore.php
+++ b/classes/data-stores/ActionScheduler_wpPostStore.php
@@ -949,7 +949,7 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 		global $wpdb;
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-		if ( ! $wpdb->query(
+		$status_updated = $wpdb->query(
 			$wpdb->prepare(
 				"UPDATE {$wpdb->posts} SET menu_order = menu_order+1, post_status=%s, post_modified_gmt = %s, post_modified = %s WHERE ID = %d AND post_type = %s",
 				self::STATUS_RUNNING,
@@ -958,7 +958,9 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 				$action_id,
 				self::POST_TYPE
 			)
-		) ) {
+		);
+
+		if ( ! $status_updated ) {
 			throw new Exception(
 				sprintf(
 					/* translators: 1: action ID. 2: status slug. */

--- a/classes/data-stores/ActionScheduler_wpPostStore.php
+++ b/classes/data-stores/ActionScheduler_wpPostStore.php
@@ -936,6 +936,8 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 	/**
 	 * Log Execution.
 	 *
+	 * @throws Exception If the action status cannot be updated to self::STATUS_RUNNING ('in-progress').
+	 *
 	 * @param string $action_id Action ID.
 	 */
 	public function log_execution( $action_id ) {
@@ -947,7 +949,7 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 		global $wpdb;
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-		$wpdb->query(
+		if ( ! $wpdb->query(
 			$wpdb->prepare(
 				"UPDATE {$wpdb->posts} SET menu_order = menu_order+1, post_status=%s, post_modified_gmt = %s, post_modified = %s WHERE ID = %d AND post_type = %s",
 				self::STATUS_RUNNING,
@@ -956,7 +958,16 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 				$action_id,
 				self::POST_TYPE
 			)
-		);
+		) ) {
+			throw new Exception(
+				sprintf(
+					/* translators: 1: action ID. 2: status slug. */
+					__( 'Unable to update the status of action %1$d to %2$s.', 'action-scheduler' ),
+					$action_id,
+					self::STATUS_RUNNING
+				)
+			);
+		}
 	}
 
 	/**


### PR DESCRIPTION
Immediately before we begin to process an action, we try to change its status to running ('in-progress') [[1]](https://github.com/woocommerce/action-scheduler/blob/3.5.4/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php#L64) [[2]](https://github.com/woocommerce/action-scheduler/blob/3.5.4/classes/data-stores/ActionScheduler_DBStore.php#L1012-L1019). However, we do not check that the status update succeeded.

This is potentially risky, as identified in the linked issue. In this change we add a check to ensure the status update was successful, throwing an exception if it is unsuccessful (this exception is handled by existing logic [[3]](https://github.com/woocommerce/action-scheduler/blob/3.5.4/classes/data-stores/ActionScheduler_DBStore.php#L1012-L1019) which will then mark the action as having failed).

Closes #896.

### Changelog

> Fix - Guard against problems when an action cannot be set to 'in-progress'.

### Testing instructions

We can optionally test to ensure that, under 'normal conditions', things still work as previously (ie, an action is still successfully set to 'in-progress' when it is run). Start by adding the following snippet to a suitable location, such as `wp-content/mu-plugins/pr-904.php`:

```php
<?php

add_action( 'init', function () {
	if ( as_has_scheduled_action( 'test_pr_904' ) ) {
		return;
	}

	as_schedule_single_action( time() + HOUR_IN_SECONDS, 'test_pr_904' );
} );

add_action( 'test_pr_904', function () {
	sleep( 20 );
} );
```

Now visit **Tools ▸ Scheduled Actions ▸ Pending** and you should see our test action (if you have a *lot* of pending actions, you may need to perform a search for `test_or_904` to surface it):

<img width="449" alt="pending" src="https://user-images.githubusercontent.com/3594411/215824662-261727a6-3536-4699-a1c2-7ac2ee31571e.png">

Run it manually (ie, hover over it and click on the run link) then, *as quickly as you can,* open **Tools ▸ Scheduled Actions** in a new tab. There should be an `In-Progress` tab/link and if you open this you should see the test action is running:

<img width="493" alt="running" src="https://user-images.githubusercontent.com/3594411/215825324-f36cbcdf-012b-4eda-97c6-76a6354aae8c.png">

After another 20 seconds have elapsed, that action should non longer be running and will be marked as complete.

☝🏽 To clarify, the goal of these testing instructions is imply to ensure normal operations are not impeded. 