### PR TITLE
Use WP 6.4 Admin Notices 

### DIFF
--- a/action-scheduler.php
+++ b/action-scheduler.php
@@ -7,7 +7,7 @@
  * Author URI: https://automattic.com/
  * Version: 3.8.0
  * License: GPLv3
- * Requires at least: 6.2
+ * Requires at least: 6.4
  * Tested up to: 6.5
  * Requires PHP: 5.6
  *

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Changelog ***
 
+= 4.1.0 - xxxx-xx-xx =
+* Use `wp_admin_notice()` to render admin notices, instead of custom HTML.
+
 = 4.0.0 - 2026-06-16 =
 * Breaking change: action args are taken into account when scheduling unique actions.
 * Breaking change: failed actions are now automatically purged after 3 months by default, controlled by the `action_scheduler_retention_period_for_failed` filter.

--- a/classes/ActionScheduler_AdminView.php
+++ b/classes/ActionScheduler_AdminView.php
@@ -190,8 +190,7 @@ class ActionScheduler_AdminView extends ActionScheduler_AdminView_Deprecated {
 		), admin_url( 'tools.php' ) );
 
 		# Print notice.
-		echo '<div class="notice notice-warning"><p>';
-		printf(
+		$message = sprintf(
 			// translators: 1) is the number of affected actions, 2) is a link to an admin screen.
 			_n(
 				'<strong>Action Scheduler:</strong> %1$d <a href="%2$s">past-due action</a> found; something may be wrong. <a href="https://actionscheduler.org/faq/#my-site-has-past-due-actions-what-can-i-do" target="_blank">Read documentation &raquo;</a>',
@@ -202,7 +201,13 @@ class ActionScheduler_AdminView extends ActionScheduler_AdminView_Deprecated {
 			$num_pastdue_actions,
 			esc_attr( esc_url( $actions_url ) )
 		);
-		echo '</p></div>';
+		wp_admin_notice(
+			$message,
+			array(
+				'type' => 'warning',
+				'paragraph_wrap' => true,
+			)
+		);
 
 		# Facilitate third-parties to evaluate and print notices.
 		do_action( 'action_scheduler_pastdue_actions_extra_notices', $query_args );

--- a/classes/ActionScheduler_AdminView.php
+++ b/classes/ActionScheduler_AdminView.php
@@ -213,28 +213,29 @@ class ActionScheduler_AdminView extends ActionScheduler_AdminView_Deprecated {
 		);
 
 		// Print notice.
-		echo '<div class="notice notice-warning"><p>';
-		printf(
-			wp_kses(
-				// translators: 1) is the number of affected actions, 2) is a link to an admin screen.
-				_n(
-					'<strong>Action Scheduler:</strong> %1$d <a href="%2$s">past-due action</a> found; something may be wrong. <a href="https://actionscheduler.org/faq/#my-site-has-past-due-actions-what-can-i-do" target="_blank">Read documentation &raquo;</a>',
-					'<strong>Action Scheduler:</strong> %1$d <a href="%2$s">past-due actions</a> found; something may be wrong. <a href="https://actionscheduler.org/faq/#my-site-has-past-due-actions-what-can-i-do" target="_blank">Read documentation &raquo;</a>',
-					$num_pastdue_actions,
-					'action-scheduler'
-				),
-				array(
-					'strong' => array(),
-					'a'      => array(
-						'href'   => true,
-						'target' => true,
-					),
-				)
+		$message = wp_kses(
+			// translators: 1) is the number of affected actions, 2) is a link to an admin screen.
+			_n(
+				'<strong>Action Scheduler:</strong> %1$d <a href="%2$s">past-due action</a> found; something may be wrong. <a href="https://actionscheduler.org/faq/#my-site-has-past-due-actions-what-can-i-do" target="_blank">Read documentation &raquo;</a>',
+				'<strong>Action Scheduler:</strong> %1$d <a href="%2$s">past-due actions</a> found; something may be wrong. <a href="https://actionscheduler.org/faq/#my-site-has-past-due-actions-what-can-i-do" target="_blank">Read documentation &raquo;</a>',
+				$num_pastdue_actions,
+				'action-scheduler'
 			),
-			absint( $num_pastdue_actions ),
-			esc_attr( esc_url( $actions_url ) )
+			array(
+				'strong' => array(),
+				'a'      => array(
+					'href'   => true,
+					'target' => true,
+				),
+			)
 		);
-		echo '</p></div>';
+		wp_admin_notice(
+			$message,
+			array(
+				'type' => 'warning',
+				'paragraph_wrap' => true,
+			)
+		);
 
 		// Facilitate third-parties to evaluate and print notices.
 		do_action( 'action_scheduler_pastdue_actions_extra_notices', $query_args );

--- a/classes/ActionScheduler_AdminView.php
+++ b/classes/ActionScheduler_AdminView.php
@@ -232,7 +232,7 @@ class ActionScheduler_AdminView extends ActionScheduler_AdminView_Deprecated {
 		wp_admin_notice(
 			$message,
 			array(
-				'type' => 'warning',
+				'type'           => 'warning',
 				'paragraph_wrap' => true,
 			)
 		);

--- a/classes/ActionScheduler_ListTable.php
+++ b/classes/ActionScheduler_ListTable.php
@@ -360,7 +360,7 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 			foreach ( $table_list as $table_name ) {
 				if ( ! in_array( $wpdb->prefix . $table_name, $found_tables ) ) {
 					$this->admin_notices[] = array(
-						'class'   => 'error',
+						'type'    => 'error',
 						'message' => __( 'It appears one or more database tables were missing. Attempting to re-create the missing table(s).' , 'action-scheduler' ),
 					);
 					$this->recreate_tables();
@@ -374,7 +374,7 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 		if ( $this->runner->has_maximum_concurrent_batches() ) {
 			$claim_count           = $this->store->get_claim_count();
 			$this->admin_notices[] = array(
-				'class'   => 'updated',
+				'type'    => 'updated',
 				'message' => sprintf(
 					/* translators: %s: amount of claims */
 					_n(
@@ -401,7 +401,7 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 			}
 
 			$this->admin_notices[] = array(
-				'class'   => 'notice notice-info',
+				'type'    => 'info',
 				'message' => $async_request_message,
 			);
 		}
@@ -414,7 +414,7 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 			$action = $this->store->fetch_action( $notification['action_id'] );
 			$action_hook_html = '<strong><code>' . $action->get_hook() . '</code></strong>';
 			if ( 1 == $notification['success'] ) {
-				$class = 'updated';
+				$type = 'updated';
 				switch ( $notification['row_action_type'] ) {
 					case 'run' :
 						/* translators: %s: action HTML */
@@ -430,7 +430,7 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 						break;
 				}
 			} else {
-				$class = 'error';
+				$type = 'error';
 				/* translators: 1: action HTML 2: action ID 3: error message */
 				$action_message_html = sprintf( __( 'Could not process change for action: "%1$s" (ID: %2$d). Error: %3$s', 'action-scheduler' ), $action_hook_html, esc_html( $notification['action_id'] ), esc_html( $notification['error_message'] ) );
 			}
@@ -438,7 +438,7 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 			$action_message_html = apply_filters( 'action_scheduler_admin_notice_html', $action_message_html, $action, $notification );
 
 			$this->admin_notices[] = array(
-				'class'   => $class,
+				'type'    => $type,
 				'message' => $action_message_html,
 			);
 		}

--- a/classes/ActionScheduler_ListTable.php
+++ b/classes/ActionScheduler_ListTable.php
@@ -416,7 +416,7 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 			$action_hook_html = '<strong><code>' . $action->get_hook() . '</code></strong>';
 
 			if ( 1 === (int) $notification['success'] ) {
-				$type = 'updated';
+				$type = 'success';
 				switch ( $notification['row_action_type'] ) {
 					case 'run':
 						/* translators: %s: action HTML */
@@ -434,7 +434,7 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 			} else {
 				$type = 'error';
 				/* translators: 1: action HTML 2: action ID 3: error message */
-				$action_message_html = sprintf( __( 'Could not process change for action: "%1$s" (ID: %2$d). Error: %3$s', 'action-scheduler' ), $action_hook_html, esc_html( $notification['action_id'] ), esc_html( $notification['error_message'] ) );
+				$action_message_html = sprintf( __( 'Could not process change for action: %1$s (ID: %2$d). Error: %3$s', 'action-scheduler' ), $action_hook_html, esc_html( $notification['action_id'] ), esc_html( $notification['error_message'] ) );
 			}
 
 			$action_message_html = apply_filters( 'action_scheduler_admin_notice_html', $action_message_html, $action, $notification );

--- a/classes/ActionScheduler_ListTable.php
+++ b/classes/ActionScheduler_ListTable.php
@@ -361,8 +361,8 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 			foreach ( $table_list as $table_name ) {
 				if ( ! in_array( $wpdb->prefix . $table_name, $found_tables, true ) ) {
 					$this->admin_notices[] = array(
-						'class'   => 'error',
-						'message' => __( 'It appears one or more database tables were missing. Attempting to re-create the missing table(s).', 'action-scheduler' ),
+						'type'    => 'error',
+						'message' => __( 'It appears one or more database tables were missing. Attempting to re-create the missing table(s).' , 'action-scheduler' ),
 					);
 					$this->recreate_tables();
 					parent::display_admin_notices();
@@ -375,7 +375,7 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 		if ( $this->runner->has_maximum_concurrent_batches() ) {
 			$claim_count           = $this->store->get_claim_count();
 			$this->admin_notices[] = array(
-				'class'   => 'updated',
+				'type'    => 'updated',
 				'message' => sprintf(
 					/* translators: %s: amount of claims */
 					_n(
@@ -402,7 +402,7 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 			}
 
 			$this->admin_notices[] = array(
-				'class'   => 'notice notice-info',
+				'type'    => 'info',
 				'message' => $async_request_message,
 			);
 		}
@@ -413,10 +413,10 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 			delete_transient( 'action_scheduler_admin_notice' );
 
 			$action           = $this->store->fetch_action( $notification['action_id'] );
-			$action_hook_html = '<strong><code>' . esc_html( $action->get_hook() ) . '</code></strong>';
+			$action_hook_html = '<strong><code>' . $action->get_hook() . '</code></strong>';
 
-			if ( 1 === absint( $notification['success'] ) ) {
-				$class = 'updated';
+			if ( 1 == $notification['success'] ) {
+				$type = 'updated';
 				switch ( $notification['row_action_type'] ) {
 					case 'run':
 						/* translators: %s: action HTML */
@@ -432,7 +432,7 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 						break;
 				}
 			} else {
-				$class = 'error';
+				$type = 'error';
 				/* translators: 1: action HTML 2: action ID 3: error message */
 				$action_message_html = sprintf( __( 'Could not process change for action: "%1$s" (ID: %2$d). Error: %3$s', 'action-scheduler' ), $action_hook_html, esc_html( $notification['action_id'] ), esc_html( $notification['error_message'] ) );
 			}
@@ -440,7 +440,7 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 			$action_message_html = apply_filters( 'action_scheduler_admin_notice_html', $action_message_html, $action, $notification );
 
 			$this->admin_notices[] = array(
-				'class'   => $class,
+				'type'    => $type,
 				'message' => $action_message_html,
 			);
 		}

--- a/classes/ActionScheduler_ListTable.php
+++ b/classes/ActionScheduler_ListTable.php
@@ -375,7 +375,7 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 		if ( $this->runner->has_maximum_concurrent_batches() ) {
 			$claim_count           = $this->store->get_claim_count();
 			$this->admin_notices[] = array(
-				'type'    => 'updated',
+				'type'    => 'info',
 				'message' => sprintf(
 					/* translators: %s: amount of claims */
 					_n(

--- a/classes/ActionScheduler_ListTable.php
+++ b/classes/ActionScheduler_ListTable.php
@@ -362,7 +362,7 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 				if ( ! in_array( $wpdb->prefix . $table_name, $found_tables, true ) ) {
 					$this->admin_notices[] = array(
 						'type'    => 'error',
-						'message' => __( 'It appears one or more database tables were missing. Attempting to re-create the missing table(s).' , 'action-scheduler' ),
+						'message' => __( 'It appears one or more database tables were missing. Attempting to re-create the missing table(s).', 'action-scheduler' ),
 					);
 					$this->recreate_tables();
 					parent::display_admin_notices();
@@ -415,7 +415,7 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 			$action           = $this->store->fetch_action( $notification['action_id'] );
 			$action_hook_html = '<strong><code>' . $action->get_hook() . '</code></strong>';
 
-			if ( 1 == $notification['success'] ) {
+			if ( 1 === (int) $notification['success'] ) {
 				$type = 'updated';
 				switch ( $notification['row_action_type'] ) {
 					case 'run':

--- a/classes/ActionScheduler_WPCommentCleaner.php
+++ b/classes/ActionScheduler_WPCommentCleaner.php
@@ -90,7 +90,7 @@ class ActionScheduler_WPCommentCleaner {
 	public static function register_admin_notice() {
 		add_action( 'admin_notices', array( __CLASS__, 'print_admin_notice' ) );
 	}
-	
+
 	/**
 	 * Prints details about the orphaned action logs and includes information on where to learn more.
 	 */
@@ -110,6 +110,12 @@ class ActionScheduler_WPCommentCleaner {
 			'https://github.com/woocommerce/action-scheduler/issues/368'
 		);
 
-		echo '<div class="notice notice-warning"><p>' . wp_kses_post( $notice ) . '</p></div>';
+		wp_admin_notice(
+			$notice,
+			array(
+				'type' => 'warning',
+				'paragraph_wrap' => true,
+			)
+		);
 	}
 }

--- a/classes/ActionScheduler_WPCommentCleaner.php
+++ b/classes/ActionScheduler_WPCommentCleaner.php
@@ -131,7 +131,7 @@ class ActionScheduler_WPCommentCleaner {
 		wp_admin_notice(
 			$notice,
 			array(
-				'type' => 'warning',
+				'type'           => 'warning',
 				'paragraph_wrap' => true,
 			)
 		);

--- a/classes/ActionScheduler_WPCommentCleaner.php
+++ b/classes/ActionScheduler_WPCommentCleaner.php
@@ -128,6 +128,12 @@ class ActionScheduler_WPCommentCleaner {
 			'https://github.com/woocommerce/action-scheduler/issues/368'
 		);
 
-		echo '<div class="notice notice-warning"><p>' . wp_kses_post( $notice ) . '</p></div>';
+		wp_admin_notice(
+			$notice,
+			array(
+				'type' => 'warning',
+				'paragraph_wrap' => true,
+			)
+		);
 	}
 }

--- a/classes/abstracts/ActionScheduler_Abstract_ListTable.php
+++ b/classes/abstracts/ActionScheduler_Abstract_ListTable.php
@@ -678,9 +678,10 @@ abstract class ActionScheduler_Abstract_ListTable extends WP_List_Table {
 			wp_admin_notice(
 				$notice['message'],
 				array(
-					'type'           => $notice['type'] === 'updated' ? '' : $notice['type'],
-					'paragraph_wrap' => true,
-					'additional_classes' => ( $notice['type'] === 'updated' ? 'updated' : '')
+					'id'                 => 'message',
+					'type'               => $notice['type'] === 'updated' ? '' : $notice['type'],
+					'paragraph_wrap'     => true,
+					'additional_classes' => ( $notice['type'] === 'updated' ? 'updated' : ''),
 				)
 			);
 		}

--- a/classes/abstracts/ActionScheduler_Abstract_ListTable.php
+++ b/classes/abstracts/ActionScheduler_Abstract_ListTable.php
@@ -103,7 +103,7 @@ abstract class ActionScheduler_Abstract_ListTable extends WP_List_Table {
 	protected $status_counts = array();
 
 	/**
-	 * Notices to display when loading the table. Array of arrays of form array( 'class' => {updated|error}, 'message' => 'This is the notice text display.' ).
+	 * Notices to display when loading the table. Array of arrays of form array( 'type' => {updated|error}, 'message' => 'This is the notice text display.' ).
 	 *
 	 * @var array
 	 */
@@ -675,9 +675,14 @@ abstract class ActionScheduler_Abstract_ListTable extends WP_List_Table {
 	 */
 	protected function display_admin_notices() {
 		foreach ( $this->admin_notices as $notice ) {
-			echo '<div id="message" class="' . esc_attr( $notice['class'] ) . '">';
-			echo '	<p>' . wp_kses_post( $notice['message'] ) . '</p>';
-			echo '</div>';
+			wp_admin_notice(
+				$notice['message'],
+				array(
+					'type'           => $notice['type'] === 'updated' ? '' : $notice['type'],
+					'paragraph_wrap' => true,
+					'additional_classes' => ( $notice['type'] === 'updated' ? 'updated' : '')
+				)
+			);
 		}
 	}
 

--- a/classes/abstracts/ActionScheduler_Abstract_ListTable.php
+++ b/classes/abstracts/ActionScheduler_Abstract_ListTable.php
@@ -679,9 +679,9 @@ abstract class ActionScheduler_Abstract_ListTable extends WP_List_Table {
 				$notice['message'],
 				array(
 					'id'                 => 'message',
-					'type'               => $notice['type'] === 'updated' ? '' : $notice['type'],
+					'type'               => 'updated' === $notice['type'] ? '' : $notice['type'],
 					'paragraph_wrap'     => true,
-					'additional_classes' => ( $notice['type'] === 'updated' ? 'updated' : ''),
+					'additional_classes' => 'updated' === $notice['type'] ? 'updated' : '',
 				)
 			);
 		}

--- a/classes/migration/Controller.php
+++ b/classes/migration/Controller.php
@@ -159,7 +159,13 @@ class Controller {
 	 * Show a dashboard notice that migration is in progress.
 	 */
 	public function display_migration_notice() {
-		printf( '<div class="notice notice-warning"><p>%s</p></div>', esc_html__( 'Action Scheduler migration in progress. The list of scheduled actions may be incomplete.', 'action-scheduler' ) );
+		wp_admin_notice(
+			__('Action Scheduler migration in progress. The list of scheduled actions may be incomplete.', 'action-scheduler' ),
+			array(
+				'type' => 'warning',
+				'paragraph_wrap' => true
+			)
+		);
 	}
 
 	/**

--- a/classes/migration/Controller.php
+++ b/classes/migration/Controller.php
@@ -180,7 +180,13 @@ class Controller {
 	 * Show a dashboard notice that migration is in progress.
 	 */
 	public function display_migration_notice() {
-		printf( '<div class="notice notice-warning"><p>%s</p></div>', esc_html__( 'Action Scheduler migration in progress. The list of scheduled actions may be incomplete.', 'action-scheduler' ) );
+		wp_admin_notice(
+			__('Action Scheduler migration in progress. The list of scheduled actions may be incomplete.', 'action-scheduler' ),
+			array(
+				'type' => 'warning',
+				'paragraph_wrap' => true
+			)
+		);
 	}
 
 	/**

--- a/classes/migration/Controller.php
+++ b/classes/migration/Controller.php
@@ -181,10 +181,10 @@ class Controller {
 	 */
 	public function display_migration_notice() {
 		wp_admin_notice(
-			__('Action Scheduler migration in progress. The list of scheduled actions may be incomplete.', 'action-scheduler' ),
+			__( 'Action Scheduler migration in progress. The list of scheduled actions may be incomplete.', 'action-scheduler' ),
 			array(
-				'type' => 'warning',
-				'paragraph_wrap' => true
+				'type'           => 'warning',
+				'paragraph_wrap' => true,
 			)
 		);
 	}


### PR DESCRIPTION
Resolves #1072 .

Updates all notice prints to `wp_admin_notice` calls. Also updates the WordPress minimum version to due the introduction version of the `wp_admin_notice` function