### PR TITLE
Use `_doing_it_wrong` in initialization check

### DIFF
--- a/classes/abstracts/ActionScheduler.php
+++ b/classes/abstracts/ActionScheduler.php
@@ -226,7 +226,7 @@ abstract class ActionScheduler {
 				__( '%s() was called before the Action Scheduler data store was initialized', 'action-scheduler' ),
 				esc_attr( $function_name )
 			);
-			error_log( $message );
+			_doing_it_wrong( $function_name, $message, '3.1.6' );
 		}
 
 		return self::$data_store_initialized;


### PR DESCRIPTION
Replaces the `error_log` call with WP Core's `_doing_it_wrong` function. The latter uses `trigger_error`, which is more versatile than `error_log` because its behavior can be customized with an error handler. `_doing_it_wrong` also only triggers an error if WP_DEBUG is set to true, so it won't add noise to logs in production environments.

## To test

1. In your testing environment, set `WP_DEBUG` to `true`. Also, either install and activate [Query Monitor](https://wordpress.org/plugins/query-monitor/) (for viewing PHP errors) or set `WP_DEBUG_LOG` to `true`.
2. Add the following snippet to a file in your mu-plugins directory:
    ```
	add_action(
		'plugins_loaded',
		function() {
			as_schedule_single_action( time() + HOUR_IN_SECONDS, 'not_a_real_hook' );
		}
	);
    ```
3. In WP Admin, navigate to **Tools > Scheduled Actions**. There should _not_ be a scheduled event for `not_a_real_hook`, because `as_schedule_single_action` was called before Action Scheduler was fully initialized.
4. Now check your PHP errors, either in the Query Monitor console or in your error log file. You should see the following error:
    > Function as_schedule_single_action was called incorrectly. as_schedule_single_action() was called before the Action Scheduler data store was initialized Please see Debugging in WordPress for more information. (This message was added in version 3.1.6.)
5. Now set `WP_DEBUG` to `false` and refresh the Scheduled Actions screen. You should still _not_ see a scheduled event for `not_a_real_hook`. Additionally, though, there should _not_ be a PHP error message this time, because debug has been disabled.