### PR TITLE
add CLI clean command

### DIFF
--- a/classes/ActionScheduler_QueueCleaner.php
+++ b/classes/ActionScheduler_QueueCleaner.php
@@ -65,12 +65,12 @@ class ActionScheduler_QueueCleaner {
 	 * Delete selected actions limited by status and date.
 	 *
 	 * @param string[] $statuses_to_purge List of action statuses to purge. Defaults to canceled, complete.
-	 * @param DateTime|null $cutoff_date Date limit for selecting actions. Defaults to 31 days.
+	 * @param DateTime $cutoff_date Date limit for selecting actions. Defaults to 31 days ago.
 	 * @param int|null $batch_size Maximum number of actions per status to delete. Defaults to 20.
 	 * @param string $context Calling process context. Defaults to `old`.
 	 * @return array Actions deleted.
 	 */
-	public function clean_actions( array $statuses_to_purge = [], DateTime $cutoff_date, int $batch_size = null, string $context = 'old' ) {
+	public function clean_actions( array $statuses_to_purge, DateTime $cutoff_date, int $batch_size = null, string $context = 'old' ) {
 		$batch_size = $batch_size !== null ? $batch_size : $this->batch_size;
 		$cutoff     = $cutoff_date !== null ? $cutoff_date : as_get_datetime_object( $this->month_in_seconds . ' seconds ago' );
 		$lifespan   = time() - $cutoff->getTimestamp();

--- a/classes/ActionScheduler_QueueCleaner.php
+++ b/classes/ActionScheduler_QueueCleaner.php
@@ -70,7 +70,7 @@ class ActionScheduler_QueueCleaner {
 	 * @param string $context Calling process context. Defaults to `old`.
 	 * @return array Actions deleted.
 	 */
-	public function clean_actions( array $statuses_to_purge, DateTime $cutoff_date, int $batch_size = null, string $context = 'old' ) {
+	public function clean_actions( array $statuses_to_purge, DateTime $cutoff_date, $batch_size = null, $context = 'old' ) {
 		$batch_size = $batch_size !== null ? $batch_size : $this->batch_size;
 		$cutoff     = $cutoff_date !== null ? $cutoff_date : as_get_datetime_object( $this->month_in_seconds . ' seconds ago' );
 		$lifespan   = time() - $cutoff->getTimestamp();

--- a/classes/ActionScheduler_QueueCleaner.php
+++ b/classes/ActionScheduler_QueueCleaner.php
@@ -70,7 +70,7 @@ class ActionScheduler_QueueCleaner {
 	 * @param string $context Calling process context. Defaults to `old`.
 	 * @return array Actions deleted.
 	 */
-	public function clean_actions( array $statuses_to_purge = [], DateTime $cutoff_date = null, int $batch_size = null, string $context = 'old' ) {
+	public function clean_actions( array $statuses_to_purge = [], DateTime $cutoff_date = NULL, int $batch_size = NULL, string $context = 'old' ) {
 		$batch_size = $batch_size !== null ? $batch_size : $this->batch_size;
 		$cutoff     = $cutoff_date !== null ? $cutoff_date : as_get_datetime_object( $this->month_in_seconds . ' seconds ago' );
 		$lifespan   = time() - $cutoff->getTimestamp();
@@ -100,7 +100,7 @@ class ActionScheduler_QueueCleaner {
 	 * @param string $context Context of the delete request.
 	 * @return array Deleted action IDs.
 	 */
-	private function delete_actions( array $actions_to_delete, int $lifespan = null, string $context = 'old' ) {
+	private function delete_actions( array $actions_to_delete, int $lifespan = NULL, string $context = 'old' ) {
 		$deleted_actions = [];
 		if ( $lifespan === null ) {
 			$lifespan = $this->month_in_seconds;

--- a/classes/ActionScheduler_QueueCleaner.php
+++ b/classes/ActionScheduler_QueueCleaner.php
@@ -100,7 +100,7 @@ class ActionScheduler_QueueCleaner {
 	 * @param string $context Context of the delete request.
 	 * @return array Deleted action IDs.
 	 */
-	private function delete_actions( array $actions_to_delete, int $lifespan = NULL, string $context = 'old' ) {
+	private function delete_actions( array $actions_to_delete, $lifespan = null, $context = 'old' ) {
 		$deleted_actions = [];
 		if ( $lifespan === null ) {
 			$lifespan = $this->month_in_seconds;

--- a/classes/ActionScheduler_QueueCleaner.php
+++ b/classes/ActionScheduler_QueueCleaner.php
@@ -70,7 +70,7 @@ class ActionScheduler_QueueCleaner {
 	 * @param string $context Calling process context. Defaults to `old`.
 	 * @return array Actions deleted.
 	 */
-	public function clean_actions( array $statuses_to_purge = [], DateTime $cutoff_date = NULL, int $batch_size = NULL, string $context = 'old' ) {
+	public function clean_actions( array $statuses_to_purge = [], DateTime $cutoff_date, int $batch_size = null, string $context = 'old' ) {
 		$batch_size = $batch_size !== null ? $batch_size : $this->batch_size;
 		$cutoff     = $cutoff_date !== null ? $cutoff_date : as_get_datetime_object( $this->month_in_seconds . ' seconds ago' );
 		$lifespan   = time() - $cutoff->getTimestamp();

--- a/classes/ActionScheduler_QueueCleaner.php
+++ b/classes/ActionScheduler_QueueCleaner.php
@@ -19,6 +19,14 @@ class ActionScheduler_QueueCleaner {
 	private $month_in_seconds = 2678400;
 
 	/**
+	 * @var string[] Default list of statuses purged by the cleaner process.
+	 */
+	private $default_statuses_to_purge = [
+		ActionScheduler_Store::STATUS_COMPLETE,
+		ActionScheduler_Store::STATUS_CANCELED,
+	];
+
+	/**
 	 * ActionScheduler_QueueCleaner constructor.
 	 *
 	 * @param ActionScheduler_Store $store      The store instance.
@@ -29,46 +37,97 @@ class ActionScheduler_QueueCleaner {
 		$this->batch_size = $batch_size;
 	}
 
+	/**
+	 * Default queue cleaner process used by queue runner.
+	 *
+	 * @return void
+	 */
 	public function delete_old_actions() {
+		/**
+		 * Filter the minimum scheduled date age for action deletion.
+		 *
+		 * @param int $retention_period Minimum scheduled age in seconds of the actions to be deleted.
+		 */
 		$lifespan = apply_filters( 'action_scheduler_retention_period', $this->month_in_seconds );
-		$cutoff = as_get_datetime_object($lifespan.' seconds ago');
+		$cutoff = as_get_datetime_object( $lifespan . ' seconds ago' );
 
-		$statuses_to_purge = array(
-			ActionScheduler_Store::STATUS_COMPLETE,
-			ActionScheduler_Store::STATUS_CANCELED,
-		);
+		/**
+		 * Filter the statuses when cleaning the queue.
+		 *
+		 * @param string[] $default_statuses_to_purge Action statuses to clean.
+		 */
+		$statuses_to_purge = (array) apply_filters( 'action_scheduler_default_cleaner_statuses', $this->default_statuses_to_purge );
 
+		$this->clean_actions( $statuses_to_purge, $cutoff, $this->get_batch_size() );
+	}
+
+	/**
+	 * Delete selected actions limited by status and date.
+	 *
+	 * @param string[] $statuses_to_purge List of action statuses to purge. Defaults to canceled, complete.
+	 * @param DateTime|null $cutoff_date Date limit for selecting actions. Defaults to 31 days.
+	 * @param int|null $batch_size Maximum number of actions per status to delete. Defaults to 20.
+	 * @param string $context Calling process context. Defaults to `old`.
+	 * @return array Actions deleted.
+	 */
+	public function clean_actions( array $statuses_to_purge = [], DateTime $cutoff_date = null, int $batch_size = null, string $context = 'old' ) {
+		$batch_size = $batch_size !== null ? $batch_size : $this->batch_size;
+		$cutoff     = $cutoff_date !== null ? $cutoff_date : as_get_datetime_object( $this->month_in_seconds . ' seconds ago' );
+		$lifespan   = time() - $cutoff->getTimestamp();
+		if ( empty( $statuses_to_purge ) ) {
+			$statuses_to_purge = $this->default_statuses_to_purge;
+		}
+
+		$deleted_actions = [];
 		foreach ( $statuses_to_purge as $status ) {
 			$actions_to_delete = $this->store->query_actions( array(
 				'status'           => $status,
 				'modified'         => $cutoff,
 				'modified_compare' => '<=',
-				'per_page'         => $this->get_batch_size(),
+				'per_page'         => $batch_size,
 				'orderby'          => 'none',
 			) );
 
-			foreach ( $actions_to_delete as $action_id ) {
-				try {
-					$this->store->delete_action( $action_id );
-				} catch ( Exception $e ) {
+			$deleted_actions = array_merge( $deleted_actions, $this->delete_actions( $actions_to_delete, $lifespan, $context ) );
+		}
 
-					/**
-					 * Notify 3rd party code of exceptions when deleting a completed action older than the retention period
-					 *
-					 * This hook provides a way for 3rd party code to log or otherwise handle exceptions relating to their
-					 * actions.
-					 *
-					 * @since 2.0.0
-					 *
-					 * @param int $action_id The scheduled actions ID in the data store
-					 * @param Exception $e The exception thrown when attempting to delete the action from the data store
-					 * @param int $lifespan The retention period, in seconds, for old actions
-					 * @param int $count_of_actions_to_delete The number of old actions being deleted in this batch
-					 */
-					do_action( 'action_scheduler_failed_old_action_deletion', $action_id, $e, $lifespan, count( $actions_to_delete ) );
-				}
+		return $deleted_actions;
+	}
+
+	/**
+	 * @param int[] $actions_to_delete List of action IDs to delete.
+	 * @param int $lifespan Minimum scheduled age in seconds of the actions being deleted.
+	 * @param string $context Context of the delete request.
+	 * @return array Deleted action IDs.
+	 */
+	private function delete_actions( array $actions_to_delete, int $lifespan = null, string $context = 'old' ) {
+		$deleted_actions = [];
+		if ( $lifespan === null ) {
+			$lifespan = $this->month_in_seconds;
+		}
+
+		foreach ( $actions_to_delete as $action_id ) {
+			try {
+				$this->store->delete_action( $action_id );
+				$deleted_actions[] = $action_id;
+			} catch ( Exception $e ) {
+				/**
+				 * Notify 3rd party code of exceptions when deleting a completed action older than the retention period
+				 *
+				 * This hook provides a way for 3rd party code to log or otherwise handle exceptions relating to their
+				 * actions.
+				 *
+				 * @param int $action_id The scheduled actions ID in the data store
+				 * @param Exception $e The exception thrown when attempting to delete the action from the data store
+				 * @param int $lifespan The retention period, in seconds, for old actions
+				 * @param int $count_of_actions_to_delete The number of old actions being deleted in this batch
+				 * @since 2.0.0
+				 *
+				 */
+				do_action( "action_scheduler_failed_{$context}_action_deletion", $action_id, $e, $lifespan, count( $actions_to_delete ) );
 			}
 		}
+		return $deleted_actions;
 	}
 
 	/**

--- a/classes/WP_CLI/ActionScheduler_WPCLI_Clean_Command.php
+++ b/classes/WP_CLI/ActionScheduler_WPCLI_Clean_Command.php
@@ -19,7 +19,7 @@ class ActionScheduler_WPCLI_Clean_Command extends WP_CLI_Command {
 	 * : Only clean actions with the specified status. Defaults to Canceled, Completed. Define multiple statuses as a comma separated string (without spaces), e.g. `--status=complete,failed,canceled`
 	 *
 	 * [--before=<datestring>]
-	 * : Only delete actions with scheduled date older than this. Defaults to 31 days. e.g `--before='-7 days'`, `--before='02-Feb-2020 20:20:20'`
+	 * : Only delete actions with scheduled date older than this. Defaults to 31 days. e.g `--before='7 days ago'`, `--before='02-Feb-2020 20:20:20'`
 	 *
 	 * [--pause=<seconds>]
 	 * : The number of seconds to pause between batches. Default no pause.

--- a/classes/WP_CLI/ActionScheduler_WPCLI_Clean_Command.php
+++ b/classes/WP_CLI/ActionScheduler_WPCLI_Clean_Command.php
@@ -1,0 +1,125 @@
+<?php
+
+/**
+ * Commands for Action Scheduler.
+ */
+class ActionScheduler_WPCLI_Clean_Command extends WP_CLI_Command {
+	/**
+	 * Run the Action Scheduler Queue Cleaner
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--batch-size=<size>]
+	 * : The maximum number of actions to delete per batch. Defaults to 20.
+	 *
+	 * [--batches=<size>]
+	 * : Limit execution to a number of batches. Defaults to 0, meaning batches will continue all eligible actions are deleted.
+	 *
+	 * [--status=<status>]
+	 * : Only clean actions with the specified status. Defaults to Canceled, Completed. Define multiple statuses as a comma separated string (without spaces), e.g. `--status=complete,failed,canceled`
+	 *
+	 * [--before=<datestring>]
+	 * : Only delete actions with scheduled date older than this. Defaults to 31 days. e.g `--before='-7 days'`, `--before='02-Feb-2020 20:20:20'`
+	 *
+	 * [--pause=<seconds>]
+	 * : The number of seconds to pause between batches. Default no pause.
+	 *
+	 * @param array $args Positional arguments.
+	 * @param array $assoc_args Keyed arguments.
+	 * @throws \WP_CLI\ExitException When an error occurs.
+	 *
+	 * @subcommand clean
+	 */
+	public function clean( $args, $assoc_args ) {
+		// Handle passed arguments.
+		$batch   = absint( \WP_CLI\Utils\get_flag_value( $assoc_args, 'batch-size', 20 ) );
+		$batches = absint( \WP_CLI\Utils\get_flag_value( $assoc_args, 'batches', 0 ) );
+		$status  = explode( ',', WP_CLI\Utils\get_flag_value( $assoc_args, 'status', '' ) );
+		$status  = array_filter( array_map( 'trim', $status ) );
+		$before  = \WP_CLI\Utils\get_flag_value( $assoc_args, 'before', '' );
+		$sleep   = \WP_CLI\Utils\get_flag_value( $assoc_args, 'pause', 0 );
+
+		$batches_completed = 0;
+		$actions_deleted   = 0;
+		$unlimited         = $batches === 0;
+		try {
+			$lifespan = as_get_datetime_object( $before );
+		} catch ( Exception $e ) {
+			$lifespan = null;
+		}
+
+		try {
+			// Custom queue cleaner instance.
+			$cleaner = new ActionScheduler_QueueCleaner( null, $batch );
+
+			// Clean actions for as long as possible.
+			while ( $unlimited || $batches_completed < $batches ) {
+				if ( $sleep && $batches_completed > 0 ) {
+					sleep( $sleep );
+				}
+
+				$deleted = count( $cleaner->clean_actions( $status, $lifespan, null,'CLI' ) );
+				if ( $deleted <= 0 ) {
+					break;
+				}
+				$actions_deleted += $deleted;
+				$batches_completed++;
+				$this->print_success( $deleted );
+			}
+		} catch ( Exception $e ) {
+			$this->print_error( $e );
+		}
+
+		$this->print_total_batches( $batches_completed );
+		if ( $batches_completed > 1 ) {
+			$this->print_success( $actions_deleted );
+		}
+	}
+
+	/**
+	 * Print WP CLI message about how many batches of actions were processed.
+	 *
+	 * @param int $batches_processed
+	 */
+	protected function print_total_batches( int $batches_processed ) {
+		WP_CLI::log(
+			sprintf(
+				/* translators: %d refers to the total number of batches processed */
+				_n( '%d batch processed.', '%d batches processed.', $batches_processed, 'action-scheduler' ),
+				number_format_i18n( $batches_processed )
+			)
+		);
+	}
+
+	/**
+	 * Convert an exception into a WP CLI error.
+	 *
+	 * @param Exception $e The error object.
+	 *
+	 * @throws \WP_CLI\ExitException
+	 */
+	protected function print_error( Exception $e ) {
+		WP_CLI::error(
+			sprintf(
+				/* translators: %s refers to the exception error message */
+				__( 'There was an error deleting an action: %s', 'action-scheduler' ),
+				$e->getMessage()
+			)
+		);
+	}
+
+	/**
+	 * Print a success message with the number of completed actions.
+	 *
+	 * @param int $actions_deleted
+	 */
+	protected function print_success( int $actions_deleted ) {
+		WP_CLI::success(
+			sprintf(
+				/* translators: %d refers to the total number of actions deleted */
+				_n( '%d action deleted.', '%d actions deleted.', $actions_deleted, 'action-scheduler' ),
+				number_format_i18n( $actions_deleted )
+			)
+		);
+	}
+}

--- a/classes/WP_CLI/ActionScheduler_WPCLI_Clean_Command.php
+++ b/classes/WP_CLI/ActionScheduler_WPCLI_Clean_Command.php
@@ -86,7 +86,7 @@ class ActionScheduler_WPCLI_Clean_Command extends WP_CLI_Command {
 			sprintf(
 				/* translators: %d refers to the total number of batches processed */
 				_n( '%d batch processed.', '%d batches processed.', $batches_processed, 'action-scheduler' ),
-				number_format_i18n( $batches_processed )
+				$batches_processed
 			)
 		);
 	}
@@ -118,7 +118,7 @@ class ActionScheduler_WPCLI_Clean_Command extends WP_CLI_Command {
 			sprintf(
 				/* translators: %d refers to the total number of actions deleted */
 				_n( '%d action deleted.', '%d actions deleted.', $actions_deleted, 'action-scheduler' ),
-				number_format_i18n( $actions_deleted )
+				$actions_deleted
 			)
 		);
 	}

--- a/classes/WP_CLI/ActionScheduler_WPCLI_Scheduler_command.php
+++ b/classes/WP_CLI/ActionScheduler_WPCLI_Scheduler_command.php
@@ -126,7 +126,7 @@ class ActionScheduler_WPCLI_Scheduler_command extends WP_CLI_Command {
 	protected function print_total_actions( $total ) {
 		WP_CLI::log(
 			sprintf(
-				/* translators: %d refers to how many scheduled taks were found to run */
+				/* translators: %d refers to how many scheduled tasks were found to run */
 				_n( 'Found %d scheduled task', 'Found %d scheduled tasks', $total, 'action-scheduler' ),
 				number_format_i18n( $total )
 			)
@@ -179,7 +179,7 @@ class ActionScheduler_WPCLI_Scheduler_command extends WP_CLI_Command {
 	protected function print_success( $actions_completed ) {
 		WP_CLI::success(
 			sprintf(
-				/* translators: %d refers to the total number of taskes completed */
+				/* translators: %d refers to the total number of tasks completed */
 				_n( '%d scheduled task completed.', '%d scheduled tasks completed.', $actions_completed, 'action-scheduler' ),
 				number_format_i18n( $actions_completed )
 			)

--- a/classes/abstracts/ActionScheduler.php
+++ b/classes/abstracts/ActionScheduler.php
@@ -166,6 +166,7 @@ abstract class ActionScheduler {
 
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			WP_CLI::add_command( 'action-scheduler', 'ActionScheduler_WPCLI_Scheduler_command' );
+			WP_CLI::add_command( 'action-scheduler', 'ActionScheduler_WPCLI_Clean_Command' );
 			if ( ! ActionScheduler_DataController::is_migration_complete() && Controller::instance()->allow_migration() ) {
 				$command = new Migration_Command();
 				$command->register();

--- a/docs/perf.md
+++ b/docs/perf.md
@@ -127,6 +127,23 @@ add_action( 'wp_ajax_nopriv_eg_create_additional_runners', 'eg_create_additional
 
 > WARNING: because of the processing rate of scheduled actions, this kind of increase can very easily take down a site. Use only on high powered servers and be sure to test before attempting to use it in production.
 
+## Cleaning Failed Actions
+
+By default, Action Scheduler does not automatically delete old failed actions. There are two optional methods of removing these actions:
+
+- Include the failed status in the list of statuses to purge:
+```php
+add_filter( 'action_scheduler_default_cleaner_statuses', function( $statuses ) {
+    $statuses[] = ActionScheduler_Store::STATUS_FAILED;
+    return $statuses;
+} );
+```
+- Use [WP CLI](/wp-cli/):
+```shell
+// Example
+wp action-scheduler clean --status=failed --batch-size=50 --before='90 days ago' --pause=2
+```
+
 ## High Volume Plugin
 
 It's not necessary to add all of this code yourself, there is a handy plugin to get access to each of these increases - the [Action Scheduler - High Volume](https://github.com/woocommerce/action-scheduler-high-volume) plugin.

--- a/docs/wp-cli.md
+++ b/docs/wp-cli.md
@@ -19,6 +19,15 @@ If you choose to utilize WP CLI exclusively, you can disable the normal WP CLI q
 
 These are the commands available to use with Action Scheduler:
 
+* `action-scheduler clean`
+
+  Options:
+  * `--batch-size` - This is the number of actions per status to clean in a single batch. Default is `20`.
+  * `--batches` - This is the number of batches to process. Default 0 means that batches will continue to process until there are no more actions to delete.
+  * `--status` - Process only actions with specific status or statuses. Default is `canceled` and `complete`. Define multiple statuses as a comma separated string (without spaces), e.g. `--status=complete,failed,canceled`
+  * `--before` - Process only actions with scheduled date older than this. Defaults to 31 days. e.g `--before='7 days ago'`, `--before='02-Feb-2020 20:20:20'`
+  * `--pause` - The number of seconds to pause between batches. Default no pause.
+
 * `action-scheduler migrate`
 
     **Note**: This command is only available while the migration to custom tables is in progress.


### PR DESCRIPTION
Closes #421

This PR adds the WP CLI `clean` subcommand.

### Testing

- Review docs additions
- Use `wp help action-scheduler clean` to obtain the list of parameters
- Use the test actions code in #905 to create a good number of actions that will fail
- Combine small batch sizes, low number of batches, pauses, and before to verify that all the parameters are applied correctly
- As a final test use `wp action-scheduler clean --status=canceled,complete,failed --before='1 second ago'` which should remove all non-pending actions.

---

### Changelog

> Add - New `wp action-scheduler clean` WP CLI command.