### PR TITLE
Add a hook allowing exceptions for consistently failing recurring actions.

### DIFF
--- a/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php
+++ b/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php
@@ -143,12 +143,22 @@ abstract class ActionScheduler_Abstract_QueueRunner extends ActionScheduler_Abst
 			return false;
 		}
 
-		// Now let's fetch the first action (having the same hook) of *any status*ithin the same window.
+		// Now let's fetch the first action (having the same hook) of *any status* within the same window.
 		unset( $query_args['status'] );
 		$first_action_id_with_the_same_hook = $this->store->query_actions( $query_args );
 
-		// If the IDs match, then actions for this hook must be consistently failing.
-		return $first_action_id_with_the_same_hook === $first_failing_action_id;
+		/**
+		 * If a recurring action is assessed as consistently failing, it will not be rescheduled. This hook provides a
+		 * way to observe and optionally override that assessment.
+		 *
+		 * @param bool                   $is_consistently_failing If the action is considered to be consistently failing.
+		 * @param ActionScheduler_Action $action                  The action being assessed.
+		 */
+		return (bool) apply_filters(
+			'action_scheduler_recurring_action_is_consistently_failing',
+			$first_action_id_with_the_same_hook === $first_failing_action_id,
+			$action
+		);
 	}
 
 	/**


### PR DESCRIPTION
Since the [3.5.0](https://github.com/woocommerce/action-scheduler/releases/tag/3.5.0) release, if a recurring action consistently fails then it will not be rescheduled.

However, there may be cases where that is undesirable and an exception should be made, or else where plugins simply want to be able to observe the fact that an action has been deemed to be consistently failing. To accomplish these things, this PR introduces a new filter hook:

`action_scheduler_recurring_action_is_consistently_failing`

This can be used both to observe that an action has been determined to be consistently failing, and to make an exemption if appropriate.

Closes #908.

---

### Testing instructions

New assertions/code review are probably sufficient, but we can also mimic the same thing manually. First, to make it easier to test, I recommend deleting all existing actions from the queue before you begin. Via WP CLI:

```sh
wp db query "DELETE FROM $(wp db prefix)actionscheduler_actions"
```

Next, add the following snippet to a suitable location. I recommend `wp-content/mu-plugins/test-908.php`:

```php
<?php

add_filter( 'action_scheduler_recurring_action_is_consistently_failing', function( $is_failing, $action ) {
	return 'foo' === $action->get_hook() ? false : $is_failing;
}, 10, 2 );
```

Now create two recurring actions (for hooks `foo` and `bar`):

```sh
wp eval "as_schedule_recurring_action( time(), 1, 'foo' );" \
wp eval "as_schedule_recurring_action( time(), 1, 'bar' );"
```

Now let's wait for the queue runner to do its thing. You can hurry things along via WP CLI in most shells by using the following:

```sh
for i in `seq 8`; wp action-scheduler run; done
```

That done, if you observe the list of scheduled actions via the **Tools ▸ Scheduled Actions** screen, you should see something close to the following:

<img width="862" alt="foo-bar-threshold" src="https://user-images.githubusercontent.com/3594411/223287593-99aa16e3-7eb7-44ae-99ef-a32d3ecce07c.png">

Principally:

* Scheduled actions for `bar` stop being rescheduled after 5 failed attempts.
* Scheduled actions for `foo` continue to be rescheduled (because our filter function is making an exception for these).

### Changelog

> Add - New hook `action_scheduler_recurring_action_is_consistently_failing`.
