### PR TITLE
Update "Tested up to" tag to WordPress 6.5

### DIFF
--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -16,7 +16,11 @@ jobs:
         exclude:
           # WordPress 6.3+ requires PHP 7.0+
           - php: 5.6
-            wp: [ '6.3', 'latest', 'nightly' ]
+            wp: 6.3
+          - php: 5.6
+            wp: latest
+          - php: 5.6
+            wp: nightly
     services:
       database:
         image: mysql:5.6

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -11,14 +11,12 @@ jobs:
       matrix:
         # We test against the earliest and latest PHP versions for each major supported version.
         php: [ '5.6', '7.0', '7.4', '8.0', '8.1', '8.2' ]
-        wp: [ '6.2', '6.3', 'latest' ]
+        wp: [ '6.2', '6.3', 'latest', 'nightly' ]
         multisite: [ '0', '1' ]
         exclude:
           # WordPress 6.3+ requires PHP 7.0+
           - php: 5.6
-            wp: 6.3
-          - php: 5.6
-            wp: latest
+            wp: [ '6.3', 'latest', 'nightly' ]
     services:
       database:
         image: mysql:5.6

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: scheduler, cron
 Stable tag: 3.7.2
 License: GPLv3
 Requires at least: 6.2
-Tested up to: 6.4
+Tested up to: 6.5
 Requires PHP: 5.6
 
 Action Scheduler - Job Queue for WordPress


### PR DESCRIPTION
To be ready for WordPress 6.5, this PR updates the "Tested up to" tag in `readme.txt` to `6.5`. 

I did some manual testing locally to make sure things work well under WordPress 6.5; in addition, this PR adds `nightly` to the testing matrix. 

To review, ensure the testing matrix looks right, covers WordPress 6.5 (i.e., nightly for now) and all combinations pass. 