### PR TITLE
Improve bulk delete handling.

### DIFF
--- a/classes/ActionScheduler_ListTable.php
+++ b/classes/ActionScheduler_ListTable.php
@@ -502,7 +502,20 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 	 */
 	protected function bulk_delete( array $ids, $ids_sql ) {
 		foreach ( $ids as $id ) {
-			$this->store->delete_action( $id );
+			try {
+				$this->store->delete_action( $id );
+			} catch ( Exception $e ) {
+				// A possible reason for an exception would include a scenario where the same action is deleted by a
+				// concurrent request.
+				error_log(
+					sprintf(
+						/* translators: 1: action ID 2: exception message. */
+						__( 'Action Scheduler was unable to delete action %1$d. Reason: %2$s', 'action-scheduler' ),
+						$id,
+						$e->getMessage()
+					)
+				);
+			}
 		}
 	}
 


### PR DESCRIPTION
Though presumably the conditions required for this to happen are rare, it seems it is possible for a fatal error to occur during a bulk delete operation. This is because an exception can be thrown [by the datastore](https://github.com/woocommerce/action-scheduler/blob/3.6.1/classes/data-stores/ActionScheduler_DBStore.php#L743-L746), which is fine in itself and could happen if the action was already deleted (ie, an concurrent process deleted it just a moment earlier), but is not handled by the [list table](https://github.com/woocommerce/action-scheduler/blob/3.6.1/classes/ActionScheduler_ListTable.php#L505). 

For reference, the specific situation cited in [this forum report](https://wordpress.org/support/topic/critical-error-524/) was as follows:

> While performing a ‘Bulk Deletion’ of completed tasks in WooCommerce > Status > Scheduled Actions, I received a Critical Error:
>
> ```
> Error Details
> 
> An error of type E_ERROR was caused in line 724 of the file /.../wp-content/plugins/woocommerce/packages/action-scheduler/classes/data-stores/ActionScheduler_DBStore.php. 
> Error message: Uncaught InvalidArgumentException: Unidentified action 5382 in /.../wp-content/plugins/woocommerce/packages/action-scheduler/classes/data-stores/ActionScheduler_DBStore.php:724
> ```

This change attempts to resolve the problem by catching any exceptions, logging them, and moving on.

Closes #954.

---

### Testing instructions

If you don't already have some scheduled actions you can test with (bearing in mind you will need to delete some of them), you can generate a set using this WP CLI one-liner:

```sh
wp eval "for ( \$i = 0; \$i < 20; \$i++ ) as_schedule_single_action( time() + HOUR_IN_SECONDS, 'Test Action!' );"
```

Then, to simulate the conditions in which this error occurs, add the following code to a suitable location. I would recommend a mu-plugin:

```php
add_action( 'load-tools_page_action-scheduler', function () {
	$action = $_GET['action'] ?? '';
	$ids    = (array) ( $_GET['ID'] ?? [] );

	// If this is not an Action Scheduler delete request, do nothing.
	if ( $action !== 'delete' || empty( $ids ) ) {
		return;
	}

	// Otherwise, setup an action to pre-emptively delete one of the actions before Action Scheduler can do so via its
	// bulk actions handler (we need to wait before doing this: if we do it now, we won't trigger the error).
	add_filter( 'query', function( $query ) use ( $ids ) {
		global $wpdb;
		static $invoked = false;
		$actions_table  = $wpdb->prefix . 'actionscheduler_actions';

		// Is this the bulk action delete query?
		if (
			! str_starts_with( $query, 'DELETE' )
			|| ! str_contains( $query, $actions_table )
		) {
			return $query;
		}

		// If the callback was already invoked, in relation to a 'delete actions' query, bail out.
		if ( $invoked ) {
			return $query;
		} else {
			$invoked = true;
		}

		$wpdb->delete( $actions_table, [ 'action_id' => current( $ids ) ] );
		return $query;
	} );
}, 5 );
```

The above code simply listens for a bulk delete request, then waits until almost the last opportunity before the actual delete query runs, then pre-emptively deletes one of the actions before Action Scheduler can do so. So, to test:

* Setup some test actions you don't mind deleting.
* Add the above code.
* Visit **Tools ▸ Scheduled Actions**.
* Select one or more actions.
* Use the bulk delete tool.

With this change, there should be no fatal error. If you test with the current release, however, you should see the same error as noted above.

---

### Notes

- We could go a step further and provide an admin notice, informing users of the exception. Since this is presumably a rare condition, I didn't want to go to the lengths of adding that in (could be a nice incremental change for the future, though).
- I did not check to see if the same thing is possible using the post store, as that is probably used only very rarely at this point.

---

### Changelog

- Fix - Guard against possible fatal errors when bulk deleting actions.