### PR TITLE
update version in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "action-scheduler",
-      "version": "3.7.0",
+      "version": "3.7.2",
       "license": "GPL-3.0+",
       "devDependencies": {
         "grunt": "1.5.3",


### PR DESCRIPTION
The `3.7.2` branch has `version` set to `3.7.2.` only in the top-level `version` field ([see here](https://github.com/woocommerce/action-scheduler/blob/3.7.2/package-lock.json)), but not in the nested `action-scheduler` package. 

Running `npm install` in `trunk` updates that version, too. 

I'm not sure if this was done on purpose or not, so I'm putting out this PR to update the version if necessary. I'd especially like @nigeljamesstevenson to chime in in case there's something about the release process that I'm overlooking here. Thanks! 