### PR TITLE
Update minimum requirements for WordPress (and PHP). Fix test matrix.

### DIFF
--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -10,17 +10,16 @@ jobs:
       fail-fast: false
       matrix:
         # We test against the earliest and latest PHP versions for each major supported version.
-        php: [ '5.6', '7.0', '7.4', '8.0', '8.1', '8.2' ]
-        wp: [ '6.2', '6.3', 'latest', 'nightly' ]
+        php: [ '7.0', '7.4', '8.0', '8.1', '8.2' ]
+        wp: [ '6.3', '6.4', '6.5', 'latest', 'nightly' ]
         multisite: [ '0', '1' ]
         exclude:
-          # WordPress 6.3+ requires PHP 7.0+
-          - php: 5.6
-            wp: 6.3
-          - php: 5.6
+          # WordPress 6.6+ requires PHP 7.2+
+          - php: 7.0
             wp: latest
-          - php: 5.6
+          - php: 7.0
             wp: nightly
+            
     services:
       database:
         image: mysql:5.6

--- a/readme.txt
+++ b/readme.txt
@@ -3,9 +3,9 @@ Contributors: Automattic, wpmuguru, claudiosanches, peterfabian1000, vedjain, ja
 Tags: scheduler, cron
 Stable tag: 3.7.4
 License: GPLv3
-Requires at least: 6.2
+Requires at least: 6.3
 Tested up to: 6.5
-Requires PHP: 5.6
+Requires PHP: 7.0
 
 Action Scheduler - Job Queue for WordPress
 


### PR DESCRIPTION
This change addresses two areas:

- It updates our test matrix to avoid failures resulting from running WP 6.6 and higher against PHP 7.0 and lower (see linked issue).
- It updates the plugin's requirements, per our [L-2 policy](https://developer.woocommerce.com/2023/10/24/action-scheduler-to-adopt-l-2-dependency-version-policy/):

> The latest version of WordPress, the version before that, and the version before that.  
> The latter version’s minimum PHP version.

At time of writing the current stable version of WordPress is 6.5, so the oldest version we should still support is 6.3. This also means we can adjust our minimum required version of PHP to 7.0, to [match that of WP 6.3](https://github.com/WordPress/wordpress-develop/blob/6.3.0/src/readme.html#L54). Given the nature of the change, it seems appropriate to slate this for `3.8.0` instead of `3.7.5`.

Closes #1055.

### Testing instructions

No functional changes, but the test matrix has updated and we expect it to complete without any new problems.

### Changelog

> Update Action Scheduler's minimum requirements to WordPress 6.3 and PHP 7.0.