### PR TITLE
Update PR unit tests matrix

### DIFF
--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -25,6 +25,9 @@ jobs:
             wp: 5.4
           - php: 8.0
             wp: 5.5
+          # WordPress 6.3+ requires PHP 7.0+
+          - php: 5.6
+            wp: latest
     services:
       database:
         image: mysql:5.6

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,25 @@
-phpunit.xml
-vendor
+# Operating System files
+.DS_Store
+Thumbs.db
+
+# IDE files
 .idea
-node_modules
+.vscode/*
+project.xml
+project.properties
+.project
+.settings*
+*.sublime-project
+*.sublime-workspace
+.sublimelinterrc
+
+# Project files
+node_modules/
+vendor/
+
+#PHP Unit
+.phpunit.result.cache
+phpunit.xml
+
+# Build files
 action-scheduler.zip


### PR DESCRIPTION
Action Scheduler's [unit test matrix](https://github.com/woocommerce/action-scheduler/blob/trunk/.github/workflows/pr-unit-tests.yml#L11) tries to run tests with PHP 5.6 and WordPress latest. As of 6.3, [WordPress supports only PHP versions 7+](https://github.com/WordPress/wordpress-develop/commit/f7dbb2462ba35362be2ab632f466ba1a4d760282), so the "PHP 5.6 / WordPress latest" tests have been failing very quickly.

This PR excludes that combination from the test matrix (and also updates the `.gitignore` file by picking the most relevant bits from WooCommerce's).

Also see https://github.com/woocommerce/action-scheduler/issues/996 for additional tasks around this issue. 