### PR TITLE
Remove SHOW TABLES usage when checking if tables exist.

### DIFF
--- a/classes/abstracts/ActionScheduler_Abstract_Schema.php
+++ b/classes/abstracts/ActionScheduler_Abstract_Schema.php
@@ -25,7 +25,7 @@ abstract class ActionScheduler_Abstract_Schema {
 	/**
 	 * @var array Names of tables that will be registered by this class.
 	 */
-	protected $tables = [];
+	protected $tables = array();
 
 	/**
 	 * Can optionally be used by concrete classes to carry out additional initialization work
@@ -90,10 +90,10 @@ abstract class ActionScheduler_Abstract_Schema {
 			$plugin_option_name = 'schema-';
 
 			switch ( static::class ) {
-				case 'ActionScheduler_StoreSchema' :
+				case 'ActionScheduler_StoreSchema':
 					$plugin_option_name .= 'Action_Scheduler\Custom_Tables\DB_Store_Table_Maker';
 					break;
-				case 'ActionScheduler_LoggerSchema' :
+				case 'ActionScheduler_LoggerSchema':
 					$plugin_option_name .= 'Action_Scheduler\Custom_Tables\DB_Logger_Table_Maker';
 					break;
 			}
@@ -129,7 +129,7 @@ abstract class ActionScheduler_Abstract_Schema {
 	 * @return void
 	 */
 	private function update_table( $table ) {
-		require_once( ABSPATH . 'wp-admin/includes/upgrade.php' );
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
 		$definition = $this->get_table_definition( $table );
 		if ( $definition ) {
 			$updated = dbDelta( $definition );
@@ -148,7 +148,7 @@ abstract class ActionScheduler_Abstract_Schema {
 	 *                table prefix for the current blog
 	 */
 	protected function get_full_table_name( $table ) {
-		return $GLOBALS[ 'wpdb' ]->prefix . $table;
+		return $GLOBALS['wpdb']->prefix . $table;
 	}
 
 	/**
@@ -159,7 +159,6 @@ abstract class ActionScheduler_Abstract_Schema {
 	public function tables_exist() {
 		global $wpdb;
 
-		$existing_tables = $wpdb->get_col( 'SHOW TABLES' );
 		$expected_tables = array_map(
 			function ( $table_name ) use ( $wpdb ) {
 				return $wpdb->prefix . $table_name;
@@ -167,6 +166,18 @@ abstract class ActionScheduler_Abstract_Schema {
 			$this->tables
 		);
 
-		return count( array_intersect( $existing_tables, $expected_tables ) ) === count( $expected_tables );
+		$tables_exist = true;
+
+		foreach ( $expected_tables as $table_name ) {
+			$pattern        = str_replace( '_', '\\_', $table_name );
+			$existing_table = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $pattern ) );
+
+			if ( $existing_table !== $table_name ) {
+				$tables_exist = false;
+				break;
+			}
+		}
+
+		return $tables_exist;
 	}
 }

--- a/classes/abstracts/ActionScheduler_Abstract_Schema.php
+++ b/classes/abstracts/ActionScheduler_Abstract_Schema.php
@@ -159,16 +159,10 @@ abstract class ActionScheduler_Abstract_Schema {
 	public function tables_exist() {
 		global $wpdb;
 
-		$expected_tables = array_map(
-			function ( $table_name ) use ( $wpdb ) {
-				return $wpdb->prefix . $table_name;
-			},
-			$this->tables
-		);
-
 		$tables_exist = true;
 
-		foreach ( $expected_tables as $table_name ) {
+		foreach ( $this->tables as $table_name ) {
+			$table_name     = $wpdb->prefix . $table_name;
 			$pattern        = str_replace( '_', '\\_', $table_name );
 			$existing_table = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $pattern ) );
 


### PR DESCRIPTION
ActionScheduler_Abstract_Schema::get_tables() fails on some hosts(WordPress.com for instance) because [HyperDB](https://github.com/Automattic/HyperDB) can't [find a table from the query](https://github.com/Automattic/HyperDB/blob/09c962470332f4dee70d57282bd67d56dd4864ab/db.php#L304). HyperDB allows for splitting a table across multiple servers so it needs to find the table based on the query.
It's failing here because the query is trying to return _all_ of the tables which HyperDB doesn't know what to do with.

`[06-Apr-2023 11:39:59 UTC] WordPress database error Unable to determine dataset (for table: ) for query SHOW TABLES made by ActionScheduler_Abstract_Schema::tables_exist`

This change goes through the expected tables and performs a SHOW TABLES LIKE query on each, and if one fails, marks the return of the `tables_exist()` function as `false`.

### Changelog

> Add - Improved compability when running alongside HyperDB.