### PR TITLE
Fix incorrect text domain.

### DIFF
--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -1029,7 +1029,7 @@ AND `group_id` = %d
 		if ( $row_updates < count( $action_ids ) ) {
 			throw new RuntimeException(
 				sprintf(
-					__( 'Unable to release actions from claim id %d.', 'woocommerce' ),
+					__( 'Unable to release actions from claim id %d.', 'action-scheduler' ),
 					$claim->get_id()
 				)
 			);


### PR DESCRIPTION
After revisiting [this issue](https://github.com/woocommerce/action-scheduler/issues/944#issuecomment-1531388111), I thought I'd try running `npm run check-textdomain` and, lo and behold, it found a case where we'd supplied `'woocommerce'` as the text domain.

This change fixes that :bowtie: 

_Perhaps it would make sense to invoke this utility during pre-commit, or as part of the build command. However, it would make more sense to do so when working on #944, or else shortly afterwards (since, as part of addressing that issue, we may also drop the `grunt-checktextdomain` package, and perhaps replace it with `wp-textdomain` as used in WooCommmerce)._