### PR TITLE
Defensive coding relating to gaps in declared schedule types.

### DIFF
--- a/classes/ActionScheduler_ListTable.php
+++ b/classes/ActionScheduler_ListTable.php
@@ -252,7 +252,7 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 	 */
 	protected function get_recurrence( $action ) {
 		$schedule = $action->get_schedule();
-		if ( $schedule->is_recurring() ) {
+		if ( $schedule->is_recurring() && method_exists( $schedule, 'get_recurrence' ) ) {
 			$recurrence = $schedule->get_recurrence();
 
 			if ( is_numeric( $recurrence ) ) {
@@ -471,7 +471,7 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 			return __( 'async', 'action-scheduler' );
 		}
 
-		if ( ! $schedule->get_date() ) {
+		if ( ! method_exists( $schedule, 'get_date' ) || ! $schedule->get_date() ) {
 			return '0000-00-00 00:00:00';
 		}
 


### PR DESCRIPTION
Addresses some gaps in our type-safety, while maintaining backwards-compatibility. 

As described in the linked issue, in two locations within the `ActionScheduler_ListTable` we are using a variable type-hinted as implementing the [`ActionScheduler_Scheduler`](https://github.com/woocommerce/action-scheduler/blob/3.5.4/classes/schedules/ActionScheduler_Schedule.php) interface. However, we are also attempting to call the following methods on those variables—neither of which are part of that interface:

- `ActionScheduler_Schedule::get_date()`
- `ActionScheduler_Schedule::get_recurrence()`

In practice, the code works, because the concrete types in play *do* define those methods, however for safety and to avoid noise when running tools like PhpStan against our codebase, it makes sense to make some small changes in this area (...noting that backwards compatibility constraints don't leave us with a lot of flexibility—we can't for instance add two new methods to the interface, or change our public method signatures).

Closes https://github.com/woocommerce/action-scheduler/issues/786.

---

### Testing instructions

Code review is sufficient for this change, however you can manually verify nothing breaks if you run the following in your shell:

```sh
wp db query "DELETE FROM $(wp db prefix)actionscheduler_actions"; \
wp eval "as_schedule_recurring_action( time() + DAY_IN_SECONDS, DAY_IN_SECONDS, 'foo' );"; \
wp eval "as_schedule_single_action( time() + HOUR_IN_SECONDS, 'bar' );" 
```

The above code:

- Removes all existing scheduled actions (to give a cleaner view of things).
- Creates two new actions (one recurring, one not recurring).

If you now visit the **Tools ▸ Scheduled Actions ▸ Pending** screen both code-paths impacted by this PR will be executed, letting you:

- Watch for any breakages.
- Add breakpoints to the relevant methods to ensure things continue to work as expected.

### Changelog

> Fix - Improve safety within the List Table when interacting with Schedule objects.
