### PR TITLE
Try to save actions as unique even when the store doesn't support it

### DIFF
--- a/tests/phpunit/procedural_api/procedural_api_Test.php
+++ b/tests/phpunit/procedural_api/procedural_api_Test.php
@@ -353,6 +353,20 @@ class Procedural_API_Test extends ActionScheduler_UnitTestCase {
 	}
 
 	/**
+	 * Test enqueueing a unique action using the hybrid store.
+	 * This is using a best-effort approach, so it's possible that the action will be enqueued even if it's not unique.
+	 */
+	public function test_as_enqueue_async_action_unique_hybrid_best_effort() {
+		$this->set_action_scheduler_store( new ActionScheduler_HybridStore() );
+
+		$action_id = as_enqueue_async_action( 'hook_1', array( 'a' ), 'dummy', true );
+		$this->assertValidAction( $action_id );
+
+		$action_id_duplicate = as_enqueue_async_action( 'hook_1', array( 'a' ), 'dummy', true );
+		$this->assertEquals( 0, $action_id_duplicate );
+	}
+
+	/**
 	 * Test as_schedule_single_action with unique param.
 	 */
 	public function test_as_schedule_single_action_unique() {


### PR DESCRIPTION
This PR changes how we save unique actions in an attempt to at least partially address the issue reported in #1023. 

The problem with the Hybrid Store and unique actions is that it doesn't support the atomic operation that would be necessary for guaranteeing uniqueness -- we can't write-lock the store for everyone else, check whether an action exists, and if it doesn't insert a new action, and then free the lock. It's not a relational database. 

When saving unique actions, we currently ask the store whether it supports saving unique actions or not. If it doesn't we just save the action. So if the Hybrid Store is active (e.g., because we switch to it every time a plugin is disabled) saving a unique action is downgraded to just a regular save. This way it's possible to have many, many actions scheduled that should have been a single unique one. 

So as we cannot guarantee uniqueness, we just insert. 

This PR changes the strategy to check for an existing pending action and only inserts if none is found. As the Hybrid Store doesn't provide atomic operations, this is a best-effort strategy rather than a guaranteed uniqueness constraint. 

The consequence should be that, in practice, a lot fewer duplicate actions should be generated than previously. 

To test, check out this branch, step back a commit, and run the tests -- they'll fail as I have introduced a test that expects the Hybrid Store to support uniqueness. Then checkout this branch again, adding back the commit that changes the strategy. Run the tests again -- they should now pass. 

Or, in other words: 

1. `git checkout update/try-unique-action-hybrid-store`
3. `npm install` // will update package-lock.json, please ignore #1038
4. `composer install`
5. `git checkout ad63d64`
6. `composer run test` // this should fail 🔴 
7. `git switch -`
8. `composer run test` // this should succeed 🟢 