### PR TITLE
Filter view labels (status names) should be translatable | #919

### DIFF
--- a/classes/abstracts/ActionScheduler_Abstract_ListTable.php
+++ b/classes/abstracts/ActionScheduler_Abstract_ListTable.php
@@ -680,21 +680,27 @@ abstract class ActionScheduler_Abstract_ListTable extends WP_List_Table {
 			$this->status_counts = array( 'all' => $all_count ) + $this->status_counts;
 		}
 
-		foreach ( $this->status_counts as $status_name => $count ) {
+		// Translated status labels.
+		$status_labels             = ActionScheduler_Store::instance()->get_status_labels();
+		$status_labels['all']      = _x( 'All', 'status labels', 'action-scheduler' );
+		$status_labels['past-due'] = _x( 'Past-due', 'status labels', 'action-scheduler' );
+
+		foreach ( $this->status_counts as $status_slug => $count ) {
 
 			if ( 0 === $count ) {
 				continue;
 			}
 
-			if ( $status_name === $request_status || ( empty( $request_status ) && 'all' === $status_name ) ) {
+			if ( $status_slug === $request_status || ( empty( $request_status ) && 'all' === $status_slug ) ) {
 				$status_list_item = '<li class="%1$s"><a href="%2$s" class="current">%3$s</a> (%4$d)</li>';
 			} else {
 				$status_list_item = '<li class="%1$s"><a href="%2$s">%3$s</a> (%4$d)</li>';
 			}
 
-			$status_filter_url   = ( 'all' === $status_name ) ? remove_query_arg( 'status' ) : add_query_arg( 'status', $status_name );
+			$status_name         = isset( $status_labels[ $status_slug ] ) ? $status_labels[ $status_slug ] : ucfirst( $status_slug );
+			$status_filter_url   = ( 'all' === $status_slug ) ? remove_query_arg( 'status' ) : add_query_arg( 'status', $status_slug );
 			$status_filter_url   = remove_query_arg( array( 'paged', 's' ), $status_filter_url );
-			$status_list_items[] = sprintf( $status_list_item, esc_attr( $status_name ), esc_url( $status_filter_url ), esc_html( ucfirst( $status_name ) ), absint( $count ) );
+			$status_list_items[] = sprintf( $status_list_item, esc_attr( $status_slug ), esc_url( $status_filter_url ), esc_html( $status_name ), absint( $count ) );
 		}
 
 		if ( $status_list_items ) {


### PR DESCRIPTION
The status/filter view names found in the **Tools ▸ Scheduled Actions** screen should be translatable:

<img width="806" alt="filter-status-labels" src="https://user-images.githubusercontent.com/3594411/222219967-2627914e-1f0a-4da4-889f-fa0cada60e11.png">

Currently, as highlighted in the linked issue, they are not—what we are actually doing is echoing the status *slugs*, after passing them through [ucfirst()](https://www.php.net/manual/en/function.ucfirst.php), rather than using the translated status labels. 

Closes #919.

### Testing instructions

Start by adding the following snippet to a suitable location. I recommend `wp-content/mu-plugins/test-919.php` (which you can remove when you have finished testing):

```php
<?php

function test_fix_for_919( $translation, $text ) {
	$status_labels = array( 'All', 'Complete', 'Pending', 'In-progress', 'Failed', 'Canceled', 'Past-due' );
	return in_array( $text, $status_labels ) ? "Translated '$text'" : $translation;
}

add_filter( 'gettext_action-scheduler', 'test_fix_for_919', 10, 2 );
add_filter( 'gettext_with_context_action-scheduler', 'test_fix_for_919', 10, 2 );
```

With that in place, if you visit the **Tools ▸ Scheduled Actions** screen:

- Without this change, there will be no change to the status labels (they will render in English).
- With this change, each status name should render as `Translated '<slug>'` (simulating a situation where we have translations for these strings).

<img width="865" alt="filter-status-labels-translated" src="https://user-images.githubusercontent.com/3594411/222221896-41a39934-74a9-4bca-a17d-2c88aa7a2221.png">

For clarity, this should only impact the 'filter views' as in the above screenshot. I don't know if we surface the status slugs elsewhere, but if we do they are probably not covered by this change.

### Changelog

> Fix - Makes the filter names in the `Tools > Scheduled Actions` screen translatable.