### PR TITLE
Add tested up to back to readme

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,6 +3,7 @@ Contributors: Automattic, wpmuguru, claudiosanches, peterfabian1000, vedjain, ja
 Tags: scheduler, cron
 Stable tag: 3.6.1
 License: GPLv3
+Tested up to: 6.2
 
 Action Scheduler - Job Queue for WordPress
 


### PR DESCRIPTION
I had previously removed `Tested up to` from the readme file in #974. While the [plugin handbook](https://developer.wordpress.org/plugins/wordpress-org/how-your-readme-txt-works/) mentions that `Requires PHP` and `Requires at least` have been moved to the main plugin file, apparently `Tested up to` still remains in the readme.

I had a look at what we do in Accommodation Bookings, which is another extension we release to .org with Woorelease, and it looks like we populate it in [both](https://github.com/woocommerce/woocommerce-accommodation-bookings/blob/b168d530f1048d855daebcfa28664da1c62aa5d9/woocommerce-accommodation-bookings.php#L11) [places](https://github.com/woocommerce/woocommerce-accommodation-bookings/blob/b168d530f1048d855daebcfa28664da1c62aa5d9/readme.txt#L5). I'm adding it back to the readme because of that, as Woorelease is already configured to update both locations.