### PR TITLE
update wporg tested to version to 6.2

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: Automattic, wpmuguru, claudiosanches, peterfabian1000, vedjain, jamosova, obliviousharmony, konamiman, sadowski, royho, barryhughes-1
 Tags: scheduler, cron
 Requires at least: 5.2
-Tested up to: 6.0
+Tested up to: 6.2
 Stable tag: 3.6.1
 License: GPLv3
 Requires PHP: 5.6


### PR DESCRIPTION
This PR only updates the tested to version of WordPress to 6.2 in the WordPress.org readme.txt file.