### PR TITLE
Update unit tests for upcoming dependency version policy

### DIFF
--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -16,6 +16,8 @@ jobs:
         exclude:
           # WordPress 6.3+ requires PHP 7.0+
           - php: 5.6
+            wp: 6.3
+          - php: 5.6
             wp: latest
     services:
       database:

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -10,21 +10,10 @@ jobs:
       fail-fast: false
       matrix:
         # We test against the earliest and latest PHP versions for each major supported version.
-        php: [ '5.6', '7.0', '7.4', '8.0' ]
-        wp: [ '5.2', '5.3', '5.4', '5.5', '5.6', 'latest' ]
+        php: [ '5.6', '7.0', '7.4', '8.0', '8.1', '8.2' ]
+        wp: [ '6.1', '6.2', '6.3', 'latest' ]
         multisite: [ '0', '1' ]
         exclude:
-          # Earlier versions of WordPress do not support PHP 7.4+
-          - php: 7.4
-            wp: 5.2
-          - php: 8.0
-            wp: 5.2
-          - php: 8.0
-            wp: 5.3
-          - php: 8.0
-            wp: 5.4
-          - php: 8.0
-            wp: 5.5
           # WordPress 6.3+ requires PHP 7.0+
           - php: 5.6
             wp: latest

--- a/tests/phpunit/procedural_api/procedural_api_Test.php
+++ b/tests/phpunit/procedural_api/procedural_api_Test.php
@@ -227,7 +227,7 @@ class Procedural_API_Test extends ActionScheduler_UnitTestCase {
 
 	public function test_as_get_datetime_object_default() {
 
-		$utc_now = new ActionScheduler_DateTime( null, new DateTimeZone( 'UTC' ) );
+		$utc_now = new ActionScheduler_DateTime( 'now', new DateTimeZone( 'UTC' ) );
 		$as_now  = as_get_datetime_object();
 
 		// Don't want to use 'U' as timestamps will always be in UTC.
@@ -268,7 +268,7 @@ class Procedural_API_Test extends ActionScheduler_UnitTestCase {
 		// phpcs:ignore
 		date_default_timezone_set( $timezone_au );
 
-		$au_now = new ActionScheduler_DateTime( null );
+		$au_now = new ActionScheduler_DateTime( 'now' );
 		$as_now = as_get_datetime_object();
 
 		// Make sure they're for the same time.
@@ -277,7 +277,7 @@ class Procedural_API_Test extends ActionScheduler_UnitTestCase {
 		// But not in the same timezone, as $as_now should be using UTC.
 		$this->assertNotEquals( $au_now->format( 'Y-m-d H:i:s' ), $as_now->format( 'Y-m-d H:i:s' ) );
 
-		$au_now    = new ActionScheduler_DateTime( null );
+		$au_now    = new ActionScheduler_DateTime( 'now' );
 		$as_au_now = as_get_datetime_object();
 
 		$this->assertEquals( $au_now->getTimestamp(), $as_now->getTimestamp(), '', 2 );


### PR DESCRIPTION
This PR updates our CI to ensure unit tests run with the WordPress and PHP versions that we'll require in our upcoming L-2 dependency version policy. 

To test:
- ensure CI passes
- ensure the versions in the file conform to the L-2 policy -- also [see here](https://make.wordpress.org/core/handbook/references/php-compatibility-and-wordpress-versions/), we want to support WordPress latest minus 2 versions and the respective minimum PHP versions
