### PR TITLE
mention dependency version policy in usage.md

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -15,6 +15,8 @@ There are two ways to install Action Scheduler:
 1. regular WordPress plugin; or
 1. a library within your plugin's codebase.
 
+Note that [Action Scheduler follows an L-2 dependency version policy](https://developer.woocommerce.com/2023/10/24/action-scheduler-to-adopt-l-2-dependency-version-policy/). That is, the library requires at least the "latest minus two" version of WordPress and the PHP minimum version requirement of that WordPress version.
+
 ### Usage as a Plugin
 
 Action Scheduler includes the necessary file headers to be used as a standard WordPress plugin.


### PR DESCRIPTION
This PR adds a brief note regarding [the “L-2” Dependency Version Policy](https://developer.woocommerce.com/2023/10/24/action-scheduler-to-adopt-l-2-dependency-version-policy/) to the `usage.md` markdown file that will be rendered at `https://actionscheduler.org/usage/`. 

To review, please look at the changes in the markdown file. 