### PR TITLE
Add a cast-to-int for extra safety before forming new DateTime object.

### DIFF
--- a/classes/ActionScheduler_QueueCleaner.php
+++ b/classes/ActionScheduler_QueueCleaner.php
@@ -49,7 +49,23 @@ class ActionScheduler_QueueCleaner {
 		 * @param int $retention_period Minimum scheduled age in seconds of the actions to be deleted.
 		 */
 		$lifespan = (int) apply_filters( 'action_scheduler_retention_period', $this->month_in_seconds );
-		$cutoff = as_get_datetime_object( $lifespan . ' seconds ago' );
+
+		try {
+			$cutoff = as_get_datetime_object( $lifespan . ' seconds ago' );
+		} catch ( Exception $e ) {
+			_doing_it_wrong(
+				__METHOD__,
+				sprintf(
+					/* Translators: %s is the exception message. */
+					esc_html__( 'It was not possible to determine a valid cut-off time: %s.', 'action-scheduler' ),
+					esc_html( $e->getMessage() )
+				),
+				'3.5.5'
+			);
+
+			return array();
+		}
+
 
 		/**
 		 * Filter the statuses when cleaning the queue.

--- a/classes/ActionScheduler_QueueCleaner.php
+++ b/classes/ActionScheduler_QueueCleaner.php
@@ -40,7 +40,7 @@ class ActionScheduler_QueueCleaner {
 	/**
 	 * Default queue cleaner process used by queue runner.
 	 *
-	 * @return void
+	 * @return array
 	 */
 	public function delete_old_actions() {
 		/**
@@ -58,7 +58,7 @@ class ActionScheduler_QueueCleaner {
 		 */
 		$statuses_to_purge = (array) apply_filters( 'action_scheduler_default_cleaner_statuses', $this->default_statuses_to_purge );
 
-		$this->clean_actions( $statuses_to_purge, $cutoff, $this->get_batch_size() );
+		return $this->clean_actions( $statuses_to_purge, $cutoff, $this->get_batch_size() );
 	}
 
 	/**

--- a/classes/ActionScheduler_QueueCleaner.php
+++ b/classes/ActionScheduler_QueueCleaner.php
@@ -48,7 +48,7 @@ class ActionScheduler_QueueCleaner {
 		 *
 		 * @param int $retention_period Minimum scheduled age in seconds of the actions to be deleted.
 		 */
-		$lifespan = (int) apply_filters( 'action_scheduler_retention_period', $this->month_in_seconds );
+		$lifespan = apply_filters( 'action_scheduler_retention_period', $this->month_in_seconds );
 
 		try {
 			$cutoff = as_get_datetime_object( $lifespan . ' seconds ago' );

--- a/classes/ActionScheduler_QueueCleaner.php
+++ b/classes/ActionScheduler_QueueCleaner.php
@@ -48,7 +48,7 @@ class ActionScheduler_QueueCleaner {
 		 *
 		 * @param int $retention_period Minimum scheduled age in seconds of the actions to be deleted.
 		 */
-		$lifespan = apply_filters( 'action_scheduler_retention_period', $this->month_in_seconds );
+		$lifespan = (int) apply_filters( 'action_scheduler_retention_period', $this->month_in_seconds );
 		$cutoff = as_get_datetime_object( $lifespan . ' seconds ago' );
 
 		/**

--- a/tests/phpunit/runner/ActionScheduler_QueueCleaner_Test.php
+++ b/tests/phpunit/runner/ActionScheduler_QueueCleaner_Test.php
@@ -39,12 +39,20 @@ class ActionScheduler_QueueCleaner_Test extends ActionScheduler_UnitTestCase {
 		add_filter( 'action_scheduler_retention_period', '__return_null' );
 		$cleaner = new ActionScheduler_QueueCleaner( ActionScheduler::store() );
 
+		$this->setExpectedIncorrectUsage( 'ActionScheduler_QueueCleaner::delete_old_actions' );
+		$result = $cleaner->delete_old_actions();
+		remove_filter( 'action_scheduler_retention_period', '__return_zero' );
+
 		$this->assertIsArray(
-			$cleaner->delete_old_actions(),
-			'ActionScheduler_QueueCleaner::delete_old_actions() can be invoked without a fatal error, even if the retention period is a non-integer.'
+			$result,
+			'ActionScheduler_QueueCleaner::delete_old_actions() can be invoked without a fatal error, even if the retention period was invalid.'
 		);
 
-		remove_filter( 'action_scheduler_retention_period', '__return_zero' );
+		$this->assertCount(
+			0,
+			$result,
+			'ActionScheduler_QueueCleaner::delete_old_actions() will not delete any actions if the retention period was invalid.'
+		);
 	}
 
 	public function test_delete_canceled_actions() {

--- a/tests/phpunit/runner/ActionScheduler_QueueCleaner_Test.php
+++ b/tests/phpunit/runner/ActionScheduler_QueueCleaner_Test.php
@@ -34,7 +34,7 @@ class ActionScheduler_QueueCleaner_Test extends ActionScheduler_UnitTestCase {
 		}
 	}
 
-	public function test_retention_period_filter_hook() {
+	public function test_invalid_retention_period_filter_hook() {
 		// Supplying a non-integer such as null would break under 3.5.4 and earlier.
 		add_filter( 'action_scheduler_retention_period', '__return_null' );
 		$cleaner = new ActionScheduler_QueueCleaner( ActionScheduler::store() );


### PR DESCRIPTION
Adds a small piece of defensive coding for the `action_scheduler_retention_period` hook. 

We use this hook to allow an integer value (representing a number of seconds) to be modified by other plugins, but it is possible they will return a non-integer and, in some cases—such as if `null` or `(string) ''` are returned—they will trigger a fatal error.

Closes https://github.com/woocommerce/action-scheduler/issues/917.

### Testing

Try this multi-liner:

```sh
wp eval "\
  add_filter( 'action_scheduler_retention_period', '__return_false' ); \
  ( new ActionScheduler_QueueRunner )->run(); \
"
```

With this branch, there should be no problem. Without this branch, you should find a fatal error similar to the following is reported:

```
Error: There has been a critical error on this website.Learn more about troubleshooting WordPress.Error details:Array
(
    [type] => 1
    [message] => Uncaught Exception: DateTime::__construct(): Failed to parse time string ( seconds ago) at position 0 (s)
    ...
)
```

### Changelog

> Fix - Improves safety around the `action_scheduler_retention_period` filter hook.