### PR TITLE
Do not iterate over all of GET when building form in list table

### DIFF
--- a/classes/abstracts/ActionScheduler_Abstract_ListTable.php
+++ b/classes/abstracts/ActionScheduler_Abstract_ListTable.php
@@ -699,8 +699,8 @@ abstract class ActionScheduler_Abstract_ListTable extends WP_List_Table {
 
 		// Translated status labels.
 		$status_labels             = ActionScheduler_Store::instance()->get_status_labels();
-		$status_labels['all']      = _x( 'All', 'status labels', 'action-scheduler' );
-		$status_labels['past-due'] = _x( 'Past-due', 'status labels', 'action-scheduler' );
+		$status_labels['all']      = esc_html_x( 'All', 'status labels', 'action-scheduler' );
+		$status_labels['past-due'] = esc_html_x( 'Past-due', 'status labels', 'action-scheduler' );
 
 		foreach ( $this->status_counts as $status_slug => $count ) {
 

--- a/classes/abstracts/ActionScheduler_Abstract_ListTable.php
+++ b/classes/abstracts/ActionScheduler_Abstract_ListTable.php
@@ -314,6 +314,23 @@ abstract class ActionScheduler_Abstract_ListTable extends WP_List_Table {
 	}
 
 	/**
+	 * Querystring arguments to persist between form submissions.
+	 *
+	 * @since 3.7.3
+	 *
+	 * @return string[]
+	 */
+	protected function get_request_query_args_to_persist() {
+		return array_merge(
+			$this->sort_by,
+			array(
+				'page',
+				'status',
+			)
+		);
+	}
+
+	/**
 	 * Return the sortable column specified for this request to order the results by, if any.
 	 *
 	 * @return string
@@ -717,12 +734,15 @@ abstract class ActionScheduler_Abstract_ListTable extends WP_List_Table {
 	 */
 	protected function display_table() {
 		echo '<form id="' . esc_attr( $this->_args['plural'] ) . '-filter" method="get">';
-		foreach ( $_GET as $key => $value ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			if ( '_' === $key[0] || 'paged' === $key || 'ID' === $key ) {
+		foreach ( $this->get_request_query_args_to_persist() as $arg ) {
+			$arg_value = isset( $_GET[ $arg ] ) ? sanitize_text_field( wp_unslash( $_GET[ $arg ] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			if ( ! $arg_value ) {
 				continue;
 			}
-			echo '<input type="hidden" name="' . esc_attr( $key ) . '" value="' . esc_attr( $value ) . '" />';
+
+			echo '<input type="hidden" name="' . esc_attr( $arg ) . '" value="' . esc_attr( $arg_value ) . '" />';
 		}
+
 		if ( ! empty( $this->search_by ) ) {
 			echo $this->search_box( $this->get_search_box_button_text(), 'plugin' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}


### PR DESCRIPTION
For reasons (?) we currently iterate over `$_GET` to preserve most arguments present in the querystring when building the `<form>` tag in the list table.
This might've been a case of thinking about future extensibility, but this seems backwards. Instead of allowing everything _but_ a few keys, we should instead restrict everything and allow the arguments we need.

This PR introduced a new function that does precisely that. It can be overridden in subclasses (if any?) to allow even further arguments.

I'm not sure if there's any need to actually make this filterable as it doesn't seem like you can extend the form in a reasonable and useful way without subclassing anyway, but happy to adjust if necessary.

For context, this is from the wporg's review mentioned in #1027:

> We strongly recommend you never attempt to process the whole $_POST/$_REQUEST/$_GET stack. This makes your plugin slower as you're needlessly cycling through data you don't need. Instead, you should only be attempting to process the items within that are required for your plugin to function.

Fixes #1027.


### Testing instructions
Go to Tools > Scheduled Actions. Make sure that status filters work correctly in combination with different sort orders and searches.