### PR TITLE
Include database error in the exception message

### DIFF
--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -935,7 +935,17 @@ AND `group_id` = %d
 		$sql           = $wpdb->prepare( "{$update} {$where} {$order} LIMIT %d", $params ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders
 		$rows_affected = $wpdb->query( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 		if ( false === $rows_affected ) {
-			throw new \RuntimeException( __( 'Unable to claim actions. Database error.', 'action-scheduler' ) );
+			$error = empty( $wpdb->last_error )
+				? _x( 'unknown', 'database error', 'action-scheduler' )
+				: $wpdb->last_error;
+
+			throw new \RuntimeException(
+				sprintf(
+					/* translators: %s database error. */
+					__( 'Unable to claim actions. Database error: %s.', 'action-scheduler' ),
+					$error
+				)
+			);
 		}
 
 		return (int) $rows_affected;


### PR DESCRIPTION
If we cannot claim actions due to a database error, we throw an exception:

`Unable to claim actions. Database error.`

However, there is no further information about what went wrong. This PR introduces a small change to include the last database error (if it is available) in the exception message.

Closes #878.

---

### Testing instructions

You will need to create conditions in which the claim query fails. One way is to temporarily edit the [`claim_actions`](https://github.com/woocommerce/action-scheduler/blob/3.6.1/classes/data-stores/ActionScheduler_DBStore.php#L860) method and modify part of the query. Another is to add the following snippet to your site, which will achieve the same effect (I would recommend placing it in a `mu-plugin`, then removing it after testing):

```php
add_filter( 'action_scheduler_claim_actions_order_by', function ( $sql ) {
	return "USING `phasers` SET TO `stun` $sql";
} );
```

With that in place, try processing the queue via WP CLI:

```
wp action-scheduler run
```

The WP CLI error message should now include details of the database error (depending on your environment and how it is configured, essentially the same error may additionally be output *before* the WP CLI error line ... that's ok, what we're confirming is that the db error is included in the exception):

```
Error: There was an error running the action scheduler: Unable to claim actions. Database error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'USING `phasers` SET TO `stun` ORDER BY priority ASC, attempts' at line 1.
```

Then, remove the snippet (or undo your manual change to the query) and run the queue a second time:

```
wp action-scheduler run
```

This time, things should work as normal.

--- 

### Changelog

> Dev - We try to capture and surface the specific database error, if one occurs, during the claim process.