### PR TITLE
Improve logic for flushing the runtime cache.

### DIFF
--- a/classes/ActionScheduler_QueueRunner.php
+++ b/classes/ActionScheduler_QueueRunner.php
@@ -186,8 +186,14 @@ class ActionScheduler_QueueRunner extends ActionScheduler_Abstract_QueueRunner {
 		/*
 		 * Calling wp_cache_flush_runtime() lets us clear the runtime cache without invalidating the external object
 		 * cache, so we will always prefer this when it is available (but it was only introduced in WordPress 6.0).
+		 *
+		 * Additionally, the preferred way of detecting support changed in WordPress 6.1 so we use two different
+		 * methods here.
 		 */
-		if ( function_exists( 'wp_cache_flush_runtime' ) ) {
+		$flushing_runtime_cache_explicitly_supported = function_exists( 'wp_cache_supports' ) && wp_cache_supports( 'flush_runtime' );
+		$flushing_runtime_cache_implicitly_supported = ! function_exists( 'wp_cache_supports' ) && function_exists( 'wp_cache_flush_runtime' );
+
+		if ( $flushing_runtime_cache_explicitly_supported || $flushing_runtime_cache_implicitly_supported ) {
 			wp_cache_flush_runtime();
 		} elseif (
 			! wp_using_ext_object_cache()

--- a/classes/ActionScheduler_QueueRunner.php
+++ b/classes/ActionScheduler_QueueRunner.php
@@ -185,10 +185,10 @@ class ActionScheduler_QueueRunner extends ActionScheduler_Abstract_QueueRunner {
 	protected function clear_caches() {
 		/*
 		 * Calling wp_cache_flush_runtime() lets us clear the runtime cache without invalidating the external object
-		 * cache, so we will always prefer this when it is available (but it was only introduced in WordPress 6.0).
+		 * cache, so we will always prefer this method (as compared to calling wp_cache_flush()) when it is available.
 		 *
-		 * Additionally, the preferred way of detecting support changed in WordPress 6.1 so we use two different
-		 * methods here.
+		 * However, this function was only introduced in WordPress 6.0. Additionally, the preferred way of detecting if
+		 * it is supported changed in WordPress 6.1 so we use two different methods to decide if we should utilize it.
 		 */
 		$flushing_runtime_cache_explicitly_supported = function_exists( 'wp_cache_supports' ) && wp_cache_supports( 'flush_runtime' );
 		$flushing_runtime_cache_implicitly_supported = ! function_exists( 'wp_cache_supports' ) && function_exists( 'wp_cache_flush_runtime' );


### PR DESCRIPTION
Before flushing the runtime cache and depending on the active version of WordPress, we should:

- Check if support for flushing the runtime cache is explicitly declared (possible from WP 6.1 onwards).
- Otherwise, check if the `wp_cache_flush_runtime()` function exists (possible with all versions of WP).

Calling `wp_cache_flush_runtime()` is essentially safe so long as we are using WP 6.0 or up, but with WP 6.1 and above it will potentially lead to a doing-it-wrong notice if the active cache does not support the concept (even though nothing will break).

Closes #909.

### Testing

This code will not be invoked when using the WP CLI queue runner, and there isn't a super easy 'user test' you can apply. Code review should be sufficient in this case.

### Changelog

> Fix - Avoid throwing errors when clearing the runtime cache with WP 6.1 and higher.

