### PR TITLE
Add action priorities.

### DIFF
--- a/classes/actions/ActionScheduler_Action.php
+++ b/classes/actions/ActionScheduler_Action.php
@@ -10,6 +10,19 @@ class ActionScheduler_Action {
 	protected $schedule = NULL;
 	protected $group = '';
 
+	/**
+	 * Priorities are conceptually similar to those used for regular WordPress actions.
+	 * Like those, a lower priority takes precedence over a higher priority and the default
+	 * is 10.
+	 *
+	 * Unlike regular WordPress actions, the priority of a scheduled action is strictly an
+	 * integer and should be kept within the bounds 0-255 (anything outside the bounds will
+	 * be brought back into the acceptable range).
+	 *
+	 * @var int
+	 */
+	protected $priority = 10;
+
 	public function __construct( $hook, array $args = array(), ActionScheduler_Schedule $schedule = NULL, $group = '' ) {
 		$schedule = empty( $schedule ) ? new ActionScheduler_NullSchedule() : $schedule;
 		$this->set_hook($hook);
@@ -92,5 +105,31 @@ class ActionScheduler_Action {
 	 */
 	public function is_finished() {
 		return FALSE;
+	}
+
+	/**
+	 * Sets the priority of the action.
+	 *
+	 * @param int $priority Priority level (lower is higher priority). Should be in the range 0-255.
+	 *
+	 * @return void
+	 */
+	public function set_priority( $priority ) {
+		if ( $priority < 0 ) {
+			$priority = 0;
+		} elseif ( $priority > 255 ) {
+			$priority = 255;
+		}
+
+		$this->priority = $priority;
+	}
+
+	/**
+	 * Gets the action priority.
+	 *
+	 * @return int
+	 */
+	public function get_priority() {
+		return $this->priority;
 	}
 }

--- a/classes/actions/ActionScheduler_Action.php
+++ b/classes/actions/ActionScheduler_Action.php
@@ -121,7 +121,7 @@ class ActionScheduler_Action {
 			$priority = 255;
 		}
 
-		$this->priority = $priority;
+		$this->priority = (int) $priority;
 	}
 
 	/**

--- a/classes/schema/ActionScheduler_StoreSchema.php
+++ b/classes/schema/ActionScheduler_StoreSchema.php
@@ -16,7 +16,7 @@ class ActionScheduler_StoreSchema extends ActionScheduler_Abstract_Schema {
 	/**
 	 * @var int Increment this value to trigger a schema update.
 	 */
-	protected $schema_version = 6;
+	protected $schema_version = 7;
 
 	public function __construct() {
 		$this->tables = [
@@ -49,6 +49,7 @@ class ActionScheduler_StoreSchema extends ActionScheduler_Abstract_Schema {
 				        status varchar(20) NOT NULL,
 				        scheduled_date_gmt datetime NULL default '{$default_date}',
 				        scheduled_date_local datetime NULL default '{$default_date}',
+				        priority tinyint unsigned NOT NULL default '10',
 				        args varchar($max_index_length),
 				        schedule longtext,
 				        group_id bigint(20) unsigned NOT NULL default '0',

--- a/functions.php
+++ b/functions.php
@@ -12,10 +12,11 @@
  * @param array  $args Arguments to pass when the hook triggers.
  * @param string $group The group to assign this job to.
  * @param bool   $unique Whether the action should be unique.
+ * @param int    $priority Lower values take precedence over higher values. Defaults to 10, with acceptable values falling in the range 0-255.
  *
  * @return int The action ID.
  */
-function as_enqueue_async_action( $hook, $args = array(), $group = '', $unique = false ) {
+function as_enqueue_async_action( $hook, $args = array(), $group = '', $unique = false, $priority = 10 ) {
 	if ( ! ActionScheduler::is_initialized( __FUNCTION__ ) ) {
 		return 0;
 	}
@@ -33,13 +34,23 @@ function as_enqueue_async_action( $hook, $args = array(), $group = '', $unique =
 	 * @param string   $hook       Action hook.
 	 * @param array    $args       Action arguments.
 	 * @param string   $group      Action group.
+	 * @param int      $priority   Action priority.
 	 */
-	$pre = apply_filters( 'pre_as_enqueue_async_action', null, $hook, $args, $group );
+	$pre = apply_filters( 'pre_as_enqueue_async_action', null, $hook, $args, $group, $priority );
 	if ( null !== $pre ) {
 		return is_int( $pre ) ? $pre : 0;
 	}
 
-	return ActionScheduler::factory()->async_unique( $hook, $args, $group, $unique );
+	return ActionScheduler::factory()->create(
+		array(
+			'type'      => 'async',
+			'hook'      => $hook,
+			'arguments' => $args,
+			'group'     => $group,
+			'unique'    => $unique,
+			'priority'  => $priority,
+		)
+	);
 }
 
 /**
@@ -50,10 +61,11 @@ function as_enqueue_async_action( $hook, $args = array(), $group = '', $unique =
  * @param array  $args Arguments to pass when the hook triggers.
  * @param string $group The group to assign this job to.
  * @param bool   $unique Whether the action should be unique.
+ * @param int    $priority Lower values take precedence over higher values. Defaults to 10, with acceptable values falling in the range 0-255.
  *
  * @return int The action ID.
  */
-function as_schedule_single_action( $timestamp, $hook, $args = array(), $group = '', $unique = false ) {
+function as_schedule_single_action( $timestamp, $hook, $args = array(), $group = '', $unique = false, $priority = 10 ) {
 	if ( ! ActionScheduler::is_initialized( __FUNCTION__ ) ) {
 		return 0;
 	}
@@ -72,13 +84,24 @@ function as_schedule_single_action( $timestamp, $hook, $args = array(), $group =
 	 * @param string   $hook       Action hook.
 	 * @param array    $args       Action arguments.
 	 * @param string   $group      Action group.
+	 * @param int      $priorities Action priority.
 	 */
-	$pre = apply_filters( 'pre_as_schedule_single_action', null, $timestamp, $hook, $args, $group );
+	$pre = apply_filters( 'pre_as_schedule_single_action', null, $timestamp, $hook, $args, $group, $priority );
 	if ( null !== $pre ) {
 		return is_int( $pre ) ? $pre : 0;
 	}
 
-	return ActionScheduler::factory()->single_unique( $hook, $args, $timestamp, $group, $unique );
+	return ActionScheduler::factory()->create(
+		array(
+			'type'      => 'single',
+			'hook'      => $hook,
+			'arguments' => $args,
+			'when'      => $timestamp,
+			'group'     => $group,
+			'unique'    => $unique,
+			'priority'  => $priority,
+		)
+	);
 }
 
 /**
@@ -90,10 +113,11 @@ function as_schedule_single_action( $timestamp, $hook, $args = array(), $group =
  * @param array  $args Arguments to pass when the hook triggers.
  * @param string $group The group to assign this job to.
  * @param bool   $unique Whether the action should be unique.
+ * @param int    $priority Lower values take precedence over higher values. Defaults to 10, with acceptable values falling in the range 0-255.
  *
  * @return int The action ID.
  */
-function as_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, $args = array(), $group = '', $unique = false ) {
+function as_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, $args = array(), $group = '', $unique = false, $priority = 10 ) {
 	if ( ! ActionScheduler::is_initialized( __FUNCTION__ ) ) {
 		return 0;
 	}
@@ -113,13 +137,25 @@ function as_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, 
 	 * @param string   $hook                Action hook.
 	 * @param array    $args                Action arguments.
 	 * @param string   $group               Action group.
+	 * @param int      $priority            Action priority.
 	 */
-	$pre = apply_filters( 'pre_as_schedule_recurring_action', null, $timestamp, $interval_in_seconds, $hook, $args, $group );
+	$pre = apply_filters( 'pre_as_schedule_recurring_action', null, $timestamp, $interval_in_seconds, $hook, $args, $group, $priority );
 	if ( null !== $pre ) {
 		return is_int( $pre ) ? $pre : 0;
 	}
 
-	return ActionScheduler::factory()->recurring_unique( $hook, $args, $timestamp, $interval_in_seconds, $group, $unique );
+	return ActionScheduler::factory()->create(
+		array(
+			'type'      => 'recurring',
+			'hook'      => $hook,
+			'arguments' => $args,
+			'when'      => $timestamp,
+			'pattern'   => $interval_in_seconds,
+			'group'     => $group,
+			'unique'    => $unique,
+			'priority'  => $priority,
+		)
+	);
 }
 
 /**
@@ -143,10 +179,11 @@ function as_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, 
  * @param array  $args Arguments to pass when the hook triggers.
  * @param string $group The group to assign this job to.
  * @param bool   $unique Whether the action should be unique.
+ * @param int    $priority Lower values take precedence over higher values. Defaults to 10, with acceptable values falling in the range 0-255.
  *
  * @return int The action ID.
  */
-function as_schedule_cron_action( $timestamp, $schedule, $hook, $args = array(), $group = '', $unique = false ) {
+function as_schedule_cron_action( $timestamp, $schedule, $hook, $args = array(), $group = '', $unique = false, $priority = 10 ) {
 	if ( ! ActionScheduler::is_initialized( __FUNCTION__ ) ) {
 		return 0;
 	}
@@ -166,13 +203,25 @@ function as_schedule_cron_action( $timestamp, $schedule, $hook, $args = array(),
 	 * @param string   $hook       Action hook.
 	 * @param array    $args       Action arguments.
 	 * @param string   $group      Action group.
+	 * @param int      $priority   Action priority.
 	 */
-	$pre = apply_filters( 'pre_as_schedule_cron_action', null, $timestamp, $schedule, $hook, $args, $group );
+	$pre = apply_filters( 'pre_as_schedule_cron_action', null, $timestamp, $schedule, $hook, $args, $group, $priority );
 	if ( null !== $pre ) {
 		return is_int( $pre ) ? $pre : 0;
 	}
 
-	return ActionScheduler::factory()->cron_unique( $hook, $args, $timestamp, $schedule, $group, $unique );
+	return ActionScheduler::factory()->create(
+		array(
+			'type'      => 'cron',
+			'hook'      => $hook,
+			'arguments' => $args,
+			'when'      => $timestamp,
+			'pattern'   => $schedule,
+			'group'     => $group,
+			'unique'    => $unique,
+			'priority'  => $priority,
+		)
+	);
 }
 
 /**

--- a/tests/phpunit/jobstore/ActionScheduler_DBStore_Test.php
+++ b/tests/phpunit/jobstore/ActionScheduler_DBStore_Test.php
@@ -307,6 +307,38 @@ class ActionScheduler_DBStore_Test extends AbstractStoreTest {
 	}
 
 	/**
+	 * Confirm that priorities are respected when claiming actions.
+	 *
+	 * @return void
+	 */
+	public function test_claim_actions_respecting_priority() {
+		$store = new ActionScheduler_DBStore();
+
+		$schedule = new ActionScheduler_SimpleSchedule( as_get_datetime_object( '-2 hours' ) );
+		$routine_action_1 = $store->save_action( new ActionScheduler_Action( 'routine_past_due', array(), $schedule, '' ) );
+
+		$schedule = new ActionScheduler_SimpleSchedule( as_get_datetime_object( '-1 hour' ) );
+		$action   = new ActionScheduler_Action( 'high_priority_past_due', array(), $schedule, '' );
+		$action->set_priority( 5 );
+		$priority_action = $store->save_action( $action );
+
+		$schedule = new ActionScheduler_SimpleSchedule( as_get_datetime_object( '-4 hours' ) );
+		$routine_action_2 = $store->save_action( new ActionScheduler_Action( 'routine_past_due', array(), $schedule, '' ) );
+
+		$schedule = new ActionScheduler_SimpleSchedule( as_get_datetime_object( '+1 hour' ) );
+		$action   = new ActionScheduler_Action( 'high_priority_future', array(), $schedule, '' );
+		$action->set_priority( 2 );
+		$priority_future_action = $store->save_action( $action );
+
+		$claim = $store->stake_claim();
+		$this->assertEquals(
+			array( $priority_action, $routine_action_2, $routine_action_1 ),
+			$claim->get_actions(),
+			'High priority actions take precedence over older but lower priority actions.'
+		);
+	}
+
+	/**
 	 * The query used to claim actions explicitly ignores future pending actions, but it
 	 * is still possible under unusual conditions (such as if MySQL runs out of temporary
 	 * storage space) for such actions to be returned.

--- a/tests/phpunit/runner/ActionScheduler_QueueRunner_Test.php
+++ b/tests/phpunit/runner/ActionScheduler_QueueRunner_Test.php
@@ -182,7 +182,15 @@ class ActionScheduler_QueueRunner_Test extends ActionScheduler_UnitTestCase {
 		// Create an action to recur every 24 hours, with the first instance scheduled to run 12 hours ago
 		$random    = md5( rand() );
 		$date      = as_get_datetime_object( '12 hours ago' );
-		$action_id = ActionScheduler::factory()->recurring( $random, array(), $date->getTimestamp(), DAY_IN_SECONDS );
+		$action_id = ActionScheduler::factory()->create(
+			array(
+				'type'     => 'recurring',
+				'hook'     => $random,
+				'when'     => $date->getTimestamp(),
+				'pattern'  => DAY_IN_SECONDS,
+				'priority' => 2,
+			)
+		);
 		$store     = ActionScheduler::store();
 		$runner    = ActionScheduler_Mocker::get_queue_runner( $store );
 
@@ -214,7 +222,7 @@ class ActionScheduler_QueueRunner_Test extends ActionScheduler_UnitTestCase {
 		$this->assertNotEquals( $fetched_action_id, $action_id );
 		$this->assertEquals( $random, $fetched_action->get_hook() );
 		$this->assertEquals( $date->getTimestamp(), $fetched_action->get_schedule()->get_date()->getTimestamp(), '', 1 );
-
+		$this->assertEquals( 2, $fetched_action->get_priority(), 'The replacement action should inherit the same priority as the original action.' );
 		$store->release_claim( $claim );
 
 		// Make sure the 3rd instance of the cron action is scheduled for 24 hours from now, as the action was run early, ahead of schedule


### PR DESCRIPTION
Adds support for priorities to scheduled actions. 

- Given a set of scheduled actions that are due (or past-due) for processing, higher priority actions will be claimed and processed first.
- This gives library consumers the latitude to designate certain actions (an example could be those used for processing renewal payments) priority over others (those used to perform routine clean-up tasks, perhaps).
- Scheduled action priorities mimic regular WordPress action priorities in the sense the lower values such as 1 are a higher priority than large values such as 100.
    - On the other hand, they diverge from WordPress action priorities in that they must be integers.
    - They also need to be in the range 0-255. This seems sufficient for our needs, and means there is very little overhead.

Updates #910.

---

### Testing instructions

Please see the new and revised unit tests, though we can also test manually as described here. However, before you begin, I recommend disabling all other plugins and wiping the queue clean:

- If you are using a system scheduler (like `cron.d`) to trigger either WP Cron or Action Scheduler directly, then disable the relevant rules.
- Disable WP Cron by adding `define( 'DISABLE_WP_CRON', true );` to your wp-config.php file.
- Delete the existing queue: `wp db query "DELETE FROM $(wp db prefix)actionscheduler_actions"`
- Add the following code to a suitable location. I recommend `wp-content/mu-plugins/test-pr-921.php`:

```php
<?php

add_filter( 'action_scheduler_allow_async_request_runner', '__return_false' );
add_action( 'test_action', function( $arg ) { echo $arg . PHP_EOL; } );
```

Now create some past-due actions of mixed priority (all these timestamps are in the past—the early 2000s in fact):

```sh
wp eval "as_schedule_single_action( 1000000000, 'test_action', [ 'DEFAULT PRIORITY' ] );" \
wp eval "as_schedule_single_action( 1000000100, 'test_action', [ 'HIGH PRIORITY' ], '', false, 1 );" \
wp eval "as_schedule_single_action( 1000010000, 'test_action', [ 'LOW PRIORITY' ], '', false, 100 );" \
wp eval "as_schedule_single_action( 1010000000, 'test_action', [ 'DEFAULT PRIORITY' ] );"
```

Now run the queue using `wp action-scheduler run`. You should see output looking something like the following:

```
Found 4 scheduled tasks
Started processing action 2772
HIGH PRIORITY
Completed processing action 2772 with hook: test_action
Running 4 actions  25 % [=====================>                                                                 ] 0:00 / 0:00Started processing action 2773
DEFAULT PRIORITY
Completed processing action 2773 with hook: test_action
Started processing action 2774
DEFAULT PRIORITY
Completed processing action 2774 with hook: test_action
Started processing action 2775
LOW PRIORITY
Completed processing action 2775 with hook: test_action
Running 4 actions  100% [=======================================================================================] 0:00 / 0:00
1 batch executed.
Success: 4 scheduled tasks completed.
```

Specifically, what we want to see is that the priority labels are ordered just as you see above:

- `HIGH PRIORITY` processed first
- `DEFAULT PRIORITY` (x2) processed second
- `LOW PRIORITY` processed last

---

### Changelog

> Add - Priorities can now be set for scheduled actions.