### PR TITLE
Preserve the tab field if set.

### DIFF
--- a/classes/abstracts/ActionScheduler_Abstract_ListTable.php
+++ b/classes/abstracts/ActionScheduler_Abstract_ListTable.php
@@ -326,6 +326,7 @@ abstract class ActionScheduler_Abstract_ListTable extends WP_List_Table {
 			array(
 				'page',
 				'status',
+				'tab',
 			)
 		);
 	}


### PR DESCRIPTION
- Builds on https://github.com/woocommerce/action-scheduler/pull/1029/
- Fixes https://github.com/woocommerce/woocommerce/issues/46090

The same admin list table exposed via **Tools ▸ Scheduled Actions** is also embedded inside **WooCommerce ▸ Status ▸ Scheduled Actions**. 

For the second of those (the embedded view), it is contained inside one of 4 'tabs' and, to support this, we need to preserve the hidden tab field when set. Otherwise, if a user performs a search, or possibly various other operations, they will be taken *out* of this tab and will see the system status report, which occupies the default tab.

### Steps to replicate

- Install WooCommmerce (latest) and Action Scheduler (latest). Activate both.
- We want to ensure that it is our top-level Action Scheduler plugin that loads, and not the version bundled inside of WooCommerce.
    - If you have a preferred existing way of doing this, do so!
    - Otherwise, a quick was to do this is to open `woocommerce/packages/action-scheduler/action-scheduler.php` and add a `return` statement above the first `if` block. Remember to undo this after testing 🙃
- Visit **WooCommerce ▸ Status ▸ Scheduled Actions** and perform a search: notice you are taken to the system status report.
- Update your copy of Action Scheduler to *this* branch, and repeat the search. This time it should work as expected.
- Now visit **Tools ▸ Scheduled Actions** and confirm that still displays as expected, and that search and other actions also continue to function correctly.

### Changelog 

> Fix - Ensure the admin list table embedded inside WooCommerce continues to function as expected.