### PR TITLE
Try: Make code coverage work

### DIFF
--- a/.github/workflows/pr-coverage.yml
+++ b/.github/workflows/pr-coverage.yml
@@ -34,7 +34,7 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('./composer.lock') }}
 
       - name: Install dependencies
-        run: composer self-update && composer require --dev --no-update phpunit/phpunit:^9.5 && composer install && composer dump-autoload
+        run: composer self-update && composer require --dev --no-update phpunit/phpunit:^9.5 && composer update && composer install && composer dump-autoload
 
       - name: Init database and WordPress
         run: ./tests/bin/install.sh woo_test root root 127.0.0.1 latest

--- a/.github/workflows/pr-coverage.yml
+++ b/.github/workflows/pr-coverage.yml
@@ -1,0 +1,48 @@
+name: Run Codecov on PR
+on:
+    pull_request
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    services:
+      database:
+        image: mysql:5.6
+        env:
+          MYSQL_ROOT_PASSWORD: root
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up PHP 8.1
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+          tools: composer
+          extensions: mysql
+          coverage: xdebug
+
+      - name: Get cached composer directories
+        uses: actions/cache@v2
+        with:
+          path: ./vendor
+          key: ${{ runner.os }}-${{ hashFiles('./composer.lock') }}
+
+      - name: Install dependencies
+        run: composer self-update && composer install && composer dump-autoload
+
+      - name: Init database and WordPress
+        run: ./tests/bin/install.sh woo_test root root 127.0.0.1 latest
+
+      - name: Run tests and collect coverage
+        run: ./vendor/bin/phpunit -c ./tests/phpunit.xml.dist --coverage-clover coverage.xml
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4-beta
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_ORG_TOKEN }}

--- a/.github/workflows/pr-coverage.yml
+++ b/.github/workflows/pr-coverage.yml
@@ -34,13 +34,13 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('./composer.lock') }}
 
       - name: Install dependencies
-        run: composer self-update && composer install && composer dump-autoload
+        run: composer self-update && composer require --dev --no-update phpunit/phpunit:^9.5 && composer install && composer dump-autoload
 
       - name: Init database and WordPress
         run: ./tests/bin/install.sh woo_test root root 127.0.0.1 latest
 
       - name: Run tests and collect coverage
-        run: ./vendor/bin/phpunit -c ./tests/phpunit.xml.dist --coverage-clover coverage.xml
+        run: XDEBUG_MODE=coverage ./vendor/bin/phpunit -c ./tests/phpunit.xml.dist --coverage-clover coverage.xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4-beta

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Run tests
         run: |
           ./vendor/bin/phpunit --version
-          WP_MULTISITE=${{ matrix.multisite }} ./vendor/bin/phpunit -c ./tests/phpunit.xml.dist --coverage-clover coverage.xml .
+          WP_MULTISITE=${{ matrix.multisite }} ./vendor/bin/phpunit -c ./tests/phpunit.xml.dist --coverage-clover coverage.xml
 
       - name: Code Coverage
         run: |

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -88,6 +88,7 @@ jobs:
           ./vendor/bin/phpunit --version
           WP_MULTISITE=${{ matrix.multisite }} ./vendor/bin/phpunit -c ./tests/phpunit.xml.dist --coverage-clover coverage.xml
 
-      - name: Code Coverage
-        run: |
-          bash <(curl -s https://codecov.io/bash)
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4-beta
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -30,8 +30,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 2
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -39,7 +37,7 @@ jobs:
           php-version: ${{ matrix.php }}
           tools: composer
           extensions: mysql
-          coverage: xdebug
+          coverage: none
 
       - name: Tool versions
         run: |
@@ -86,9 +84,4 @@ jobs:
       - name: Run tests
         run: |
           ./vendor/bin/phpunit --version
-          WP_MULTISITE=${{ matrix.multisite }} ./vendor/bin/phpunit -c ./tests/phpunit.xml.dist --coverage-clover coverage.xml
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4-beta
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          WP_MULTISITE=${{ matrix.multisite }} ./vendor/bin/phpunit -c ./tests/phpunit.xml.dist

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -29,7 +29,9 @@ jobs:
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Run tests
         run: |
           ./vendor/bin/phpunit --version
-          WP_MULTISITE=${{ matrix.multisite }} ./vendor/bin/phpunit -c ./tests/phpunit.xml.dist
+          WP_MULTISITE=${{ matrix.multisite }} ./vendor/bin/phpunit -c ./tests/phpunit.xml.dist --coverage-clover coverage.xml .
 
       - name: Code Coverage
         run: |

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -39,7 +39,7 @@ jobs:
           php-version: ${{ matrix.php }}
           tools: composer
           extensions: mysql
-          coverage: none
+          coverage: xdebug
 
       - name: Tool versions
         run: |

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,5 @@
 codecov:
-  branch: master
+  branch: trunk
 
 coverage:
   ignore:

--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,6 @@
   "config": {
     "allow-plugins": {
       "dealerdirect/phpcodesniffer-composer-installer": true
-    },
-    "platform": {
-      "php": "5.6"
     }
   },
   "archive": {

--- a/tests/ActionScheduler_UnitTestCase.php
+++ b/tests/ActionScheduler_UnitTestCase.php
@@ -9,14 +9,16 @@ class ActionScheduler_UnitTestCase extends WP_UnitTestCase {
 
 	/**
 	 * Perform test set-up work.
+	 * @before
 	 */
 	public function set_up() {
-		ActionScheduler_Callbacks::add_callbacks();
 		parent::set_up();
+		ActionScheduler_Callbacks::add_callbacks();
 	}
 
 	/**
 	 * Perform test tear-down work.
+	 * @after
 	 */
 	public function tear_down() {
 		ActionScheduler_Callbacks::remove_callbacks();

--- a/tests/phpunit/deprecated/ActionScheduler_UnitTestCase.php
+++ b/tests/phpunit/deprecated/ActionScheduler_UnitTestCase.php
@@ -9,14 +9,16 @@ class ActionScheduler_UnitTestCase extends WP_UnitTestCase {
 
 	/**
 	 * Perform test set-up work.
+	 * @before
 	 */
 	public function set_up() {
-		ActionScheduler_Callbacks::add_callbacks();
 		parent::set_up();
+		ActionScheduler_Callbacks::add_callbacks();
 	}
 
 	/**
 	 * Perform test tear-down work.
+	 * @after
 	 */
 	public function tear_down() {
 		ActionScheduler_Callbacks::remove_callbacks();

--- a/tests/phpunit/jobstore/ActionScheduler_DBStore_Test.php
+++ b/tests/phpunit/jobstore/ActionScheduler_DBStore_Test.php
@@ -7,14 +7,15 @@ use Action_Scheduler\Tests\DataStores\AbstractStoreTest;
  * @group tables
  */
 class ActionScheduler_DBStore_Test extends AbstractStoreTest {
+	/**
+	 * @before
+	 */
+	public function set_up() {
+		parent::set_up();
 
-	public function setUp() {
 		global $wpdb;
-
 		// Delete all actions before each test.
 		$wpdb->query( "DELETE FROM {$wpdb->actionscheduler_actions}" );
-
-		parent::setUp();
 	}
 
 	/**

--- a/tests/phpunit/jobstore/ActionScheduler_HybridStore_Test.php
+++ b/tests/phpunit/jobstore/ActionScheduler_HybridStore_Test.php
@@ -14,8 +14,11 @@ use ActionScheduler_wpPostStore as PostStore;
 class ActionScheduler_HybridStore_Test extends ActionScheduler_UnitTestCase {
 	private $demarkation_id = 1000;
 
-	public function setUp() {
-		parent::setUp();
+	/**
+	 * @before
+	 */
+	public function set_up() {
+		parent::set_up();
 		if ( ! taxonomy_exists( PostStore::GROUP_TAXONOMY ) ) {
 			// register the post type and taxonomy necessary for the store to work
 			$store = new PostStore();
@@ -26,15 +29,18 @@ class ActionScheduler_HybridStore_Test extends ActionScheduler_UnitTestCase {
 		$hybrid->set_autoincrement( '', ActionScheduler_StoreSchema::ACTIONS_TABLE );
 	}
 
-	public function tearDown() {
-		parent::tearDown();
-
+	/*
+	 * @after
+	 */
+	public function tear_down() {
 		// reset the autoincrement index
 		/** @var \wpdb $wpdb */
 		global $wpdb;
 		$wpdb->query( "TRUNCATE TABLE {$wpdb->actionscheduler_actions}" );
 		$wpdb->query( "TRUNCATE TABLE {$wpdb->actionscheduler_logs}" );
 		delete_option( ActionScheduler_HybridStore::DEMARKATION_OPTION );
+
+		parent::tear_down();
 	}
 
 	public function test_actions_are_migrated_on_find() {

--- a/tests/phpunit/migration/ActionMigrator_Test.php
+++ b/tests/phpunit/migration/ActionMigrator_Test.php
@@ -8,8 +8,11 @@ use Action_Scheduler\Migration\LogMigrator;
  * @group migration
  */
 class ActionMigrator_Test extends ActionScheduler_UnitTestCase {
-	public function setUp() {
-		parent::setUp();
+	/**
+	 * @before
+	 */
+	public function set_up() {
+		parent::set_up();
 		if ( ! taxonomy_exists( ActionScheduler_wpPostStore::GROUP_TAXONOMY )  ) {
 			// register the post type and taxonomy necessary for the store to work
 			$store = new ActionScheduler_wpPostStore();

--- a/tests/phpunit/migration/BatchFetcher_Test.php
+++ b/tests/phpunit/migration/BatchFetcher_Test.php
@@ -8,8 +8,11 @@ use ActionScheduler_wpPostStore as PostStore;
  * @group migration
  */
 class BatchFetcher_Test extends ActionScheduler_UnitTestCase {
-	public function setUp() {
-		parent::setUp();
+	/**
+	 * @before
+	 */
+	public function set_up() {
+		parent::set_up();
 		if ( ! taxonomy_exists( PostStore::GROUP_TAXONOMY ) ) {
 			// register the post type and taxonomy necessary for the store to work
 			$store = new PostStore();

--- a/tests/phpunit/migration/LogMigrator_Test.php
+++ b/tests/phpunit/migration/LogMigrator_Test.php
@@ -7,8 +7,11 @@ use Action_Scheduler\Migration\LogMigrator;
  * @group migration
  */
 class LogMigrator_Test extends ActionScheduler_UnitTestCase {
-	function setUp() {
-		parent::setUp();
+	/**
+	 * @before
+	 */
+	function set_up() {
+		parent::set_up();
 		if ( ! taxonomy_exists( ActionScheduler_wpPostStore::GROUP_TAXONOMY )  ) {
 			// register the post type and taxonomy necessary for the store to work
 			$store = new ActionScheduler_wpPostStore();

--- a/tests/phpunit/migration/Runner_Test.php
+++ b/tests/phpunit/migration/Runner_Test.php
@@ -11,8 +11,11 @@ use ActionScheduler_wpPostStore as PostStore;
  * @group migration
  */
 class Runner_Test extends ActionScheduler_UnitTestCase {
-	public function setUp() {
-		parent::setUp();
+	/**
+	 * @before
+	 */
+	public function set_up() {
+		parent::set_up();
 		if ( ! taxonomy_exists( PostStore::GROUP_TAXONOMY ) ) {
 			// register the post type and taxonomy necessary for the store to work
 			$store = new PostStore();

--- a/tests/phpunit/migration/Scheduler_Test.php
+++ b/tests/phpunit/migration/Scheduler_Test.php
@@ -8,8 +8,11 @@ use ActionScheduler_wpPostStore as PostStore;
  * @group migration
  */
 class Scheduler_Test extends ActionScheduler_UnitTestCase {
-	public function setUp() {
-		parent::setUp();
+	/**
+	 * @before
+	 */
+	public function set_up() {
+		parent::set_up();
 		if ( ! taxonomy_exists( PostStore::GROUP_TAXONOMY ) ) {
 			// register the post type and taxonomy necessary for the store to work
 			$store = new PostStore();

--- a/tests/phpunit/procedural_api/procedural_api_Test.php
+++ b/tests/phpunit/procedural_api/procedural_api_Test.php
@@ -431,11 +431,19 @@ class Procedural_API_Test extends ActionScheduler_UnitTestCase {
 
 		// ensure that all four errors were logged to error_log.
 		$logged_errors = stream_get_contents( $error_capture );
-		$this->assertContains( 'Caught exception while enqueuing action "hook_17": Error saving action', $logged_errors );
-		$this->assertContains( 'Caught exception while enqueuing action "hook_18": Error saving action', $logged_errors );
-		$this->assertContains( 'Caught exception while enqueuing action "hook_19": Error saving action', $logged_errors );
-		$this->assertContains( 'Caught exception while enqueuing action "hook_20": Error saving action', $logged_errors );
-		$this->assertContains( "Unknown column 'priority' in 'field list'", $logged_errors );
+		if ( method_exists( $this, 'assertStringContainsString' ) ) {
+			$this->assertStringContainsString( 'Caught exception while enqueuing action "hook_17": Error saving action', $logged_errors );
+			$this->assertStringContainsString( 'Caught exception while enqueuing action "hook_18": Error saving action', $logged_errors );
+			$this->assertStringContainsString( 'Caught exception while enqueuing action "hook_19": Error saving action', $logged_errors );
+			$this->assertStringContainsString( 'Caught exception while enqueuing action "hook_20": Error saving action', $logged_errors );
+			$this->assertStringContainsString( "Unknown column 'priority' in 'field list'", $logged_errors );
+		} else {
+			$this->assertContains( 'Caught exception while enqueuing action "hook_17": Error saving action', $logged_errors );
+			$this->assertContains( 'Caught exception while enqueuing action "hook_18": Error saving action', $logged_errors );
+			$this->assertContains( 'Caught exception while enqueuing action "hook_19": Error saving action', $logged_errors );
+			$this->assertContains( 'Caught exception while enqueuing action "hook_20": Error saving action', $logged_errors );
+			$this->assertContains( "Unknown column 'priority' in 'field list'", $logged_errors );
+		}
 
 		// recreate the priority column.
 		$wpdb->query( "ALTER TABLE {$wpdb->actionscheduler_actions} ADD COLUMN priority tinyint(10) UNSIGNED NOT NULL DEFAULT 10" );

--- a/tests/phpunit/procedural_api/wc_get_scheduled_actions_Test.php
+++ b/tests/phpunit/procedural_api/wc_get_scheduled_actions_Test.php
@@ -8,8 +8,11 @@ class as_get_scheduled_actions_Test extends ActionScheduler_UnitTestCase {
 	private $args = array();
 	private $groups = array();
 
-	public function setUp() {
-		parent::setUp();
+	/**
+	 * @before
+	 */
+	public function set_up() {
+		parent::set_up();
 
 		$store = ActionScheduler::store();
 


### PR DESCRIPTION
I had to make a few changes to let us use a relatively current and, most importantly, stock phpunit. Other changes I implemented to enable the process suggested by Codecov. 

The one change that seems to break about 25 assertions is [using the @before and @after annotations instead of magic method names](https://github.com/woocommerce/action-scheduler/pull/1016/commits/9b76f9e4d4356e2e3ce4e54652590c9a2ed76dad) -- but my suspicion is that this is because those method now actually work. Previously we called `parent::setUp` even though the parent class was providing a `set_up` method ... and one missing the `@before` annotation at that. 

So the next step here is to see whether the failing assertions actually make sense (as in, whether our expectations are actually correct) or else what is causing the results to be different from what we expect. Maybe the annotated `set_up` and `tear_down` methods aren't running properly at all. 