### PR TITLE
Document the new `action_scheduler_init` hook.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -22,9 +22,10 @@ Functions return similar values and accept similar arguments to their WP-Cron co
 
 As mentioned in the [Usage - Load Order](usage.md#load-order) section, Action Scheduler will initialize itself on the `'init'` hook with priority `1`. While API functions are loaded prior to this and can be called, they should not be called until after `'init'` with priority `1`, because each component, like the data store, has not yet been initialized.
 
-Do not use Action Scheduler API functions prior to `'init'` hook with priority `1`. Doing so could lead to unexpected results, like data being stored in the incorrect location.
+Do not use Action Scheduler API functions prior to `'init'` hook with priority `1`. Doing so could lead to unexpected results, like data being stored in the incorrect location. To make this easier:
 
-Action Scheduler provides `Action_Scheduler::is_initialized()` for use in hooks to confirm that the data stores have been initialized.
+- Action Scheduler provides `Action_Scheduler::is_initialized()` for use in hooks to confirm that the data stores have been initialized.
+- It also provides the `'action_scheduler_init'` action hook. It is safe to call API functions during or after this event has fired (tip: you can take advantage of WordPress's [did_action()](https://developer.wordpress.org/reference/functions/did_action/) function to check this).
 
 ## Function Reference / `as_enqueue_async_action()`
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -88,7 +88,7 @@ Action Scheduler will register its version on `'plugins_loaded'` with priority `
 
 It is recommended to load it _when the file including it is included_. However, if you need to load it on a hook, then the hook must occur before `'plugins_loaded'`, or you can use `'plugins_loaded'` with negative priority, like `-10`.
 
-Action Scheduler will later initialize itself on `'init'` with priority `1`.  Action Scheduler APIs should not be used until after `'init'` with priority `1`.
+Action Scheduler will later initialize itself on `'init'` with priority `1`.  Action Scheduler APIs should not be used until after `'init'` with priority `1`. As described in [API Function Availability](/api/#api-function-availability), you can also use the `'action_scheduler_init'` action hook for this purpose.
 
 ### Usage in Themes
 


### PR DESCRIPTION
Adds information about the new `action_scheduler_init` hook, added in https://github.com/woocommerce/action-scheduler/pull/929/.

Though otherwise unrelated, this PR 'stacks' on top of https://github.com/woocommerce/action-scheduler/pull/938 since it touches one of the same files (basic idea being to keep all doc changes together, then merge and deploy when 3.6.0 goes live).