### PR TITLE
Catch and log exceptions thrown when actions can't be created, e.g. under a corrupt database schema

### DIFF
--- a/classes/data-stores/ActionScheduler_DBLogger.php
+++ b/classes/data-stores/ActionScheduler_DBLogger.php
@@ -82,7 +82,7 @@ class ActionScheduler_DBLogger extends ActionScheduler_Logger {
 	}
 
 	/**
-	 * Retrieve the an action's log entries from the database.
+	 * Retrieve an action's log entries from the database.
 	 *
 	 * @param int $action_id Action ID.
 	 *

--- a/docs/api.md
+++ b/docs/api.md
@@ -49,8 +49,7 @@ as_enqueue_async_action( $hook, $args, $group, $unique, $priority );
 
 ### Return value
 
-`(integer)` the action's ID.
-
+`(integer)` the action's ID. Zero if there was an error scheduling the action. The error will be sent to `error_log`.
 
 ## Function Reference / `as_schedule_single_action()`
 
@@ -75,8 +74,7 @@ as_schedule_single_action( $timestamp, $hook, $args, $group, $unique, $priority 
 
 ### Return value
 
-`(integer)` the action's ID.
-
+`(integer)` the action's ID. Zero if there was an error scheduling the action. The error will be sent to `error_log`.
 
 ## Function Reference / `as_schedule_recurring_action()`
 
@@ -102,14 +100,13 @@ as_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, $args, $g
 
 ### Return value
 
-`(integer)` the action's ID.
-
+`(integer)` the action's ID. Zero if there was an error scheduling the action. The error will be sent to `error_log`.
 
 ## Function Reference / `as_schedule_cron_action()`
 
 ### Description
 
-Schedule an action that recurs on a cron-like schedule. 
+Schedule an action that recurs on a cron-like schedule.
 
 If execution of a cron-like action is delayed, the next attempt will still be scheduled according to the provided cron expression.
 
@@ -131,8 +128,7 @@ as_schedule_cron_action( $timestamp, $schedule, $hook, $args, $group, $unique, $
 
 ### Return value
 
-`(integer)` the action's ID.
-
+`(integer)` the action's ID. Zero if there was an error scheduling the action. The error will be sent to `error_log`.
 
 ## Function Reference / `as_unschedule_action()`
 
@@ -178,7 +174,6 @@ as_unschedule_all_actions( $hook, $args, $group )
 
 `(string|null)` The scheduled action ID if a scheduled action was found, or null if no matching action found.
 
-
 ## Function Reference / `as_next_scheduled_action()`
 
 ### Description
@@ -201,7 +196,6 @@ as_next_scheduled_action( $hook, $args, $group );
 
 `(integer|boolean)` The timestamp for the next occurrence of a pending scheduled action, true for an async or in-progress action or false if there is no matching action.
 
-
 ## Function Reference / `as_has_scheduled_action()`
 
 ### Description
@@ -223,7 +217,6 @@ as_has_scheduled_action( $hook, $args, $group );
 ### Return value
 
 `(boolean)` True if a matching action is pending or in-progress, false otherwise.
-
 
 ## Function Reference / `as_get_scheduled_actions()`
 

--- a/functions.php
+++ b/functions.php
@@ -53,8 +53,7 @@ function as_enqueue_async_action( $hook, $args = array(), $group = '', $unique =
 			)
 		);
 	} catch ( Exception $exception ) {
-		ActionScheduler::logger()->log(
-			0,
+		error_log(
 			sprintf(
 				/* translators: %1$s is the name of the hook to be enqueued, %2$s is the exception message. */
 				__( 'Caught exception while enqueuing action "%1$s": %2$s', 'action-scheduler' ),
@@ -117,8 +116,7 @@ function as_schedule_single_action( $timestamp, $hook, $args = array(), $group =
 			)
 		);
 	} catch ( Exception $exception ) {
-		ActionScheduler::logger()->log(
-			0,
+		error_log(
 			sprintf(
 				/* translators: %1$s is the name of the hook to be enqueued, %2$s is the exception message. */
 				__( 'Caught exception while enqueuing action "%1$s": %2$s', 'action-scheduler' ),
@@ -203,8 +201,7 @@ function as_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, 
 			)
 		);
 	} catch ( Exception $exception ) {
-		ActionScheduler::logger()->log(
-			0,
+		error_log(
 			sprintf(
 				/* translators: %1$s is the name of the hook to be enqueued, %2$s is the exception message. */
 				__( 'Caught exception while enqueuing action "%1$s": %2$s', 'action-scheduler' ),
@@ -282,8 +279,7 @@ function as_schedule_cron_action( $timestamp, $schedule, $hook, $args = array(),
 			)
 		);
 	} catch ( Exception $exception ) {
-		ActionScheduler::logger()->log(
-			0,
+		error_log(
 			sprintf(
 				/* translators: %1$s is the name of the hook to be enqueued, %2$s is the exception message. */
 				__( 'Caught exception while enqueuing action "%1$s": %2$s', 'action-scheduler' ),

--- a/functions.php
+++ b/functions.php
@@ -14,7 +14,7 @@
  * @param bool   $unique Whether the action should be unique.
  * @param int    $priority Lower values take precedence over higher values. Defaults to 10, with acceptable values falling in the range 0-255.
  *
- * @return int The action ID.
+ * @return int The action ID. Zero if there was an error scheduling the action.
  */
 function as_enqueue_async_action( $hook, $args = array(), $group = '', $unique = false, $priority = 10 ) {
 	if ( ! ActionScheduler::is_initialized( __FUNCTION__ ) ) {
@@ -76,7 +76,7 @@ function as_enqueue_async_action( $hook, $args = array(), $group = '', $unique =
  * @param bool   $unique Whether the action should be unique.
  * @param int    $priority Lower values take precedence over higher values. Defaults to 10, with acceptable values falling in the range 0-255.
  *
- * @return int The action ID.
+ * @return int The action ID. Zero if there was an error scheduling the action.
  */
 function as_schedule_single_action( $timestamp, $hook, $args = array(), $group = '', $unique = false, $priority = 10 ) {
 	if ( ! ActionScheduler::is_initialized( __FUNCTION__ ) ) {
@@ -141,7 +141,7 @@ function as_schedule_single_action( $timestamp, $hook, $args = array(), $group =
  * @param bool   $unique Whether the action should be unique.
  * @param int    $priority Lower values take precedence over higher values. Defaults to 10, with acceptable values falling in the range 0-255.
  *
- * @return int The action ID.
+ * @return int The action ID. Zero if there was an error scheduling the action.
  */
 function as_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, $args = array(), $group = '', $unique = false, $priority = 10 ) {
 	if ( ! ActionScheduler::is_initialized( __FUNCTION__ ) ) {
@@ -239,7 +239,7 @@ function as_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, 
  * @param bool   $unique Whether the action should be unique.
  * @param int    $priority Lower values take precedence over higher values. Defaults to 10, with acceptable values falling in the range 0-255.
  *
- * @return int The action ID.
+ * @return int The action ID. Zero if there was an error scheduling the action.
  */
 function as_schedule_cron_action( $timestamp, $schedule, $hook, $args = array(), $group = '', $unique = false, $priority = 10 ) {
 	if ( ! ActionScheduler::is_initialized( __FUNCTION__ ) ) {

--- a/functions.php
+++ b/functions.php
@@ -41,16 +41,28 @@ function as_enqueue_async_action( $hook, $args = array(), $group = '', $unique =
 		return is_int( $pre ) ? $pre : 0;
 	}
 
-	return ActionScheduler::factory()->create(
-		array(
-			'type'      => 'async',
-			'hook'      => $hook,
-			'arguments' => $args,
-			'group'     => $group,
-			'unique'    => $unique,
-			'priority'  => $priority,
-		)
-	);
+	try {
+		return ActionScheduler::factory()->create(
+			array(
+				'type'      => 'async',
+				'hook'      => $hook,
+				'arguments' => $args,
+				'group'     => $group,
+				'unique'    => $unique,
+				'priority'  => $priority,
+			)
+		);
+	} catch ( Exception $exception ) {
+		ActionScheduler::logger()->log(
+			0,
+			sprintf(
+				/* translators: %s is the name of the hook to be enqueued. */
+				__( 'Caught exception while enqueuing action: %s', 'action-scheduler' ),
+				esc_attr( $hook )
+			)
+		);
+		return 0;
+	}
 }
 
 /**
@@ -91,17 +103,29 @@ function as_schedule_single_action( $timestamp, $hook, $args = array(), $group =
 		return is_int( $pre ) ? $pre : 0;
 	}
 
-	return ActionScheduler::factory()->create(
-		array(
-			'type'      => 'single',
-			'hook'      => $hook,
-			'arguments' => $args,
-			'when'      => $timestamp,
-			'group'     => $group,
-			'unique'    => $unique,
-			'priority'  => $priority,
-		)
-	);
+	try {
+		return ActionScheduler::factory()->create(
+			array(
+				'type'      => 'single',
+				'hook'      => $hook,
+				'arguments' => $args,
+				'when'      => $timestamp,
+				'group'     => $group,
+				'unique'    => $unique,
+				'priority'  => $priority,
+			)
+		);
+	} catch ( Exception $exception ) {
+		ActionScheduler::logger()->log(
+			0,
+			sprintf(
+				/* translators: %s is the name of the hook to be enqueued. */
+				__( 'Caught exception while enqueuing action: %s', 'action-scheduler' ),
+				esc_attr( $hook )
+			)
+		);
+		return 0;
+	}
 }
 
 /**
@@ -163,18 +187,30 @@ function as_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, 
 		return is_int( $pre ) ? $pre : 0;
 	}
 
-	return ActionScheduler::factory()->create(
-		array(
-			'type'      => 'recurring',
-			'hook'      => $hook,
-			'arguments' => $args,
-			'when'      => $timestamp,
-			'pattern'   => $interval_in_seconds,
-			'group'     => $group,
-			'unique'    => $unique,
-			'priority'  => $priority,
-		)
-	);
+	try {
+		return ActionScheduler::factory()->create(
+			array(
+				'type'      => 'recurring',
+				'hook'      => $hook,
+				'arguments' => $args,
+				'when'      => $timestamp,
+				'pattern'   => $interval_in_seconds,
+				'group'     => $group,
+				'unique'    => $unique,
+				'priority'  => $priority,
+			)
+		);
+	} catch ( Exception $exception ) {
+		ActionScheduler::logger()->log(
+			0,
+			sprintf(
+				/* translators: %s is the name of the hook to be enqueued. */
+				__( 'Caught exception while enqueuing action: %s', 'action-scheduler' ),
+				esc_attr( $hook )
+			)
+		);
+		return 0;
+	}
 }
 
 /**
@@ -229,18 +265,30 @@ function as_schedule_cron_action( $timestamp, $schedule, $hook, $args = array(),
 		return is_int( $pre ) ? $pre : 0;
 	}
 
-	return ActionScheduler::factory()->create(
-		array(
-			'type'      => 'cron',
-			'hook'      => $hook,
-			'arguments' => $args,
-			'when'      => $timestamp,
-			'pattern'   => $schedule,
-			'group'     => $group,
-			'unique'    => $unique,
-			'priority'  => $priority,
-		)
-	);
+	try {
+		return ActionScheduler::factory()->create(
+			array(
+				'type'      => 'cron',
+				'hook'      => $hook,
+				'arguments' => $args,
+				'when'      => $timestamp,
+				'pattern'   => $schedule,
+				'group'     => $group,
+				'unique'    => $unique,
+				'priority'  => $priority,
+			)
+		);
+	} catch ( Exception $exception ) {
+		ActionScheduler::logger()->log(
+			0,
+			sprintf(
+				/* translators: %s is the name of the hook to be enqueued. */
+				__( 'Caught exception while enqueuing action: %s', 'action-scheduler' ),
+				esc_attr( $hook )
+			)
+		);
+		return 0;
+	}
 }
 
 /**

--- a/functions.php
+++ b/functions.php
@@ -56,9 +56,10 @@ function as_enqueue_async_action( $hook, $args = array(), $group = '', $unique =
 		ActionScheduler::logger()->log(
 			0,
 			sprintf(
-				/* translators: %s is the name of the hook to be enqueued. */
-				__( 'Caught exception while enqueuing action: %s', 'action-scheduler' ),
-				esc_attr( $hook )
+				/* translators: %1$s is the name of the hook to be enqueued, %2$s is the exception message. */
+				__( 'Caught exception while enqueuing action "%1$s": %2$s', 'action-scheduler' ),
+				$hook,
+				$exception->getMessage()
 			)
 		);
 		return 0;
@@ -119,9 +120,10 @@ function as_schedule_single_action( $timestamp, $hook, $args = array(), $group =
 		ActionScheduler::logger()->log(
 			0,
 			sprintf(
-				/* translators: %s is the name of the hook to be enqueued. */
-				__( 'Caught exception while enqueuing action: %s', 'action-scheduler' ),
-				esc_attr( $hook )
+				/* translators: %1$s is the name of the hook to be enqueued, %2$s is the exception message. */
+				__( 'Caught exception while enqueuing action "%1$s": %2$s', 'action-scheduler' ),
+				$hook,
+				$exception->getMessage()
 			)
 		);
 		return 0;
@@ -204,9 +206,10 @@ function as_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, 
 		ActionScheduler::logger()->log(
 			0,
 			sprintf(
-				/* translators: %s is the name of the hook to be enqueued. */
-				__( 'Caught exception while enqueuing action: %s', 'action-scheduler' ),
-				esc_attr( $hook )
+				/* translators: %1$s is the name of the hook to be enqueued, %2$s is the exception message. */
+				__( 'Caught exception while enqueuing action "%1$s": %2$s', 'action-scheduler' ),
+				$hook,
+				$exception->getMessage()
 			)
 		);
 		return 0;
@@ -282,9 +285,10 @@ function as_schedule_cron_action( $timestamp, $schedule, $hook, $args = array(),
 		ActionScheduler::logger()->log(
 			0,
 			sprintf(
-				/* translators: %s is the name of the hook to be enqueued. */
-				__( 'Caught exception while enqueuing action: %s', 'action-scheduler' ),
-				esc_attr( $hook )
+				/* translators: %1$s is the name of the hook to be enqueued, %2$s is the exception message. */
+				__( 'Caught exception while enqueuing action "%1$s": %2$s', 'action-scheduler' ),
+				$hook,
+				$exception->getMessage()
 			)
 		);
 		return 0;

--- a/functions.php
+++ b/functions.php
@@ -41,28 +41,16 @@ function as_enqueue_async_action( $hook, $args = array(), $group = '', $unique =
 		return is_int( $pre ) ? $pre : 0;
 	}
 
-	try {
-		return ActionScheduler::factory()->create(
-			array(
-				'type'      => 'async',
-				'hook'      => $hook,
-				'arguments' => $args,
-				'group'     => $group,
-				'unique'    => $unique,
-				'priority'  => $priority,
-			)
-		);
-	} catch ( Exception $exception ) {
-		error_log(
-			sprintf(
-				/* translators: %1$s is the name of the hook to be enqueued, %2$s is the exception message. */
-				__( 'Caught exception while enqueuing action "%1$s": %2$s', 'action-scheduler' ),
-				$hook,
-				$exception->getMessage()
-			)
-		);
-		return 0;
-	}
+	return ActionScheduler::factory()->create(
+		array(
+			'type'      => 'async',
+			'hook'      => $hook,
+			'arguments' => $args,
+			'group'     => $group,
+			'unique'    => $unique,
+			'priority'  => $priority,
+		)
+	);
 }
 
 /**
@@ -103,29 +91,17 @@ function as_schedule_single_action( $timestamp, $hook, $args = array(), $group =
 		return is_int( $pre ) ? $pre : 0;
 	}
 
-	try {
-		return ActionScheduler::factory()->create(
-			array(
-				'type'      => 'single',
-				'hook'      => $hook,
-				'arguments' => $args,
-				'when'      => $timestamp,
-				'group'     => $group,
-				'unique'    => $unique,
-				'priority'  => $priority,
-			)
-		);
-	} catch ( Exception $exception ) {
-		error_log(
-			sprintf(
-				/* translators: %1$s is the name of the hook to be enqueued, %2$s is the exception message. */
-				__( 'Caught exception while enqueuing action "%1$s": %2$s', 'action-scheduler' ),
-				$hook,
-				$exception->getMessage()
-			)
-		);
-		return 0;
-	}
+	return ActionScheduler::factory()->create(
+		array(
+			'type'      => 'single',
+			'hook'      => $hook,
+			'arguments' => $args,
+			'when'      => $timestamp,
+			'group'     => $group,
+			'unique'    => $unique,
+			'priority'  => $priority,
+		)
+	);
 }
 
 /**
@@ -187,30 +163,18 @@ function as_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, 
 		return is_int( $pre ) ? $pre : 0;
 	}
 
-	try {
-		return ActionScheduler::factory()->create(
-			array(
-				'type'      => 'recurring',
-				'hook'      => $hook,
-				'arguments' => $args,
-				'when'      => $timestamp,
-				'pattern'   => $interval_in_seconds,
-				'group'     => $group,
-				'unique'    => $unique,
-				'priority'  => $priority,
-			)
-		);
-	} catch ( Exception $exception ) {
-		error_log(
-			sprintf(
-				/* translators: %1$s is the name of the hook to be enqueued, %2$s is the exception message. */
-				__( 'Caught exception while enqueuing action "%1$s": %2$s', 'action-scheduler' ),
-				$hook,
-				$exception->getMessage()
-			)
-		);
-		return 0;
-	}
+	return ActionScheduler::factory()->create(
+		array(
+			'type'      => 'recurring',
+			'hook'      => $hook,
+			'arguments' => $args,
+			'when'      => $timestamp,
+			'pattern'   => $interval_in_seconds,
+			'group'     => $group,
+			'unique'    => $unique,
+			'priority'  => $priority,
+		)
+	);
 }
 
 /**
@@ -265,30 +229,18 @@ function as_schedule_cron_action( $timestamp, $schedule, $hook, $args = array(),
 		return is_int( $pre ) ? $pre : 0;
 	}
 
-	try {
-		return ActionScheduler::factory()->create(
-			array(
-				'type'      => 'cron',
-				'hook'      => $hook,
-				'arguments' => $args,
-				'when'      => $timestamp,
-				'pattern'   => $schedule,
-				'group'     => $group,
-				'unique'    => $unique,
-				'priority'  => $priority,
-			)
-		);
-	} catch ( Exception $exception ) {
-		error_log(
-			sprintf(
-				/* translators: %1$s is the name of the hook to be enqueued, %2$s is the exception message. */
-				__( 'Caught exception while enqueuing action "%1$s": %2$s', 'action-scheduler' ),
-				$hook,
-				$exception->getMessage()
-			)
-		);
-		return 0;
-	}
+	return ActionScheduler::factory()->create(
+		array(
+			'type'      => 'cron',
+			'hook'      => $hook,
+			'arguments' => $args,
+			'when'      => $timestamp,
+			'pattern'   => $schedule,
+			'group'     => $group,
+			'unique'    => $unique,
+			'priority'  => $priority,
+		)
+	);
 }
 
 /**

--- a/functions.php
+++ b/functions.php
@@ -335,9 +335,10 @@ function as_unschedule_action( $hook, $args = array(), $group = '' ) {
 			ActionScheduler::logger()->log(
 				$action_id,
 				sprintf(
-					/* translators: %s is the name of the hook to be cancelled. */
-					__( 'Caught exception while cancelling action: %s', 'action-scheduler' ),
-					esc_attr( $hook )
+					/* translators: %1$s is the name of the hook to be cancelled, %2$s is the exception message. */
+					__( 'Caught exception while cancelling action "%1$s": %2$s', 'action-scheduler' ),
+					$hook,
+					$exception->getMessage()
 				)
 			);
 

--- a/tests/phpunit/procedural_api/procedural_api_Test.php
+++ b/tests/phpunit/procedural_api/procedural_api_Test.php
@@ -411,20 +411,44 @@ class Procedural_API_Test extends ActionScheduler_UnitTestCase {
 		// ensure that no exception was thrown and zero was returned.
 		$this->assertEquals( 0, $action_id );
 
+		// ensure that the error was logged.
+		$logs = ActionScheduler_Logger::instance()->get_logs( 0 );
+		$message = end( $logs )->get_message();
+		$this->assertContains( 'hook_17', $message );
+		$this->assertContains( "Unknown column 'priority' in 'field list'", $message );
+
 		// try to schedule an async action.
-		$action_id = as_enqueue_async_action( 'hook_17', array( 'a', 'b' ), 'dummytest', true );
+		$action_id = as_enqueue_async_action( 'hook_18', array( 'a', 'b' ), 'dummytest', true );
 		// ensure that no exception was thrown and zero was returned.
 		$this->assertEquals( 0, $action_id );
+
+		// ensure that the error was logged.
+		$logs = ActionScheduler_Logger::instance()->get_logs( 0 );
+		$message = end( $logs )->get_message();
+		$this->assertContains( 'hook_18', $message );
+		$this->assertContains( "Unknown column 'priority' in 'field list'", $message );
 
 		// try to schedule a recurring action.
-		$action_id = as_schedule_recurring_action( time(), MINUTE_IN_SECONDS, 'hook_17', array( 'a', 'b' ), 'dummytest', true );
+		$action_id = as_schedule_recurring_action( time(), MINUTE_IN_SECONDS, 'hook_19', array( 'a', 'b' ), 'dummytest', true );
 		// ensure that no exception was thrown and zero was returned.
 		$this->assertEquals( 0, $action_id );
 
+		// ensure that the error was logged.
+		$logs = ActionScheduler_Logger::instance()->get_logs( 0 );
+		$message = end( $logs )->get_message();
+		$this->assertContains( 'hook_19', $message );
+		$this->assertContains( "Unknown column 'priority' in 'field list'", $message );
+
 		// try to schedule a cron action.
-		$action_id = as_schedule_cron_action( time(), '0 0 * * *', 'hook_17', array( 'a', 'b' ), 'dummytest', true );
+		$action_id = as_schedule_cron_action( time(), '0 0 * * *', 'hook_20', array( 'a', 'b' ), 'dummytest', true );
 		// ensure that no exception was thrown and zero was returned.
 		$this->assertEquals( 0, $action_id );
+
+		// ensure that the error was logged.
+		$logs = ActionScheduler_Logger::instance()->get_logs( 0 );
+		$message = end( $logs )->get_message();
+		$this->assertContains( 'hook_20', $message );
+		$this->assertContains( "Unknown column 'priority' in 'field list'", $message );
 
 		// recreate the priority column.
 		$wpdb->query( "ALTER TABLE {$wpdb->actionscheduler_actions} ADD COLUMN priority tinyint(10) UNSIGNED NOT NULL DEFAULT 10" );


### PR DESCRIPTION
This PR attempts to address parts of #973 by catching and logging the exceptions that are thrown when actions can't be created. If, e.g., a database schema migration did not complete properly, scheduling an action has been able to render a site inaccessible because exceptions just bubbled up to the user. 

This PR explicitly does not solve completing or fixing incomplete schema migrations -- that's a different task. The first step implemented here is to lessen the impact of such issues. 

To test this manually, you could take a working site with AS running fine and then drop the priority column. Without this PR the exceptions thrown when trying to schedule actions bubble up to the user, with this PR applied they're merely logged. AS isn't functional then but at least we limit the damage. 

Alternatively apply the commits from this branch sequentially and run the test suite in between: 
- ff2c680bc0fd48ca790359ab8ebd86343ddf9f77 makes the test suite fail from the uncaught exceptions
- 25a43f2e47cbc662fdc8c1d0ac3131e41274696f catches the exceptions and makes the test suite pass
- e1bd2e9d9d4edc3a228e0286c0f125ce06991ec8 adds some requirements around how we log the exceptions to the tests and makes the test suite fail again
- e5c427f942f8259e52123e3c1a67169e6f2be464 adds the exception message to the log entry and thus makes the test suite pass again
- (27bf7496c3fb176f8dac2c0ff23d3353d4a2181f and b0864e020f69265fdafeefad3d86799c6b31015b are not covered by tests)

### Changelog 

> Fix - Reduce impact when the database schema cannot be modified following an update.