### PR TITLE
Atomic option locking

### DIFF
--- a/classes/ActionScheduler_OptionLock.php
+++ b/classes/ActionScheduler_OptionLock.php
@@ -32,7 +32,6 @@ class ActionScheduler_OptionLock extends ActionScheduler_Lock {
 
 		// The lock may not exist yet, or may have been deleted.
 		if ( empty( $existing_lock_value ) ) {
-
 			return (bool) $wpdb->insert(
 				$wpdb->options,
 				array(

--- a/classes/ActionScheduler_OptionLock.php
+++ b/classes/ActionScheduler_OptionLock.php
@@ -32,20 +32,13 @@ class ActionScheduler_OptionLock extends ActionScheduler_Lock {
 
 		// The lock may not exist yet, or may have been deleted.
 		if ( empty( $existing_lock_value ) ) {
-			return (bool) $wpdb->query(
-				$wpdb->prepare(
-					"
-						INSERT INTO $wpdb->options ( option_name, option_value, autoload )
-						SELECT %s, %s, 'no'
-						WHERE NOT EXISTS (
-						    SELECT 1
-						    FROM   $wpdb->options
-						    WHERE  option_name = %s
-						)
-					",
-					$lock_key,
-					$new_lock_value,
-					$lock_key
+
+			return (bool) $wpdb->insert(
+				$wpdb->options,
+				array(
+					'option_name'  => $lock_key,
+					'option_value' => $new_lock_value,
+					'autoload'     => 'no',
 				)
 			);
 		}

--- a/classes/ActionScheduler_OptionLock.php
+++ b/classes/ActionScheduler_OptionLock.php
@@ -35,7 +35,7 @@ class ActionScheduler_OptionLock extends ActionScheduler_Lock {
 			return (bool) $wpdb->query(
 				$wpdb->prepare(
 					"
-						INSERT INTO $wpdb->options ( 'option_name', 'option_value', 'autoload' )
+						INSERT INTO $wpdb->options ( option_name, option_value, autoload )
 						SELECT %s, %s, 'no'
 						WHERE NOT EXISTS (
 						    SELECT 1

--- a/classes/ActionScheduler_QueueRunner.php
+++ b/classes/ActionScheduler_QueueRunner.php
@@ -103,9 +103,12 @@ class ActionScheduler_QueueRunner extends ActionScheduler_Abstract_QueueRunner {
 	 * should dispatch a request to process pending actions.
 	 */
 	public function maybe_dispatch_async_request() {
-		if ( is_admin() && ! ActionScheduler::lock()->is_locked( 'async-request-runner' ) ) {
-			// Only start an async queue at most once every 60 seconds
-			ActionScheduler::lock()->set( 'async-request-runner' );
+		// Only start an async queue at most once every 60 seconds.
+		if (
+			is_admin()
+			&& ! ActionScheduler::lock()->is_locked( 'async-request-runner' )
+			&& ActionScheduler::lock()->set( 'async-request-runner' )
+		) {
 			$this->async_request->maybe_dispatch();
 		}
 	}

--- a/classes/abstracts/ActionScheduler_Lock.php
+++ b/classes/abstracts/ActionScheduler_Lock.php
@@ -26,6 +26,8 @@ abstract class ActionScheduler_Lock {
 	/**
 	 * Set a lock.
 	 *
+	 * To prevent race conditions, implementations should avoid setting the lock if the lock is already held.
+	 *
 	 * @param string $lock_type A string to identify different lock types.
 	 * @return bool
 	 */


### PR DESCRIPTION
Updates the Option Lock implementation to reduce the potential for race conditions.

Previously, and with reference to [`ActionScheduler_QueueRunner::maybe_dispatch_async_request()`](https://github.com/woocommerce/action-scheduler/blob/3.6.1/classes/ActionScheduler_QueueRunner.php#L105-L111), we had this pattern:

```php
if ( is_admin() && ! ActionScheduler::lock()->is_locked( 'async-request-runner' ) ) {
	// Only start an async queue at most once every 60 seconds
	ActionScheduler::lock()->set( 'async-request-runner' );
	$this->async_request->maybe_dispatch();
}
```

The problem is that another process may obtain the lock immediately after we enter the *if {}* block, but before we set the lock. As noted in the linked issue, this isn't just theoretical: some cases of this happening have been detected in the wild. This change attempts to address the problem in the following ways:

- When calling `$lock->set()`, it will only successfully claim the lock and return true if another process did not get there first. Therefore, we now only try to dispatch the async queue runner request if calling `$lock->set()` returns true.
- The public interface remains unchanged, since there may be alternative (custom) locking implementations in use.
- Related to the previous point, within the Queue Runner we still call `$lock->is_locked()` because, even though this should now be superfluous when the updated Option Lock implementation is in use, we don't actually know that that is the active implementation.
- Lastly, though we are still using the options *table*, we are no longer using the options API. That's a trade-off, but it should mean we gain better protection against race conditions.

Closes #793.

---

### Testing instructions

Code review and some free-style testing (such as single-stepping through the locking process with XDebug) may be the best way to test and examine the changes to the locking system, but I will anyway outline a fairly manual method of testing here. *These testing instructions do not try to simulate the sort of highly concurrent conditions that would lead to a race condition, they simply ensure we haven't obviously broken the way async queue running works.*

First, we should disable any methods of triggering the queue runner *except* for the async queue runner:

- Disable WP Cron by adding `define( 'DISABLE_WP_CRON', true );` to your *wp-config.php* file.
- If you use system crontab (or equivalent), remove or disable any rules that trigger the queue runner via WP CLI, or that trigger WP Cron.

You may also wish to manually generate some scheduled actions using this one-liner:

```sh
wp eval "for ( \$i = 0; \$i <= 50; \$i++ ) as_enqueue_async_action( 'foo-' . rand( 1000, 9999 ) );"
```

That should give us 50 scheduled actions that are 'past due'. 

Before we go any further I want to highlight that, by default, the locking system is used in such a way that a new queue runner is spawned no more frequently than once every 60 seconds.

Visit **Tools ▸ Scheduled Actions** ... you should see at least 50 actions are past-due (there may be more, depending on how many were already present in your test site ... and, if you do not see any, it's possible a queue runner just finished its work and so you may need to re-run the above snippet a second time). Also, there should be an indication as to when the next queue runner will start:

<div align="center"><img width="500" alt="Screenshot 2023-06-29 at 16 14 31" src="https://github.com/woocommerce/action-scheduler/assets/3594411/1b7acc2e-e359-4533-877f-cb36f7b21737"></div>

- If you refresh the page before the next queue runner is initiated, then the past-due count should not change.
- If you wait and then refresh after the queue runner should have started , then the past-due count should reduce significantly.

This should be enough to assure us that:

- The lock is still respected.
- Async queue runners are still being spawned.
---

### Changelog

> Fix - Improve locking mechanism to protect against race conditions.