### PR TITLE
Missing parameter on apply_filters( 'pre_as_enqueue_async_action')

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -35,8 +35,9 @@ function as_enqueue_async_action( $hook, $args = array(), $group = '', $unique =
 	 * @param array    $args       Action arguments.
 	 * @param string   $group      Action group.
 	 * @param int      $priority   Action priority.
+	 * @param bool     $unique     Unique action.
 	 */
-	$pre = apply_filters( 'pre_as_enqueue_async_action', null, $hook, $args, $group, $priority );
+	$pre = apply_filters( 'pre_as_enqueue_async_action', null, $hook, $args, $group, $priority, $unique );
 	if ( null !== $pre ) {
 		return is_int( $pre ) ? $pre : 0;
 	}


### PR DESCRIPTION
Makes it possible for `pre_as_enqueue_async_action` callbacks to see if the action about to be created is considered unique.

Fixes #1082.

### Testing instructions

Add the following to a mu-plugin file, such as `wp-content/mu-plugins/test-pr-1084.php`:

```php
<?php

add_filter( 'pre_as_enqueue_async_action', function ( $null, $hook, $args, $group, $priority, $unique ) {
	var_dump( $null, $hook, $args, $group, $priority, $unique );
}, 10, 6 );
```

Now create a new async action via WP CLI:

```sh
wp eval "as_enqueue_async_action( 'foo', [ 'bar' => 'baz' ], 'foobar', true, 100 );"
```

You should see output similar to the following (whitespace added for readability):

```
./wp-content/mu-plugins/test-pr-1084.php.php:4:
NULL

./wp-content/mu-plugins/test-pr-1084.php.php:4:
string(3) "foo"

./wp-content/mu-plugins/test-pr-1084.php.php:4:
array(1) {
  'bar' =>
  string(3) "baz"
}

./wp-content/mu-plugins/test-pr-1084.php.php:4:
string(6) "foobar"

./wp-content/mu-plugins/test-pr-1084.php.php:4:
int(100)

./wp-content/mu-plugins/test-pr-1084.php.php:4:
bool(true)
```

In particular, we expect to see `(bool) true` for that final entry.

### Changelog

> Fix - Allows `pre_as_enqueue_async_action` callbacks to see if the action about to be scheduled should be unique.