### PR TITLE
Fix: Use orderby => 'none' when bulk cancelling actions.

### DIFF
--- a/classes/abstracts/ActionScheduler_Store.php
+++ b/classes/abstracts/ActionScheduler_Store.php
@@ -347,7 +347,7 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 					'hook'     => $hook,
 					'status'   => self::STATUS_PENDING,
 					'per_page' => 1000,
-					'orderby'  => 'action_id',
+					'orderby'  => 'none',
 				)
 			);
 
@@ -372,7 +372,7 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 					'group'    => $group,
 					'status'   => self::STATUS_PENDING,
 					'per_page' => 1000,
-					'orderby'  => 'action_id',
+					'orderby'  => 'none',
 				)
 			);
 

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -705,7 +705,7 @@ AND `group_id` = %d
 			array(
 				'per_page' => 1000,
 				'status'   => self::STATUS_PENDING,
-				'orderby'  => 'action_id',
+				'orderby'  => 'none',
 			)
 		);
 


### PR DESCRIPTION
The orderby clause when querying actions to cancel can result in a filesort operation for larger tables as there is no corresponding index that provides the where clause followed by the action_id.  Since any actions being cancelled transition to another status, we don't need to have a sort in the initial query to read the IDs.