### PR TITLE
Docs/3.6.0

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -35,7 +35,7 @@ Enqueue an action to run one time, as soon as possible.
 ### Usage
 
 ```php
-as_enqueue_async_action( $hook, $args, $group, $unique );
+as_enqueue_async_action( $hook, $args, $group, $unique, $priority );
 ```
 
 ### Parameters
@@ -44,6 +44,7 @@ as_enqueue_async_action( $hook, $args, $group, $unique );
 - **$args** (array) Arguments to pass to callbacks when the hook triggers. Default: _`array()`_.
 - **$group** (string) The group to assign this job to. Default: _''_.
 - **$unique** (boolean) Whether the action should be unique. Default: _`false`_.
+- **$priority** (integer) Lower values take precedence over higher values. Defaults to 10, with acceptable values falling in the range 0-255.
 
 ### Return value
 
@@ -59,7 +60,7 @@ Schedule an action to run one time at some defined point in the future.
 ### Usage
 
 ```php
-as_schedule_single_action( $timestamp, $hook, $args, $group, $unique );
+as_schedule_single_action( $timestamp, $hook, $args, $group, $unique, $priority );
 ```
 
 ### Parameters
@@ -69,6 +70,7 @@ as_schedule_single_action( $timestamp, $hook, $args, $group, $unique );
 - **$args** (array) Arguments to pass to callbacks when the hook triggers. Default: _`array()`_.
 - **$group** (string) The group to assign this job to. Default: _''_.
 - **$unique** (boolean) Whether the action should be unique. Default: _`false`_.
+- **$priority** (integer) Lower values take precedence over higher values. Defaults to 10, with acceptable values falling in the range 0-255.)
 
 ### Return value
 
@@ -84,7 +86,7 @@ Schedule an action to run repeatedly with a specified interval in seconds.
 ### Usage
 
 ```php
-as_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, $args, $group, $unique );
+as_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, $args, $group, $unique, $priority );
 ```
 
 ### Parameters
@@ -95,6 +97,7 @@ as_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, $args, $g
 - **$args** (array) Arguments to pass to callbacks when the hook triggers. Default: _`array()`_.
 - **$group** (string) The group to assign this job to. Default: _''_.
 - **$unique** (boolean) Whether the action should be unique. Default: _`false`_.
+- **$priority** (integer) Lower values take precedence over higher values. Defaults to 10, with acceptable values falling in the range 0-255.
 
 ### Return value
 
@@ -112,7 +115,7 @@ If execution of a cron-like action is delayed, the next attempt will still be sc
 ### Usage
 
 ```php
-as_schedule_cron_action( $timestamp, $schedule, $hook, $args, $group, $unique );
+as_schedule_cron_action( $timestamp, $schedule, $hook, $args, $group, $unique, $priority );
 ```
 
 ### Parameters
@@ -123,6 +126,7 @@ as_schedule_cron_action( $timestamp, $schedule, $hook, $args, $group, $unique );
 - **$args** (array) Arguments to pass to callbacks when the hook triggers. Default: _`array()`_.
 - **$group** (string) The group to assign this job to. Default: _''_.
 - **$unique** (boolean) Whether the action should be unique. Default: _`false`_.
+- **$priority** (integer) Lower values take precedence over higher values. Defaults to 10, with acceptable values falling in the range 0-255.
 
 ### Return value
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -22,9 +22,10 @@ Functions return similar values and accept similar arguments to their WP-Cron co
 
 As mentioned in the [Usage - Load Order](usage.md#load-order) section, Action Scheduler will initialize itself on the `'init'` hook with priority `1`. While API functions are loaded prior to this and can be called, they should not be called until after `'init'` with priority `1`, because each component, like the data store, has not yet been initialized.
 
-Do not use Action Scheduler API functions prior to `'init'` hook with priority `1`. Doing so could lead to unexpected results, like data being stored in the incorrect location.
+Do not use Action Scheduler API functions prior to `'init'` hook with priority `1`. Doing so could lead to unexpected results, like data being stored in the incorrect location. To make this easier:
 
-Action Scheduler provides `Action_Scheduler::is_initialized()` for use in hooks to confirm that the data stores have been initialized.
+- Action Scheduler provides `Action_Scheduler::is_initialized()` for use in hooks to confirm that the data stores have been initialized.
+- It also provides the `'action_scheduler_init'` action hook. It is safe to call API functions during or after this event has fired (tip: you can take advantage of WordPress's [did_action()](https://developer.wordpress.org/reference/functions/did_action/) function to check this).
 
 ## Function Reference / `as_enqueue_async_action()`
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -88,7 +88,7 @@ Action Scheduler will register its version on `'plugins_loaded'` with priority `
 
 It is recommended to load it _when the file including it is included_. However, if you need to load it on a hook, then the hook must occur before `'plugins_loaded'`, or you can use `'plugins_loaded'` with negative priority, like `-10`.
 
-Action Scheduler will later initialize itself on `'init'` with priority `1`.  Action Scheduler APIs should not be used until after `'init'` with priority `1`.
+Action Scheduler will later initialize itself on `'init'` with priority `1`.  Action Scheduler APIs should not be used until after `'init'` with priority `1`. As described in [API Function Availability](/api/#api-function-availability), you can also use the `'action_scheduler_init'` action hook for this purpose.
 
 ### Usage in Themes
 

--- a/docs/wp-cli.md
+++ b/docs/wp-cli.md
@@ -39,6 +39,7 @@ These are the commands available to use with Action Scheduler:
     * `--batches` - This is the number of batches to run. Using 0 means that batches will continue running until there are no more actions to run.
     * `--hooks` - Process only actions with specific hook or hooks, like `'woocommerce_scheduled_subscription_payment'`. By default, actions with any hook will be processed. Define multiple hooks as a comma separated string (without spaces), e.g. `--hooks=woocommerce_scheduled_subscription_trial_end,woocommerce_scheduled_subscription_payment,woocommerce_scheduled_subscription_expiration`
     * `--group` - Process only actions in a specific group, like `'woocommerce-memberships'`. By default, actions in any group (or no group) will be processed.
+    * `--exclude-groups` - Ignore actions from the specified group or groups (to specify multiple groups, supply a comma-separated list of slugs). This option is ignored if `--group` is also specified.
     * `--force` - By default, Action Scheduler limits the number of concurrent batches that can be run at once to ensure the server does not get overwhelmed. Using the `--force` flag overrides this behavior to force the WP CLI queue to run.
 
 The best way to get a full list of commands and their available options is to use WP CLI itself. This can be done by running `wp action-scheduler` to list all Action Scheduler commands, or by including the `--help` flag with any of the individual commands. This will provide all relevant parameters and flags for the command.
@@ -83,4 +84,4 @@ If you can batch based on each action's group, then you can improve performance 
 
 For example, if one queue is created to process emails, another to process membership updates, and another to process renewal payments, then the same queries won't be run at the same time, and 3 separate queues will be able to run more efficiently.
 
-The WP CLI runner can achieve this using the `--group` option.
+The WP CLI runner can achieve this using the `--group` option to create queue runners that focus on a specific group and, optionally, the `--exclude-groups` option to create one or more 'catch-all' queue runners that ignore those groups. 


### PR DESCRIPTION
This PR is the sum of several updates to our documentation (relating to changes shipped in 3.6.). Each has already been reviewed and approved:

- https://github.com/woocommerce/action-scheduler/pull/938
- https://github.com/woocommerce/action-scheduler/pull/939
- https://github.com/woocommerce/action-scheduler/pull/940

There are no conflicts, so will go ahead with a merge to make the updates available at https://actionscheduler.org.