### PR TITLE
Add init hook

### DIFF
--- a/classes/abstracts/ActionScheduler.php
+++ b/classes/abstracts/ActionScheduler.php
@@ -165,6 +165,13 @@ abstract class ActionScheduler {
 				 */
 				function () {
 					self::$data_store_initialized = true;
+
+					/**
+					 * Fires when Action Scheduler is ready: it is safe to use the procedural API after this point.
+					 *
+					 * @since 3.5.5
+					 */
+					do_action( 'action_scheduler_init' );
 				},
 				1
 			);
@@ -174,6 +181,13 @@ abstract class ActionScheduler {
 			$logger->init();
 			$runner->init();
 			self::$data_store_initialized = true;
+
+			/**
+			 * Fires when Action Scheduler is ready: it is safe to use the procedural API after this point.
+			 *
+			 * @since 3.5.5
+			 */
+			do_action( 'action_scheduler_init' );
 		}
 
 		if ( apply_filters( 'action_scheduler_load_deprecated_functions', true ) ) {


### PR DESCRIPTION
As suggested in the linked issue, introduces new hook `action_scheduler_init`. It is safe to use the procedural API from this action onwards.

Closes https://github.com/woocommerce/action-scheduler/issues/749.

---

### Notes

- Code review should be sufficient, there are no functional changes.
- Builds on https://github.com/woocommerce/action-scheduler/pull/927 (which tweaks the initialization procedure). Keeping as a draft until that is merged.

---

### Changelog

> Add - New `action_scheduler_init` hook.