### PR TITLE
exclude past-due from list table all filter count

### DIFF
--- a/classes/abstracts/ActionScheduler_Abstract_ListTable.php
+++ b/classes/abstracts/ActionScheduler_Abstract_ListTable.php
@@ -673,7 +673,11 @@ abstract class ActionScheduler_Abstract_ListTable extends WP_List_Table {
 
 		// Helper to set 'all' filter when not set on status counts passed in.
 		if ( ! isset( $this->status_counts['all'] ) ) {
-			$this->status_counts = array( 'all' => array_sum( $this->status_counts ) ) + $this->status_counts;
+			$all_count = array_sum( $this->status_counts );
+			if ( isset( $this->status_counts['past-due'] ) ) {
+				$all_count -= $this->status_counts['past-due'];
+			}
+			$this->status_counts = array( 'all' => $all_count ) + $this->status_counts;
 		}
 
 		foreach ( $this->status_counts as $status_name => $count ) {


### PR DESCRIPTION
Closes #913 

This PR fixes the list table `All` action count by deducting the past due count which is already included in the pending count.

### Testing

- Disable the default runner
- Create an async action
- Allow some time for it to become past due
- Go to the `All` filter in the list table
- Verify that the `All` count  on the filter matches the paging count on the right.

---

### Changelog

> Fix - Corrects the `All` action count.