### PR TITLE
WIP:  prepare 3.7.0 release

### DIFF
--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         # We test against the earliest and latest PHP versions for each major supported version.
         php: [ '5.6', '7.0', '7.4', '8.0', '8.1', '8.2' ]
-        wp: [ '6.1', '6.2', '6.3', 'latest' ]
+        wp: [ '6.2', '6.3', 'latest' ]
         multisite: [ '0', '1' ]
         exclude:
           # WordPress 6.3+ requires PHP 7.0+

--- a/action-scheduler.php
+++ b/action-scheduler.php
@@ -5,7 +5,7 @@
  * Description: A robust scheduling library for use in WordPress plugins.
  * Author: Automattic
  * Author URI: https://automattic.com/
- * Version: 3.6.4
+ * Version: 3.7.0
  * License: GPLv3
  * Tested up to: 6.3
  * Requires at least: 5.2
@@ -29,27 +29,27 @@
  * @package ActionScheduler
  */
 
-if ( ! function_exists( 'action_scheduler_register_3_dot_6_dot_4' ) && function_exists( 'add_action' ) ) { // WRCS: DEFINED_VERSION.
+if ( ! function_exists( 'action_scheduler_register_3_dot_7_dot_0' ) && function_exists( 'add_action' ) ) { // WRCS: DEFINED_VERSION.
 
 	if ( ! class_exists( 'ActionScheduler_Versions', false ) ) {
 		require_once __DIR__ . '/classes/ActionScheduler_Versions.php';
 		add_action( 'plugins_loaded', array( 'ActionScheduler_Versions', 'initialize_latest_version' ), 1, 0 );
 	}
 
-	add_action( 'plugins_loaded', 'action_scheduler_register_3_dot_6_dot_4', 0, 0 ); // WRCS: DEFINED_VERSION.
+	add_action( 'plugins_loaded', 'action_scheduler_register_3_dot_7_dot_0', 0, 0 ); // WRCS: DEFINED_VERSION.
 
 	/**
 	 * Registers this version of Action Scheduler.
 	 */
-	function action_scheduler_register_3_dot_6_dot_4() { // WRCS: DEFINED_VERSION.
+	function action_scheduler_register_3_dot_7_dot_0() { // WRCS: DEFINED_VERSION.
 		$versions = ActionScheduler_Versions::instance();
-		$versions->register( '3.6.4', 'action_scheduler_initialize_3_dot_6_dot_4' ); // WRCS: DEFINED_VERSION.
+		$versions->register( '3.7.0', 'action_scheduler_initialize_3_dot_7_dot_0' ); // WRCS: DEFINED_VERSION.
 	}
 
 	/**
 	 * Initializes this version of Action Scheduler.
 	 */
-	function action_scheduler_initialize_3_dot_6_dot_4() { // WRCS: DEFINED_VERSION.
+	function action_scheduler_initialize_3_dot_7_dot_0() { // WRCS: DEFINED_VERSION.
 		// A final safety check is required even here, because historic versions of Action Scheduler
 		// followed a different pattern (in some unusual cases, we could reach this point and the
 		// ActionScheduler class is already defined—so we need to guard against that).
@@ -61,7 +61,7 @@ if ( ! function_exists( 'action_scheduler_register_3_dot_6_dot_4' ) && function_
 
 	// Support usage in themes - load this version if no plugin has loaded a version yet.
 	if ( did_action( 'plugins_loaded' ) && ! doing_action( 'plugins_loaded' ) && ! class_exists( 'ActionScheduler', false ) ) {
-		action_scheduler_initialize_3_dot_6_dot_4(); // WRCS: DEFINED_VERSION.
+		action_scheduler_initialize_3_dot_7_dot_0(); // WRCS: DEFINED_VERSION.
 		do_action( 'action_scheduler_pre_theme_init' );
 		ActionScheduler_Versions::initialize_latest_version();
 	}

--- a/action-scheduler.php
+++ b/action-scheduler.php
@@ -7,8 +7,8 @@
  * Author URI: https://automattic.com/
  * Version: 3.7.0
  * License: GPLv3
- * Tested up to: 6.3
- * Requires at least: 5.2
+ * Requires at least: 6.2
+ * Tested up to: 6.4
  * Requires PHP: 5.6
  *
  * Copyright 2019 Automattic, Inc.  (https://automattic.com/contact/)

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,9 @@
   "license": "GPL-3.0-or-later",
   "prefer-stable": true,
   "minimum-stability": "dev",
-  "require": {},
+  "require": {
+    "php": ">=5.6"
+  },
   "require-dev": {
     "phpunit/phpunit": "^7.5",
     "wp-cli/wp-cli": "~2.5.0",
@@ -18,7 +20,7 @@
       "dealerdirect/phpcodesniffer-composer-installer": true
     },
     "platform": {
-      "php": "7.3"
+      "php": "5.6"
     }
   },
   "archive": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "action-scheduler",
-  "version": "3.6.4",
+  "version": "3.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "action-scheduler",
-      "version": "3.5.4",
+      "version": "3.7.0",
       "license": "GPL-3.0+",
       "devDependencies": {
         "grunt": "1.5.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "action-scheduler",
   "title": "Action Scheduler",
-  "version": "3.6.4",
+  "version": "3.7.0",
   "homepage": "https://actionscheduler.org/",
   "repository": {
     "type": "git",

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Action Scheduler ===
 Contributors: Automattic, wpmuguru, claudiosanches, peterfabian1000, vedjain, jamosova, obliviousharmony, konamiman, sadowski, royho, barryhughes-1
 Tags: scheduler, cron
-Stable tag: 3.6.4
+Stable tag: 3.7.0
 License: GPLv3
 Tested up to: 6.3
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,8 @@ Contributors: Automattic, wpmuguru, claudiosanches, peterfabian1000, vedjain, ja
 Tags: scheduler, cron
 Stable tag: 3.7.0
 License: GPLv3
-Tested up to: 6.3
+Requires at least: 6.2
+Tested up to: 6.4
 
 Action Scheduler - Job Queue for WordPress
 

--- a/readme.txt
+++ b/readme.txt
@@ -5,6 +5,7 @@ Stable tag: 3.7.0
 License: GPLv3
 Requires at least: 6.2
 Tested up to: 6.4
+Requires PHP: 5.6
 
 Action Scheduler - Job Queue for WordPress
 


### PR DESCRIPTION
WIP: this PR ...

- sets the minimum required PHP version to 5.6
- the minimum required WordPress version to 6.2
- the "tested up to" WordPress version to 6.4
- and updates Action Scheduler version to 3.7.0

As this is the first release adhering to [the new version dependency policy](https://developer.woocommerce.com/2023/10/24/action-scheduler-to-adopt-l-2-dependency-version-policy/), we bumped the minor version number. 