### PR TITLE
Ensure actions within each claim are executed in the expected order.

### DIFF
--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -986,7 +986,7 @@ AND `group_id` = %d
 		$cut_off     = $before_date->format( 'Y-m-d H:i:s' );
 
 		$sql = $wpdb->prepare(
-			"SELECT action_id, scheduled_date_gmt FROM {$wpdb->actionscheduler_actions} WHERE claim_id = %d ORDER BY priority ASC",
+			"SELECT action_id, scheduled_date_gmt FROM {$wpdb->actionscheduler_actions} WHERE claim_id = %d ORDER BY priority ASC, attempts ASC, scheduled_date_gmt ASC, action_id ASC",
 			$claim_id
 		);
 

--- a/tests/phpunit/jobstore/ActionScheduler_DBStore_Test.php
+++ b/tests/phpunit/jobstore/ActionScheduler_DBStore_Test.php
@@ -639,4 +639,79 @@ class ActionScheduler_DBStore_Test extends AbstractStoreTest {
 		$action_id_duplicate = $store->save_unique_action( $action_with_diff_args );
 		$this->assertEquals( 0, $action_id_duplicate );
 	}
+
+	/**
+	 * When a set of claimed actions are processed, they should be executed in the expected order (by priority,
+	 * then by least number of attempts, then by scheduled date, then finally by action ID).
+	 *
+	 * @return void
+	 */
+	public function test_actions_are_processed_in_correct_order() {
+		global $wpdb;
+
+		$now          = time();
+		$actual_order = array();
+
+		// When `foo` actions are processed, record the sequence number they supply.
+		$watcher = function ( $number ) use ( &$actual_order ) {
+			$actual_order[] = $number;
+		};
+
+		as_schedule_single_action( $now - 10, 'foo', array( 4 ), '', false, 10 );
+		as_schedule_single_action( $now - 20, 'foo', array( 3 ), '', false, 10 );
+		as_schedule_single_action( $now - 5, 'foo', array( 2 ), '', false, 5 );
+		as_schedule_single_action( $now - 20, 'foo', array( 1 ), '', false, 5 );
+		$reattempted = as_schedule_single_action( $now - 40, 'foo', array( 7 ), '', false, 20 );
+		as_schedule_single_action( $now - 40, 'foo', array( 5 ), '', false, 20 );
+		as_schedule_single_action( $now - 40, 'foo', array( 6 ), '', false, 20 );
+
+		// Modify the `attempt` count on one of our test actions, to change expectations about its execution order.
+		$wpdb->update(
+			$wpdb->actionscheduler_actions,
+			array( 'attempts' => 5 ),
+			array( 'action_id' => $reattempted )
+		);
+
+		add_action( 'foo', $watcher );
+		ActionScheduler_Mocker::get_queue_runner( ActionScheduler::store() )->run();
+		remove_action( 'foo', $watcher );
+
+		$this->assertEquals( range( 1, 7 ), $actual_order, 'When a claim is processed, individual actions execute in the expected order.' );
+	}
+
+	/**
+	 * When a set of claimed actions are processed, they should be executed in the expected order (by priority,
+	 * then by least number of attempts, then by scheduled date, then finally by action ID). This should be true
+	 * even if actions are scheduled from within other scheduled actions.
+	 *
+	 * This test is a variation of `test_actions_are_processed_in_correct_order`, see discussion in
+	 * https://github.com/woocommerce/action-scheduler/issues/951 to see why this specific nuance is tested.
+	 *
+	 * @return void
+	 */
+	public function test_child_actions_are_processed_in_correct_order() {
+		$time         = time() - 10;
+		$actual_order = array();
+		$watcher      = function ( $number ) use ( &$actual_order ) {
+			$actual_order[] = $number;
+		};
+		$parent_action = function () use ( $time ) {
+			// We generate 20 test actions because this is optimal for reproducing the conditions in the
+			// linked bug report. With fewer actions, the error condition is less likely to surface.
+			for ( $i = 1; $i <= 20; $i++ ) {
+				as_schedule_single_action( $time, 'foo', array( $i ) );
+			}
+		};
+
+		add_action( 'foo', $watcher );
+		add_action( 'parent', $parent_action );
+
+		as_schedule_single_action( $time, 'parent' );
+		ActionScheduler_Mocker::get_queue_runner( ActionScheduler::store() )->run();
+
+		remove_action( 'foo', $watcher );
+		add_action( 'parent', $parent_action );
+
+		$this->assertEquals( range( 1, 20 ), $actual_order, 'Once claimed, scheduled actions are executed in the exepcted order, including if "child actions" are scheduled from within another action.' );
+	}
 }


### PR DESCRIPTION
In [3.6.0](https://github.com/woocommerce/action-scheduler/releases/tag/3.6.0) we introduced [action priorities](https://github.com/woocommerce/action-scheduler/pull/921). However, as documented in https://github.com/woocommerce/action-scheduler/issues/951, a situation could arise where actions, *once claimed,* execute in an unexpected order. For example, suppose we have 20 past-due actions with the same hook, same scheduled date, and same priority—something like this: 

| Action ID | Scheduled Date | Priority |
| --- | --- | --- |
| 1 | 2023-05-10 12:00:00 | 10 |
| 2 | 2023-05-10 12:00:00 | 10 |
| ... | ... | ... |
| 20 | 2023-05-10 12:00:00 | 10 |

If all 20 actions are claimed, we might expect execution order to follow the sequence in which the actions were added (ie, 1 → 20), but it's actually possible we would see the reverse or some other unexpected sequence, due to a [lack of explicit ordering](https://github.com/woocommerce/action-scheduler/pull/921/files#diff-187a2644998973fd6a8b8e9455ad006ad4d502273b21f76607137c7c0acf9f1bR989) in [`find_actions_by_claim_id()`](https://github.com/woocommerce/action-scheduler/blob/3.6.0/classes/data-stores/ActionScheduler_DBStore.php#L989).

This change addresses that problem, and other potential ordering issues, and expands our test coverage accordingly.

Closes #951.

--- 

### Testing

- Review the newly added tests.
- Temporarily rollback the change made within the [`find_actions_by_claim_id`](https://github.com/woocommerce/action-scheduler/pull/952/files#diff-187a2644998973fd6a8b8e9455ad006ad4d502273b21f76607137c7c0acf9f1bR989) method to make the tests fail (then restore to see them pass).
- You may also wish to refer to #951 for other ways to manifest this problem.

### Notes

- **Issue severity** → My initial thought is that this is not a critical issue, because the problem surfaces only *after* actions have been claimed (the claim process itself follows expectations) and because action priorities, if specified, will also be respected. In other words, when this problem surfaces, the affected actions are anyway on the cusp of being executed. Please let me know if there is disagreement or concern on this point, since it may impact how quickly we aim to ship the fix.
- **Improving tests** → In the linked report, you can see an example of [snapshot testing](https://github.com/spatie/phpunit-snapshot-assertions). It would be nice to integrate this, but I don't think we can easily or elegantly do so today, because of the range of PHP versions we support. One to revisit in a future iteration, however.

### Changelog

> Fix - Within each processing batch, ensure actions are processed in the expected order.
