### PR TITLE
make sure hook action_scheduler_failed_execution can access original exception object

### DIFF
--- a/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php
+++ b/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php
@@ -91,7 +91,7 @@ abstract class ActionScheduler_Abstract_QueueRunner extends ActionScheduler_Abst
 			} catch ( Throwable $e ) {
 				// Throwable is defined when executing under PHP 7.0 and up. We convert it to an exception, for
 				// compatibility with ActionScheduler_Logger.
-				throw new Exception( $e->getMessage(), $e->getCode(), $e->getPrevious() );
+				throw new Exception( $e->getMessage(), $e->getCode(), $e );
 			}
 		} catch ( Exception $e ) {
 			// This catch block exists for compatibility with PHP 5.6.


### PR DESCRIPTION
fixes https://github.com/woocommerce/action-scheduler/issues/1003

---

This is a developer-facing enhancement/fix. It makes it possible to inspect the original exception, if one is thrown, when actions are processed.

### Testing

The problem and fix can be seen by adding the following code to a mu-plugin (example `wp-content/mu-plugins/test-1007.php`) which can be removed after testing:

```php
<?php

$action_id = 0;

add_action( 'init', function () use ( &$action_id ) {
	$action_id = as_enqueue_async_action( 'test' );
} );

add_action( 'test', function () {
	throw new Exception( 'Hello, here is a problem.' );
} );

add_action( 'action_scheduler_failed_execution', function ( $action_id, $e ) {
	$debug = is_a( $e->getPrevious(), Exception::class )
		? $e->getPrevious()->getMessage()
		: 'Previous exception not accesible.';

	update_option( 'test-pr-1007', $debug );
}, 10, 2 );
```

With the above code in place, start by testing *without* this fix. Using WP CLI, run the following command:

```sh
wp action-scheduler run && wp option get test-pr-1007
```

The output should be:

```
Previous exception not accesible.
```

Now switch to this branch, and repeat the last couple of steps. The output should be:

```
Hello, here is a problem.
```

### Changelog

> Fix - Make exceptions encountered while processing actions available for inspection.
