### PR TITLE
Fix WPCLI progress messages

### DIFF
--- a/classes/WP_CLI/ActionScheduler_WPCLI_QueueRunner.php
+++ b/classes/WP_CLI/ActionScheduler_WPCLI_QueueRunner.php
@@ -90,7 +90,7 @@ class ActionScheduler_WPCLI_QueueRunner extends ActionScheduler_Abstract_QueueRu
 		$count              = count( $this->actions );
 		$this->progress_bar = new ProgressBar(
 			/* translators: %d: amount of actions */
-			sprintf( _n( 'Running %d action', 'Running %d actions', $count, 'action-scheduler' ), number_format_i18n( $count ) ),
+			sprintf( _n( 'Running %d action', 'Running %d actions', $count, 'action-scheduler' ), $count ),
 			$count
 		);
 	}

--- a/classes/WP_CLI/ActionScheduler_WPCLI_Scheduler_command.php
+++ b/classes/WP_CLI/ActionScheduler_WPCLI_Scheduler_command.php
@@ -128,7 +128,7 @@ class ActionScheduler_WPCLI_Scheduler_command extends WP_CLI_Command {
 			sprintf(
 				/* translators: %d refers to how many scheduled taks were found to run */
 				_n( 'Found %d scheduled task', 'Found %d scheduled tasks', $total, 'action-scheduler' ),
-				number_format_i18n( $total )
+				$total
 			)
 		);
 	}
@@ -145,7 +145,7 @@ class ActionScheduler_WPCLI_Scheduler_command extends WP_CLI_Command {
 			sprintf(
 				/* translators: %d refers to the total number of batches executed */
 				_n( '%d batch executed.', '%d batches executed.', $batches_completed, 'action-scheduler' ),
-				number_format_i18n( $batches_completed )
+				$batches_completed
 			)
 		);
 	}
@@ -181,7 +181,7 @@ class ActionScheduler_WPCLI_Scheduler_command extends WP_CLI_Command {
 			sprintf(
 				/* translators: %d refers to the total number of taskes completed */
 				_n( '%d scheduled task completed.', '%d scheduled tasks completed.', $actions_completed, 'action-scheduler' ),
-				number_format_i18n( $actions_completed )
+				$actions_completed
 			)
 		);
 	}

--- a/classes/migration/Runner.php
+++ b/classes/migration/Runner.php
@@ -79,7 +79,7 @@ class Runner {
 
 		if ( $this->progress_bar ) {
 			/* translators: %d: amount of actions */
-			$this->progress_bar->set_message( sprintf( _n( 'Migrating %d action', 'Migrating %d actions', $batch_size, 'action-scheduler' ), number_format_i18n( $batch_size ) ) );
+			$this->progress_bar->set_message( sprintf( _n( 'Migrating %d action', 'Migrating %d actions', $batch_size, 'action-scheduler' ), $batch_size ) );
 			$this->progress_bar->set_count( $batch_size );
 		}
 


### PR DESCRIPTION
The WP_CLI commands pass `number_format_i18n` strings to progress messages when the message format is expecting an integer. When `$wp_locale` is set, the string may contain separators on large numbers causing the number to be truncated (eg. `1,000` is truncated to `1`).

This PR removes the `number_format_i18n` function calls as it would be an edge case where these counts would be large enough to warrnat formatting (eg. 10K+).

---

### Changelog

> Fix - Format numbers correctly when rendering WP CLI progress bars.