### PR TITLE
Add extended indexes for hook_status_scheduled_date_gmt and status_sheduled_date_gmt

### DIFF
--- a/classes/schema/ActionScheduler_StoreSchema.php
+++ b/classes/schema/ActionScheduler_StoreSchema.php
@@ -38,6 +38,7 @@ class ActionScheduler_StoreSchema extends ActionScheduler_Abstract_Schema {
 		$table_name       = $wpdb->$table;
 		$charset_collate  = $wpdb->get_charset_collate();
 		$max_index_length = 191; // @see wp_get_db_schema()
+		$hook_status_scheduled_date_gmt_max_index_length = $max_index_length - 20 - 8; // - status, - scheduled_date_gmt
 		$default_date     = self::DEFAULT_DATE;
 		switch ( $table ) {
 
@@ -59,8 +60,8 @@ class ActionScheduler_StoreSchema extends ActionScheduler_Abstract_Schema {
 				        claim_id bigint(20) unsigned NOT NULL default '0',
 				        extended_args varchar(8000) DEFAULT NULL,
 				        PRIMARY KEY  (action_id),
-				        KEY hook (hook($max_index_length)),
-				        KEY status (status),
+				        KEY hook_status_scheduled_date_gmt (hook($hook_status_scheduled_date_gmt_max_index_length), status, scheduled_date_gmt),
+				        KEY status_scheduled_date_gmt (status, scheduled_date_gmt),
 				        KEY scheduled_date_gmt (scheduled_date_gmt),
 				        KEY args (args($max_index_length)),
 				        KEY group_id (group_id),


### PR DESCRIPTION
Fixes #978

The current `hook` and `status` indexes can be pretty useless as there isn't enough uniqueness in the generated index to add much value to query performance.  Extending these keys to include the `status` and `scheduled_date_gmt` make them much more useful for functions like `as_next_scheduled_action()` and `ActionScheduler_Store::has_pending_actions_due()`.

### Changelog

> Fix - Improve indicies within the actions table.