### PR TITLE
Fix option lock test

### DIFF
--- a/tests/phpunit.xml.dist
+++ b/tests/phpunit.xml.dist
@@ -23,6 +23,7 @@
 		<testsuite name="Action Scheduler">
 			<directory>./phpunit/helpers</directory>
 			<directory>./phpunit/jobs</directory>
+			<directory>./phpunit/lock</directory>
 			<directory>./phpunit/procedural_api</directory>
 			<directory>./phpunit/runner</directory>
 			<directory>./phpunit/schedules</directory>

--- a/tests/phpunit/lock/ActionScheduler_OptionLock_Test.php
+++ b/tests/phpunit/lock/ActionScheduler_OptionLock_Test.php
@@ -57,7 +57,7 @@ class ActionScheduler_OptionLock_Test extends ActionScheduler_UnitTestCase {
 		$simulate_concurrent_claim = function ( $query ) use ( $lock, $type ) {
 			static $executed = false;
 
-			if ( ! $executed && false !== strpos( $query, 'action_scheduler_lock_' ) && 0 === strpos( $query, 'UPDATE' ) ) {
+			if ( ! $executed && false !== strpos( $query, 'action_scheduler_lock_' ) && 0 === strpos( $query, 'INSERT INTO' ) ) {
 				$executed = true;
 				$lock->set( $type );
 			}

--- a/tests/phpunit/lock/ActionScheduler_OptionLock_Test.php
+++ b/tests/phpunit/lock/ActionScheduler_OptionLock_Test.php
@@ -49,6 +49,8 @@ class ActionScheduler_OptionLock_Test extends ActionScheduler_UnitTestCase {
 	 * @return void
 	 */
 	public function test_lock_resists_race_conditions() {
+		global $wpdb;
+
 		$lock = ActionScheduler::lock();
 		$type = md5( wp_rand() );
 
@@ -66,8 +68,10 @@ class ActionScheduler_OptionLock_Test extends ActionScheduler_UnitTestCase {
 		};
 
 		add_filter( 'query', $simulate_concurrent_claim );
+		$wpdb->suppress_errors( true );
 		$this->assertFalse( $lock->is_locked( $type ), 'Initially, the lock is not held' );
 		$this->assertFalse( $lock->set( $type ), 'The lock was not obtained, because another process already claimed it.' );
+		$wpdb->suppress_errors( false );
 		remove_filter( 'query', $simulate_concurrent_claim );
 	}
 }


### PR DESCRIPTION
Fixes a couple of items (thank you @lsinger for raising awareness!):

- The lock tests were not part of the main test suite.
- One of the lock tests made the wrong assumption about the shape of an update query, and was failing.

Worth calling out: I'm deliberately suppressing database errors (but only temporarily). Without the suppression, if you run the test suite locally, you will notice unwanted noise in the output:

<img width="1511" alt="Screenshot 2023-09-22 at 09 17 39" src="https://github.com/woocommerce/action-scheduler/assets/3594411/1a43c546-0479-4ef5-a691-b134384453fb">

If there are any concerns with this, let me know.
