### PR TITLE
add CLI exclude-group filter

### DIFF
--- a/classes/WP_CLI/ActionScheduler_WPCLI_Scheduler_command.php
+++ b/classes/WP_CLI/ActionScheduler_WPCLI_Scheduler_command.php
@@ -56,7 +56,7 @@ class ActionScheduler_WPCLI_Scheduler_command extends WP_CLI_Command {
 	 * : Only run actions from the specified group. Omitting this option runs actions from all groups.
 	 *
 	 * [--exclude-group=<group>]
-	 * : Run actions from all groups except the specified group.
+	 * : Run actions from all groups except the specified group. This option is ignored when `--group` is used.
 	 *
 	 * [--free-memory-on=<count>]
 	 * : The number of actions to process between freeing memory. 0 disables freeing memory. Default 50.

--- a/classes/WP_CLI/ActionScheduler_WPCLI_Scheduler_command.php
+++ b/classes/WP_CLI/ActionScheduler_WPCLI_Scheduler_command.php
@@ -55,6 +55,9 @@ class ActionScheduler_WPCLI_Scheduler_command extends WP_CLI_Command {
 	 * [--group=<group>]
 	 * : Only run actions from the specified group. Omitting this option runs actions from all groups.
 	 *
+	 * [--exclude-group=<group>]
+	 * : Run actions from all groups except the specified group.
+	 *
 	 * [--free-memory-on=<count>]
 	 * : The number of actions to process between freeing memory. 0 disables freeing memory. Default 50.
 	 *
@@ -72,15 +75,16 @@ class ActionScheduler_WPCLI_Scheduler_command extends WP_CLI_Command {
 	 */
 	public function run( $args, $assoc_args ) {
 		// Handle passed arguments.
-		$batch   = absint( \WP_CLI\Utils\get_flag_value( $assoc_args, 'batch-size', 100 ) );
-		$batches = absint( \WP_CLI\Utils\get_flag_value( $assoc_args, 'batches', 0 ) );
-		$clean   = absint( \WP_CLI\Utils\get_flag_value( $assoc_args, 'cleanup-batch-size', $batch ) );
-		$hooks   = explode( ',', WP_CLI\Utils\get_flag_value( $assoc_args, 'hooks', '' ) );
-		$hooks   = array_filter( array_map( 'trim', $hooks ) );
-		$group   = \WP_CLI\Utils\get_flag_value( $assoc_args, 'group', '' );
-		$free_on = \WP_CLI\Utils\get_flag_value( $assoc_args, 'free-memory-on', 50 );
-		$sleep   = \WP_CLI\Utils\get_flag_value( $assoc_args, 'pause', 0 );
-		$force   = \WP_CLI\Utils\get_flag_value( $assoc_args, 'force', false );
+		$batch         = absint( \WP_CLI\Utils\get_flag_value( $assoc_args, 'batch-size', 100 ) );
+		$batches       = absint( \WP_CLI\Utils\get_flag_value( $assoc_args, 'batches', 0 ) );
+		$clean         = absint( \WP_CLI\Utils\get_flag_value( $assoc_args, 'cleanup-batch-size', $batch ) );
+		$hooks         = explode( ',', WP_CLI\Utils\get_flag_value( $assoc_args, 'hooks', '' ) );
+		$hooks         = array_filter( array_map( 'trim', $hooks ) );
+		$group         = \WP_CLI\Utils\get_flag_value( $assoc_args, 'group', '' );
+		$exclude_group = \WP_CLI\Utils\get_flag_value( $assoc_args, 'exclude-group', '' );
+		$free_on       = \WP_CLI\Utils\get_flag_value( $assoc_args, 'free-memory-on', 50 );
+		$sleep         = \WP_CLI\Utils\get_flag_value( $assoc_args, 'pause', 0 );
+		$force         = \WP_CLI\Utils\get_flag_value( $assoc_args, 'force', false );
 
 		ActionScheduler_DataController::set_free_ticks( $free_on );
 		ActionScheduler_DataController::set_sleep_time( $sleep );
@@ -88,6 +92,11 @@ class ActionScheduler_WPCLI_Scheduler_command extends WP_CLI_Command {
 		$batches_completed = 0;
 		$actions_completed = 0;
 		$unlimited         = $batches === 0;
+		if ( is_callable( [ ActionScheduler::store(), 'set_claim_filter' ] ) ) {
+			if ( ! empty( $exclude_group ) ) {
+				ActionScheduler::store()->set_claim_filter('exclude-group', $exclude_group );
+			}
+		}
 
 		try {
 			// Custom queue cleaner instance.


### PR DESCRIPTION
Closes #736 

This PR is an alternative to #784. #784 is a great solution if adding group exclusion were the only filter we were looking to add to the queue runners. However, we are considering adding:
- hook exclusion
- priorities
- retries
- settings screen for managing the async and cron runners

#784 works around the limitation that we cannot modify the `claim_actions` function definition by embedding flags in existing parameters. While that works for one flag/parameter it isn't practical for adding several. This PR avoid that by adding a new function to the base tables DB store.

It also lays the groundwork for adding additional filters. For example, excluding hooks will only require a few additional lines of code. Secondly, all added filters could be implemented on the async and cron runners through a settings screen without using similar parameter tampering.

### Testing

- Disable the default runners.
- I used this hook to create test actions:

```
add_action( 'init', function() {
    $groups = [
      'automatewoo',
      'woocommerce',
      'woocommerce-admin',
      'internal',
    ];
    $hooks = [
      'alpha',
      'beta',
      'gamma',
      'delta',
    ];
    $group = rand( 0, 3 );
    $hook = rand( 0, 3 );
    $unique = rand( 1, 9 );

    as_schedule_single_action(
        time() + MINUTE_IN_SECONDS,
        'init_' . $hooks[ $hook ] . $unique,
        [],
        'test-' . $groups[ $group ]
    );
}, 99 );
```
- Allow some time for actions to be created
- Then ran the following a few minutes apart
```
wp action-scheduler run --group=alpha
// check that all pending past due alpha actions ran
wp action-scheduler run --exclude-group=beta
// check that beta is the only group with pending past due actions
```

---

### Changelog

> Add - Add support for excluding group(s) when using the WP CLI queue runner.