### PR TITLE
Move plugin requirements to plugin header

### DIFF
--- a/action-scheduler.php
+++ b/action-scheduler.php
@@ -7,6 +7,9 @@
  * Author URI: https://automattic.com/
  * Version: 3.6.1
  * License: GPLv3
+ * Tested up to: 6.2
+ * Requires at least: 5.2
+ * Requires PHP: 5.6
  *
  * Copyright 2019 Automattic, Inc.  (https://automattic.com/contact/)
  *

--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,6 @@
 === Action Scheduler ===
 Contributors: Automattic, wpmuguru, claudiosanches, peterfabian1000, vedjain, jamosova, obliviousharmony, konamiman, sadowski, royho, barryhughes-1
 Tags: scheduler, cron
-Requires at least: 5.2
-Tested up to: 6.2
 Stable tag: 3.6.1
 License: GPLv3
 Requires PHP: 5.6

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,6 @@ Contributors: Automattic, wpmuguru, claudiosanches, peterfabian1000, vedjain, ja
 Tags: scheduler, cron
 Stable tag: 3.6.1
 License: GPLv3
-Requires PHP: 5.6
 
 Action Scheduler - Job Queue for WordPress
 


### PR DESCRIPTION
As I was attempting to release the latest version of Action Scheduler, our release command's automation for updating the tested up to header choked because it didn't find any tested up to version in the plugin header. I looked into it further, and it appears that since WP 5.8, the readme is no longer parsed for requirement values. From the handbook:

> Since WordPress 5.8 plugin [readme files are not parsed for requirements](https://core.trac.wordpress.org/ticket/48520). This means that headers Requires PHP and Requires at least are going to be parsed from plugin’s main PHP file.

This PR moves those values from the readme to the plugin header.

**Note: I intentionally left tested up to as 6.2 here so that I can be sure we can update this value to 6.3 via the release command after this PR is merged.**