### PR TITLE
PHPCS fixes: `PSR2`, `PSR12`, `PEAR`

### DIFF
--- a/classes/ActionScheduler_AdminView.php
+++ b/classes/ActionScheduler_AdminView.php
@@ -22,7 +22,7 @@ class ActionScheduler_AdminView extends ActionScheduler_AdminView_Deprecated {
 	public static function instance() {
 
 		if ( empty( self::$admin_view ) ) {
-			$class = apply_filters('action_scheduler_admin_view_class', 'ActionScheduler_AdminView');
+			$class = apply_filters( 'action_scheduler_admin_view_class', 'ActionScheduler_AdminView' );
 			self::$admin_view = new $class();
 		}
 

--- a/classes/ActionScheduler_FatalErrorMonitor.php
+++ b/classes/ActionScheduler_FatalErrorMonitor.php
@@ -71,7 +71,7 @@ class ActionScheduler_FatalErrorMonitor {
 
 		if ( $error ) {
 			if ( in_array( $error['type'], array( E_ERROR, E_PARSE, E_COMPILE_ERROR, E_USER_ERROR, E_RECOVERABLE_ERROR ) ) ) {
-				if ( !empty($this->action_id) ) {
+				if ( !empty( $this->action_id ) ) {
 					$this->store->mark_failure( $this->action_id );
 					do_action( 'action_scheduler_unexpected_shutdown', $this->action_id, $error );
 				}

--- a/classes/ActionScheduler_ListTable.php
+++ b/classes/ActionScheduler_ListTable.php
@@ -417,15 +417,15 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 			if ( 1 == $notification['success'] ) {
 				$class = 'updated';
 				switch ( $notification['row_action_type'] ) {
-					case 'run' :
+					case 'run':
 						/* translators: %s: action HTML */
 						$action_message_html = sprintf( __( 'Successfully executed action: %s', 'action-scheduler' ), $action_hook_html );
 						break;
-					case 'cancel' :
+					case 'cancel':
 						/* translators: %s: action HTML */
 						$action_message_html = sprintf( __( 'Successfully canceled action: %s', 'action-scheduler' ), $action_hook_html );
 						break;
-					default :
+					default:
 						/* translators: %s: action HTML */
 						$action_message_html = sprintf( __( 'Successfully processed change for action: %s', 'action-scheduler' ), $action_hook_html );
 						break;
@@ -567,10 +567,10 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 	protected function process_row_action( $action_id, $row_action_type ) {
 		try {
 			switch ( $row_action_type ) {
-				case 'run' :
+				case 'run':
 					$this->runner->process_action( $action_id, 'Admin List Table' );
 					break;
-				case 'cancel' :
+				case 'cancel':
 					$this->store->cancel_action( $action_id );
 					break;
 			}

--- a/classes/ActionScheduler_QueueCleaner.php
+++ b/classes/ActionScheduler_QueueCleaner.php
@@ -160,7 +160,7 @@ class ActionScheduler_QueueCleaner {
 		if ( $timeout < 0 ) {
 			return;
 		}
-		$cutoff = as_get_datetime_object($timeout . ' seconds ago');
+		$cutoff = as_get_datetime_object( $timeout . ' seconds ago' );
 		$actions_to_reset = $this->store->query_actions( array(
 			'status'           => ActionScheduler_Store::STATUS_PENDING,
 			'modified'         => $cutoff,
@@ -190,7 +190,7 @@ class ActionScheduler_QueueCleaner {
 		if ( $timeout < 0 ) {
 			return;
 		}
-		$cutoff = as_get_datetime_object($timeout . ' seconds ago');
+		$cutoff = as_get_datetime_object( $timeout . ' seconds ago' );
 		$actions_to_reset = $this->store->query_actions( array(
 			'status'           => ActionScheduler_Store::STATUS_RUNNING,
 			'modified'         => $cutoff,

--- a/classes/ActionScheduler_QueueRunner.php
+++ b/classes/ActionScheduler_QueueRunner.php
@@ -22,8 +22,8 @@ class ActionScheduler_QueueRunner extends ActionScheduler_Abstract_QueueRunner {
 	 * @codeCoverageIgnore
 	 */
 	public static function instance() {
-		if ( empty(self::$runner) ) {
-			$class = apply_filters('action_scheduler_queue_runner_class', 'ActionScheduler_QueueRunner');
+		if ( empty( self::$runner ) ) {
+			$class = apply_filters( 'action_scheduler_queue_runner_class', 'ActionScheduler_QueueRunner' );
 			self::$runner = new $class();
 		}
 		return self::$runner;
@@ -158,8 +158,8 @@ class ActionScheduler_QueueRunner extends ActionScheduler_Abstract_QueueRunner {
 	 * @return int The number of actions processed.
 	 */
 	protected function do_batch( $size = 100, $context = '' ) {
-		$claim = $this->store->stake_claim($size);
-		$this->monitor->attach($claim);
+		$claim = $this->store->stake_claim( $size );
+		$this->monitor->attach( $claim );
 		$processed_actions = 0;
 
 		foreach ( $claim->get_actions() as $action_id ) {
@@ -174,7 +174,7 @@ class ActionScheduler_QueueRunner extends ActionScheduler_Abstract_QueueRunner {
 				break;
 			}
 		}
-		$this->store->release_claim($claim);
+		$this->store->release_claim( $claim );
 		$this->monitor->detach();
 		$this->clear_caches();
 		return $processed_actions;

--- a/classes/ActionScheduler_Versions.php
+++ b/classes/ActionScheduler_Versions.php
@@ -19,7 +19,7 @@ class ActionScheduler_Versions {
 	 * @param callable $initialization_callback Callback to initialize the version.
 	 */
 	public function register( $version_string, $initialization_callback ) {
-		if ( isset($this->versions[$version_string]) ) {
+		if ( isset( $this->versions[$version_string] ) ) {
 			return FALSE;
 		}
 		$this->versions[$version_string] = $initialization_callback;
@@ -37,12 +37,12 @@ class ActionScheduler_Versions {
 	 * Get latest version registered.
 	 */
 	public function latest_version() {
-		$keys = array_keys($this->versions);
-		if ( empty($keys) ) {
+		$keys = array_keys( $this->versions );
+		if ( empty( $keys ) ) {
 			return false;
 		}
 		uasort( $keys, 'version_compare' );
-		return end($keys);
+		return end( $keys );
 	}
 
 	/**
@@ -50,7 +50,7 @@ class ActionScheduler_Versions {
 	 */
 	public function latest_version_callback() {
 		$latest = $this->latest_version();
-		if ( empty($latest) || !isset($this->versions[$latest]) ) {
+		if ( empty( $latest ) || !isset( $this->versions[$latest] ) ) {
 			return '__return_null';
 		}
 		return $this->versions[$latest];
@@ -61,7 +61,7 @@ class ActionScheduler_Versions {
 	 * @codeCoverageIgnore
 	 */
 	public static function instance() {
-		if ( empty(self::$instance) ) {
+		if ( empty( self::$instance ) ) {
 			self::$instance = new self();
 		}
 		return self::$instance;
@@ -72,6 +72,6 @@ class ActionScheduler_Versions {
 	 */
 	public static function initialize_latest_version() {
 		$self = self::instance();
-		call_user_func($self->latest_version_callback());
+		call_user_func( $self->latest_version_callback() );
 	}
 }

--- a/classes/WP_CLI/ActionScheduler_WPCLI_Scheduler_command.php
+++ b/classes/WP_CLI/ActionScheduler_WPCLI_Scheduler_command.php
@@ -96,7 +96,7 @@ class ActionScheduler_WPCLI_Scheduler_command extends WP_CLI_Command {
 			$exclude_groups = $this->parse_comma_separated_string( $exclude_groups );
 
 			if ( ! empty( $exclude_groups ) ) {
-				ActionScheduler::store()->set_claim_filter('exclude-groups', $exclude_groups );
+				ActionScheduler::store()->set_claim_filter( 'exclude-groups', $exclude_groups );
 			}
 		}
 

--- a/classes/abstracts/ActionScheduler.php
+++ b/classes/abstracts/ActionScheduler.php
@@ -143,7 +143,7 @@ abstract class ActionScheduler {
 		}
 
 		if ( file_exists( $dir . "{$class}.php" ) ) {
-			include( $dir . "{$class}.php" );
+			include $dir . "{$class}.php";
 			return;
 		}
 	}
@@ -163,7 +163,7 @@ abstract class ActionScheduler {
 		 */
 		do_action( 'action_scheduler_pre_init' );
 
-		require_once( self::plugin_path( 'functions.php' ) );
+		require_once self::plugin_path( 'functions.php' );
 		ActionScheduler_DataController::init();
 
 		$store      = self::store();
@@ -216,7 +216,7 @@ abstract class ActionScheduler {
 		}
 
 		if ( apply_filters( 'action_scheduler_load_deprecated_functions', true ) ) {
-			require_once( self::plugin_path( 'deprecated/functions.php' ) );
+			require_once self::plugin_path( 'deprecated/functions.php' );
 		}
 
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {

--- a/classes/abstracts/ActionScheduler.php
+++ b/classes/abstracts/ActionScheduler.php
@@ -19,7 +19,7 @@ abstract class ActionScheduler {
 	 * Factory.
 	 */
 	public static function factory() {
-		if ( !isset(self::$factory) ) {
+		if ( !isset( self::$factory ) ) {
 			self::$factory = new ActionScheduler_ActionFactory();
 		}
 		return self::$factory;
@@ -67,11 +67,11 @@ abstract class ActionScheduler {
 	 * @return string
 	 */
 	public static function plugin_path( $path ) {
-		$base = dirname(self::$plugin_file);
+		$base = dirname( self::$plugin_file );
 		if ( $path ) {
-			return trailingslashit($base) . $path;
+			return trailingslashit( $base ) . $path;
 		} else {
-			return untrailingslashit($base);
+			return untrailingslashit( $base );
 		}
 	}
 
@@ -82,7 +82,7 @@ abstract class ActionScheduler {
 	 * @return string
 	 */
 	public static function plugin_url( $path ) {
-		return plugins_url($path, self::$plugin_file);
+		return plugins_url( $path, self::$plugin_file );
 	}
 
 	/**
@@ -337,14 +337,14 @@ abstract class ActionScheduler {
 	 * Clone.
 	 */
 	final public function __clone() {
-		trigger_error('Singleton. No cloning allowed!', E_USER_ERROR);
+		trigger_error( 'Singleton. No cloning allowed!', E_USER_ERROR );
 	}
 
 	/**
 	 * Wakeup.
 	 */
 	final public function __wakeup() {
-		trigger_error('Singleton. No serialization allowed!', E_USER_ERROR);
+		trigger_error( 'Singleton. No serialization allowed!', E_USER_ERROR );
 	}
 
 	/**

--- a/classes/abstracts/ActionScheduler_Logger.php
+++ b/classes/abstracts/ActionScheduler_Logger.php
@@ -15,8 +15,8 @@ abstract class ActionScheduler_Logger {
 	 * @return ActionScheduler_Logger
 	 */
 	public static function instance() {
-		if ( empty(self::$logger) ) {
-			$class = apply_filters('action_scheduler_logger_class', 'ActionScheduler_wpCommentLogger');
+		if ( empty( self::$logger ) ) {
+			$class = apply_filters( 'action_scheduler_logger_class', 'ActionScheduler_wpCommentLogger' );
 			self::$logger = new $class();
 		}
 		return self::$logger;

--- a/classes/abstracts/ActionScheduler_TimezoneHelper.php
+++ b/classes/abstracts/ActionScheduler_TimezoneHelper.php
@@ -110,11 +110,11 @@ abstract class ActionScheduler_TimezoneHelper {
 		if ( $reset ) {
 			self::$local_timezone = NULL;
 		}
-		if ( !isset(self::$local_timezone) ) {
-			$tzstring = get_option('timezone_string');
+		if ( !isset( self::$local_timezone ) ) {
+			$tzstring = get_option( 'timezone_string' );
 
-			if ( empty($tzstring) ) {
-				$gmt_offset = get_option('gmt_offset');
+			if ( empty( $tzstring ) ) {
+				$gmt_offset = get_option( 'gmt_offset' );
 				if ( $gmt_offset == 0 ) {
 					$tzstring = 'UTC';
 				} else {
@@ -151,7 +151,7 @@ abstract class ActionScheduler_TimezoneHelper {
 				}
 			}
 
-			self::$local_timezone = new DateTimeZone($tzstring);
+			self::$local_timezone = new DateTimeZone( $tzstring );
 		}
 		return self::$local_timezone;
 	}

--- a/classes/actions/ActionScheduler_Action.php
+++ b/classes/actions/ActionScheduler_Action.php
@@ -36,10 +36,10 @@ class ActionScheduler_Action {
 	 */
 	public function __construct( $hook, array $args = array(), ActionScheduler_Schedule $schedule = NULL, $group = '' ) {
 		$schedule = empty( $schedule ) ? new ActionScheduler_NullSchedule() : $schedule;
-		$this->set_hook($hook);
-		$this->set_schedule($schedule);
-		$this->set_args($args);
-		$this->set_group($group);
+		$this->set_hook( $hook );
+		$this->set_schedule( $schedule );
+		$this->set_args( $args );
+		$this->set_group( $group );
 	}
 
 	/**

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -412,7 +412,7 @@ AND `group_id` = %d
 			'offset'                => 0,
 			'orderby'               => 'date',
 			'order'                 => 'ASC',
-		 ) );
+		) );
 
 		/** @var \wpdb $wpdb */
 		global $wpdb;

--- a/classes/data-stores/ActionScheduler_wpCommentLogger.php
+++ b/classes/data-stores/ActionScheduler_wpCommentLogger.php
@@ -17,7 +17,7 @@ class ActionScheduler_wpCommentLogger extends ActionScheduler_Logger {
 	 * @return string The log entry ID
 	 */
 	public function log( $action_id, $message, DateTime $date = NULL ) {
-		if ( empty($date) ) {
+		if ( empty( $date ) ) {
 			$date = as_get_datetime_object();
 		} else {
 			$date = as_get_datetime_object( clone $date );
@@ -35,18 +35,18 @@ class ActionScheduler_wpCommentLogger extends ActionScheduler_Logger {
 	 */
 	protected function create_wp_comment( $action_id, $message, DateTime $date ) {
 
-		$comment_date_gmt = $date->format('Y-m-d H:i:s');
+		$comment_date_gmt = $date->format( 'Y-m-d H:i:s' );
 		ActionScheduler_TimezoneHelper::set_local_timezone( $date );
 		$comment_data = array(
 			'comment_post_ID' => $action_id,
-			'comment_date' => $date->format('Y-m-d H:i:s'),
+			'comment_date' => $date->format( 'Y-m-d H:i:s' ),
 			'comment_date_gmt' => $comment_date_gmt,
 			'comment_author' => self::AGENT,
 			'comment_content' => $message,
 			'comment_agent' => self::AGENT,
 			'comment_type' => self::TYPE,
 		);
-		return wp_insert_comment($comment_data);
+		return wp_insert_comment( $comment_data );
 	}
 
 	/**
@@ -58,7 +58,7 @@ class ActionScheduler_wpCommentLogger extends ActionScheduler_Logger {
 	 */
 	public function get_entry( $entry_id ) {
 		$comment = $this->get_comment( $entry_id );
-		if ( empty($comment) || $comment->comment_type != self::TYPE ) {
+		if ( empty( $comment ) || $comment->comment_type != self::TYPE ) {
 			return new ActionScheduler_NullLogEntry();
 		}
 
@@ -76,7 +76,7 @@ class ActionScheduler_wpCommentLogger extends ActionScheduler_Logger {
 	 */
 	public function get_logs( $action_id ) {
 		$status = 'all';
-		if ( get_post_status($action_id) == 'trash' ) {
+		if ( get_post_status( $action_id ) == 'trash' ) {
 			$status = 'post-trashed';
 		}
 		$comments = get_comments(array(
@@ -89,7 +89,7 @@ class ActionScheduler_wpCommentLogger extends ActionScheduler_Logger {
 		$logs = array();
 		foreach ( $comments as $c ) {
 			$entry = $this->get_entry( $c );
-			if ( !empty($entry) ) {
+			if ( !empty( $entry ) ) {
 				$logs[] = $entry;
 			}
 		}
@@ -114,7 +114,7 @@ class ActionScheduler_wpCommentLogger extends ActionScheduler_Logger {
 	 */
 	public function filter_comment_queries( $query ) {
 		foreach ( array('ID', 'parent', 'post_author', 'post_name', 'post_parent', 'type', 'post_type', 'post_id', 'post_ID') as $key ) {
-			if ( !empty($query->query_vars[$key]) ) {
+			if ( !empty( $query->query_vars[$key] ) ) {
 				return; // don't slow down queries that wouldn't include action_log comments anyway.
 			}
 		}
@@ -131,7 +131,7 @@ class ActionScheduler_wpCommentLogger extends ActionScheduler_Logger {
 	 * @return array
 	 */
 	public function filter_comment_query_clauses( $clauses, $query ) {
-		if ( !empty($query->query_vars['action_log_filter']) ) {
+		if ( !empty( $query->query_vars['action_log_filter'] ) ) {
 			$clauses['where'] .= $this->get_where_clause();
 		}
 		return $clauses;
@@ -258,14 +258,14 @@ class ActionScheduler_wpCommentLogger extends ActionScheduler_Logger {
 	 * Defer comment counting.
 	 */
 	public function disable_comment_counting() {
-		wp_defer_comment_counting(true);
+		wp_defer_comment_counting( true );
 	}
 
 	/**
 	 * Enable comment counting.
 	 */
 	public function enable_comment_counting() {
-		wp_defer_comment_counting(false);
+		wp_defer_comment_counting( false );
 	}
 
 }

--- a/classes/data-stores/ActionScheduler_wpPostStore_PostTypeRegistrar.php
+++ b/classes/data-stores/ActionScheduler_wpPostStore_PostTypeRegistrar.php
@@ -46,7 +46,7 @@ class ActionScheduler_wpPostStore_PostTypeRegistrar {
 			),
 		);
 
-		$args = apply_filters('action_scheduler_post_type_args', $args);
+		$args = apply_filters( 'action_scheduler_post_type_args', $args );
 		return $args;
 	}
 }

--- a/classes/migration/ActionMigrator.php
+++ b/classes/migration/ActionMigrator.php
@@ -80,10 +80,10 @@ class ActionMigrator {
 
 		try {
 			switch ( $status ) {
-				case \ActionScheduler_Store::STATUS_FAILED :
+				case \ActionScheduler_Store::STATUS_FAILED:
 					$this->destination->mark_failure( $destination_action_id );
 					break;
-				case \ActionScheduler_Store::STATUS_CANCELED :
+				case \ActionScheduler_Store::STATUS_CANCELED:
 					$this->destination->cancel_action( $destination_action_id );
 					break;
 			}

--- a/classes/migration/BatchFetcher.php
+++ b/classes/migration/BatchFetcher.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Action_Scheduler\Migration;
-
 
 use ActionScheduler_Store as Store;
 

--- a/classes/schema/ActionScheduler_LoggerSchema.php
+++ b/classes/schema/ActionScheduler_LoggerSchema.php
@@ -43,7 +43,6 @@ class ActionScheduler_LoggerSchema extends ActionScheduler_Abstract_Schema {
 		switch ( $table ) {
 
 			case self::LOG_TABLE:
-
 				$default_date = ActionScheduler_StoreSchema::DEFAULT_DATE;
 				return "CREATE TABLE $table_name (
 				        log_id bigint(20) unsigned NOT NULL auto_increment,

--- a/classes/schema/ActionScheduler_StoreSchema.php
+++ b/classes/schema/ActionScheduler_StoreSchema.php
@@ -52,7 +52,6 @@ class ActionScheduler_StoreSchema extends ActionScheduler_Abstract_Schema {
 		switch ( $table ) {
 
 			case self::ACTIONS_TABLE:
-
 				return "CREATE TABLE {$table_name} (
 				        action_id bigint(20) unsigned NOT NULL auto_increment,
 				        hook varchar(191) NOT NULL,
@@ -79,7 +78,6 @@ class ActionScheduler_StoreSchema extends ActionScheduler_Abstract_Schema {
 				        ) $charset_collate";
 
 			case self::CLAIMS_TABLE:
-
 				return "CREATE TABLE {$table_name} (
 				        claim_id bigint(20) unsigned NOT NULL auto_increment,
 				        date_created_gmt datetime NULL default '{$default_date}',
@@ -88,7 +86,6 @@ class ActionScheduler_StoreSchema extends ActionScheduler_Abstract_Schema {
 				        ) $charset_collate";
 
 			case self::GROUPS_TABLE:
-
 				return "CREATE TABLE {$table_name} (
 				        group_id bigint(20) unsigned NOT NULL auto_increment,
 				        slug varchar(255) NOT NULL,

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -43,4 +43,11 @@
 		<exclude-pattern>lib/*</exclude-pattern>
 		<exclude-pattern>tests/*</exclude-pattern>
 	</rule>
+
+	<rule ref="PEAR.NamingConventions.ValidClassName.Invalid">
+		<exclude-pattern>classes/*</exclude-pattern>
+		<exclude-pattern>deprecated/*</exclude-pattern>
+		<exclude-pattern>lib/*</exclude-pattern>
+		<exclude-pattern>test/*</exclude-pattern>
+	</rule>
 </ruleset>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -50,4 +50,10 @@
 		<exclude-pattern>lib/*</exclude-pattern>
 		<exclude-pattern>test/*</exclude-pattern>
 	</rule>
+
+	<rule ref="PEAR.Functions.FunctionCallSignature">
+		<exclude name="PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket" />
+		<exclude name="PEAR.Functions.FunctionCallSignature.MultipleArguments" />
+		<exclude name="PEAR.Functions.FunctionCallSignature.CloseBracketLine" />
+	</rule>
 </ruleset>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -44,11 +44,8 @@
 		<exclude-pattern>tests/*</exclude-pattern>
 	</rule>
 
-	<rule ref="PEAR.NamingConventions.ValidClassName.Invalid">
-		<exclude-pattern>classes/*</exclude-pattern>
-		<exclude-pattern>deprecated/*</exclude-pattern>
-		<exclude-pattern>lib/*</exclude-pattern>
-		<exclude-pattern>test/*</exclude-pattern>
+	<rule ref="PEAR.NamingConventions.ValidClassName">
+		<exclude name="PEAR.NamingConventions.ValidClassName.Invalid" />
 	</rule>
 
 	<rule ref="PEAR.Functions.FunctionCallSignature">


### PR DESCRIPTION
Eliminates most smells from the `PSR2`, `PSR12`, and `PEAR` standards. Some rules excluded.

See https://github.com/woocommerce/action-scheduler/issues/971.