### PR TITLE
Throw an ErrorException rather than a standard exception when an error is caught during action processing

### DIFF
--- a/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php
+++ b/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php
@@ -58,9 +58,11 @@ abstract class ActionScheduler_Abstract_QueueRunner extends ActionScheduler_Abst
 			 *
 			 * @param int    $type    Error level expressed as an integer.
 			 * @param string $message Error message.
+			 * @param string $file    File in which the error occurred.
+			 * @param int    $line    Line number at which the error occurred.
 			 */
-			function ( $type, $message ) {
-				throw new Exception( $message );
+			function ( $type, $message, $file, $line ) {
+				throw new ErrorException( $message, 0, $type, $file, $line );
 			},
 			E_USER_ERROR | E_RECOVERABLE_ERROR
 		);

--- a/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php
+++ b/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php
@@ -44,14 +44,14 @@ abstract class ActionScheduler_Abstract_QueueRunner extends ActionScheduler_Abst
 	 * Process an individual action.
 	 *
 	 * @param int $action_id The action ID to process.
-	 * @param string $context Optional identifer for the context in which this action is being processed, e.g. 'WP CLI' or 'WP Cron'
+	 * @param string $context Optional identifier for the context in which this action is being processed, e.g. 'WP CLI' or 'WP Cron'
 	 *        Generally, this should be capitalised and not localised as it's a proper noun.
 	 */
 	public function process_action( $action_id, $context = '' ) {
 		// Temporarily override the error handler while we process the current action.
 		set_error_handler(
 			/**
-			 * Temporary error handler which can catch errors and convert them into exceptions. This faciliates more
+			 * Temporary error handler which can catch errors and convert them into exceptions. This facilitates more
 			 * robust error handling across all supported PHP versions.
 			 *
 			 * @throws Exception


### PR DESCRIPTION
Fixes #1052 

## Description

In the [`ActionScheduler_Abstract_QueueRunner::process_action()`](https://github.com/woocommerce/action-scheduler/blob/3.7.4/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php#L51-L66) function AS sets an error handler and any `E_USER_ERROR` or `E_RECOVERABLE_ERROR` error that occurs while processing the action is caught and thrown as an exception instead.

This is super handy for WooCommerce Subscriptions because AS will trigger the `action_scheduler_failed_execution` action which passes callbacks the exception that was caught.

WooCommerce Subscriptions uses this hook to log data about why our subscription-related scheduled actions have failed, however something I noticed today is that because AS is creating a new exception, if you use the `$exception->getFile()` `$exception->getLine()` helpers to point to where the exception occurred, it will point to AS, not where the error was actually thrown.

This is fixed by throwing an `ErrorException` which enables specifying the file and line where the error occurred. 

## Testing instructions

1. Add the following code snippet to your site to mimic an error occurring while processing an action. 


```php
add_action( 'action_scheduler_begin_execute', function() {
	trigger_error( 'Oops!', E_USER_ERROR );
} );

// Log the exception caught.
add_action( 'action_scheduler_failed_execution', function ( $action_id, $e ) {
	// When Action Scheduler throws an exception, it wraps the original exception in a new Exception. Information about the actual error is stored in the previous exception.
	$message = sprintf( 'a: %s in %s: %d', $e->getPrevious()->getMessage(), $e->getPrevious()->getFile(), $e->getPrevious()->getLine() );
	error_log( $message );
	ActionScheduler_Logger::instance()->log( $action_id, $message );
}, 10, 3 );
```

2. Go to **Tools > Action Scheduler**
3. Run any scheduled action
4. Check your error logs or the action logs
   - on `trunk` you'll notice the file and line points to AS
   - on this branch it will point to where the error was thrown. ie where you put the code snippet above. 

| `trunk` | This branch |
|--------|--------|
| <img width="281" alt="Screenshot 2024-05-09 at 2 30 12 PM" src="https://github.com/woocommerce/action-scheduler/assets/8490476/c37d6591-e67b-49fc-87f1-1d22352fb28d"> | <img width="285" alt="Screenshot 2024-05-09 at 2 30 35 PM" src="https://github.com/woocommerce/action-scheduler/assets/8490476/6487970a-2d83-42e8-8f70-e5b01c7028a8"> | 

