### PR TITLE
Always raise the time limit.

### DIFF
--- a/classes/ActionScheduler_Compatibility.php
+++ b/classes/ActionScheduler_Compatibility.php
@@ -93,12 +93,7 @@ class ActionScheduler_Compatibility {
 			return;
 		}
 
-		/*
-		 * Whichever of $max_execution_time or $limit is higher is the amount by which we raise the time limit.
-		 *
-		 * This prevents a scenario where the time limit is inadvertently lowered (such as if $limit is less than
-		 * $max_execution_time, and where the time left to run exceeds $limit).
-		 */
+		// Whichever of $max_execution_time or $limit is higher is the amount by which we raise the time limit.
 		$raise_by = 0 === $limit || $limit > $max_execution_time ? $limit : $max_execution_time;
 
 		if ( function_exists( 'wc_set_time_limit' ) ) {

--- a/classes/ActionScheduler_Compatibility.php
+++ b/classes/ActionScheduler_Compatibility.php
@@ -4,7 +4,6 @@
  * Class ActionScheduler_Compatibility
  */
 class ActionScheduler_Compatibility {
-
 	/**
 	 * Converts a shorthand byte value to an integer byte value.
 	 *
@@ -89,21 +88,23 @@ class ActionScheduler_Compatibility {
 		$limit = (int) $limit;
 		$max_execution_time = (int) ini_get( 'max_execution_time' );
 
-		/*
-		 * If the max execution time is already unlimited (zero), or if it exceeds or is equal to the proposed
-		 * limit, there is no reason for us to make further changes (we never want to lower it).
-		 */
-		if (
-			0 === $max_execution_time
-			|| ( $max_execution_time >= $limit && $limit !== 0 )
-		) {
+		// If the max execution time is already set to zero (unlimited), there is no reason to make a further change.
+		if ( 0 === $max_execution_time ) {
 			return;
 		}
 
+		/*
+		 * Whichever of $max_execution_time or $limit is higher is the amount by which we raise the time limit.
+		 *
+		 * This prevents a scenario where the time limit is inadvertently lowered (such as if $limit is less than
+		 * $max_execution_time, and where the time left to run exceeds $limit).
+		 */
+		$raise_by = 0 === $limit || $limit > $max_execution_time ? $limit : $max_execution_time;
+
 		if ( function_exists( 'wc_set_time_limit' ) ) {
-			wc_set_time_limit( $limit );
+			wc_set_time_limit( $raise_by );
 		} elseif ( function_exists( 'set_time_limit' ) && false === strpos( ini_get( 'disable_functions' ), 'set_time_limit' ) && ! ini_get( 'safe_mode' ) ) { // phpcs:ignore PHPCompatibility.IniDirectives.RemovedIniDirectives.safe_modeDeprecatedRemoved
-			@set_time_limit( $limit ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+			@set_time_limit( $raise_by ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 		}
 	}
 }


### PR DESCRIPTION
Method [`ActionScheduler_Compatibility::raise_time_limit()`](https://github.com/woocommerce/action-scheduler/blob/3.5.4/classes/ActionScheduler_Compatibility.php#L88-L108) is intended to only ever raise and never lower the time limit. However, in some scenarios a time extension is requested but will be ignored. For example:

- Suppose the max execution time is set to 60 seconds.
- Then, with 10 seconds left to run, [`raise_time_limit()`](https://github.com/woocommerce/action-scheduler/blob/3.5.4/classes/ActionScheduler_Compatibility.php#L88-L108) is called with a value of `20`. This should effectively mean the request can run for a further 20 seconds (giving us 70 seconds of execution time in total).
- As currently written, it will make no adjustment at all in this case because the [max execution time is higher than the new value](https://github.com/woocommerce/action-scheduler/blob/3.5.4/classes/ActionScheduler_Compatibility.php#L98).

The problem here is that the current logic ignores the fact that a successful call to [`set_time_limit()`](https://www.php.net/manual/en/function.set-time-limit.php) actually resets the timer. In this PR, we apply the suggestion from the linked issue to always raise the limit—using either the max execution time or the new limit, whichever is higher.

Closes https://github.com/woocommerce/action-scheduler/issues/767.

---

### Testing instructions

Code review should be sufficient in this case.

### Changelog

> Fix - Always raise and never lower the time limit.