### PR TITLE
PHPCS fixes: `PHPCompatibility`, `Generic`

### DIFF
--- a/classes/ActionScheduler_ActionClaim.php
+++ b/classes/ActionScheduler_ActionClaim.php
@@ -4,9 +4,19 @@
  * Class ActionScheduler_ActionClaim
  */
 class ActionScheduler_ActionClaim {
-	/** @var string */
+
+	/**
+	 * Claim ID.
+	 *
+	 * @var string
+	 */
 	private $id = '';
-	/** @var int[] */
+
+	/**
+	 * Action IDs to claim.
+	 *
+	 * @var int[]
+	 */
 	private $action_ids = array();
 
 	/**

--- a/classes/ActionScheduler_ActionClaim.php
+++ b/classes/ActionScheduler_ActionClaim.php
@@ -16,7 +16,7 @@ class ActionScheduler_ActionClaim {
 	 * @param int[]  $action_ids Action IDs.
 	 */
 	public function __construct( $id, array $action_ids ) {
-		$this->id = $id;
+		$this->id         = $id;
 		$this->action_ids = $action_ids;
 	}
 

--- a/classes/ActionScheduler_AdminView.php
+++ b/classes/ActionScheduler_AdminView.php
@@ -145,8 +145,6 @@ class ActionScheduler_AdminView extends ActionScheduler_AdminView_Deprecated {
 
 	/**
 	 * Check past-due actions, and print notice.
-	 *
-	 * @todo update $link_url to "Past-due" filter when released (see issue #510, PR #511)
 	 */
 	protected function check_pastdue_actions() {
 

--- a/classes/ActionScheduler_AdminView.php
+++ b/classes/ActionScheduler_AdminView.php
@@ -7,7 +7,7 @@
 class ActionScheduler_AdminView extends ActionScheduler_AdminView_Deprecated {
 
 	/** @var null|self */
-	private static $admin_view = NULL;
+	private static $admin_view = null;
 
 	/** @var string */
 	private static $screen_id = 'tools_page_action-scheduler';

--- a/classes/ActionScheduler_AdminView.php
+++ b/classes/ActionScheduler_AdminView.php
@@ -2,20 +2,35 @@
 
 /**
  * Class ActionScheduler_AdminView
+ *
  * @codeCoverageIgnore
  */
 class ActionScheduler_AdminView extends ActionScheduler_AdminView_Deprecated {
 
-	/** @var null|self */
+	/**
+	 * Instance.
+	 *
+	 * @var null|self
+	 */
 	private static $admin_view = null;
 
-	/** @var string */
+	/**
+	 * Screen ID.
+	 *
+	 * @var string
+	 */
 	private static $screen_id = 'tools_page_action-scheduler';
 
-	/** @var ActionScheduler_ListTable */
+	/**
+	 * ListTable instance.
+	 *
+	 * @var ActionScheduler_ListTable
+	 */
 	protected $list_table;
 
 	/**
+	 * Instance.
+	 *
 	 * @return ActionScheduler_AdminView
 	 * @codeCoverageIgnore
 	 */

--- a/classes/ActionScheduler_AdminView.php
+++ b/classes/ActionScheduler_AdminView.php
@@ -22,7 +22,7 @@ class ActionScheduler_AdminView extends ActionScheduler_AdminView_Deprecated {
 	public static function instance() {
 
 		if ( empty( self::$admin_view ) ) {
-			$class = apply_filters('action_scheduler_admin_view_class', 'ActionScheduler_AdminView');
+			$class            = apply_filters('action_scheduler_admin_view_class', 'ActionScheduler_AdminView');
 			self::$admin_view = new $class();
 		}
 
@@ -174,7 +174,7 @@ class ActionScheduler_AdminView extends ActionScheduler_AdminView_Deprecated {
 
 		// If no third-party preempted, run default check.
 		if ( is_null( $check ) ) {
-			$store = ActionScheduler_Store::instance();
+			$store               = ActionScheduler_Store::instance();
 			$num_pastdue_actions = (int) $store->query_actions( $query_args, 'count' );
 
 			// Check if past-due actions count is greater than or equal to threshold.

--- a/classes/ActionScheduler_AdminView.php
+++ b/classes/ActionScheduler_AdminView.php
@@ -85,7 +85,7 @@ class ActionScheduler_AdminView extends ActionScheduler_AdminView_Deprecated {
 			'action-scheduler',
 			array( $this, 'render_admin_ui' )
 		);
-		add_action( 'load-' . $hook_suffix , array( $this, 'process_admin_ui' ) );
+		add_action( 'load-' . $hook_suffix, array( $this, 'process_admin_ui' ) );
 	}
 
 	/**

--- a/classes/ActionScheduler_Compatibility.php
+++ b/classes/ActionScheduler_Compatibility.php
@@ -85,7 +85,7 @@ class ActionScheduler_Compatibility {
 	 * @param int $limit The time limit in seconds.
 	 */
 	public static function raise_time_limit( $limit = 0 ) {
-		$limit = (int) $limit;
+		$limit              = (int) $limit;
 		$max_execution_time = (int) ini_get( 'max_execution_time' );
 
 		// If the max execution time is already set to zero (unlimited), there is no reason to make a further change.

--- a/classes/ActionScheduler_DataController.php
+++ b/classes/ActionScheduler_DataController.php
@@ -18,10 +18,10 @@ class ActionScheduler_DataController {
 	const DATASTORE_CLASS = 'ActionScheduler_DBStore';
 
 	/** Logger data store class name. */
-	const LOGGER_CLASS    = 'ActionScheduler_DBLogger';
+	const LOGGER_CLASS = 'ActionScheduler_DBLogger';
 
 	/** Migration status option name. */
-	const STATUS_FLAG     = 'action_scheduler_migration_status';
+	const STATUS_FLAG = 'action_scheduler_migration_status';
 
 	/** Migration status option value. */
 	const STATUS_COMPLETE = 'complete';

--- a/classes/ActionScheduler_DataController.php
+++ b/classes/ActionScheduler_DataController.php
@@ -29,13 +29,25 @@ class ActionScheduler_DataController {
 	/** Migration minimum required PHP version. */
 	const MIN_PHP_VERSION = '5.5';
 
-	/** @var ActionScheduler_DataController */
+	/**
+	 * Instance.
+	 *
+	 * @var ActionScheduler_DataController
+	 */
 	private static $instance;
 
-	/** @var int */
+	/**
+	 * Number of seconds pause before resuming operation.
+	 *
+	 * @var int
+	 */
 	private static $sleep_time = 0;
 
-	/** @var int */
+	/**
+	 * Number of ticks to free memory.
+	 *
+	 * @var int
+	 */
 	private static $free_ticks = 50;
 
 	/**
@@ -137,6 +149,8 @@ class ActionScheduler_DataController {
 		\WP_CLI::warning( __( 'Attempting to reduce used memory...', 'action-scheduler' ) );
 
 		/**
+		 * Global variables.
+		 *
 		 * @var $wpdb            \wpdb
 		 * @var $wp_object_cache \WP_Object_Cache
 		 */

--- a/classes/ActionScheduler_FatalErrorMonitor.php
+++ b/classes/ActionScheduler_FatalErrorMonitor.php
@@ -29,9 +29,9 @@ class ActionScheduler_FatalErrorMonitor {
 		$this->claim = $claim;
 		add_action( 'shutdown', array( $this, 'handle_unexpected_shutdown' ) );
 		add_action( 'action_scheduler_before_execute', array( $this, 'track_current_action' ), 0, 1 );
-		add_action( 'action_scheduler_after_execute',  array( $this, 'untrack_action' ), 0, 0 );
-		add_action( 'action_scheduler_execution_ignored',  array( $this, 'untrack_action' ), 0, 0 );
-		add_action( 'action_scheduler_failed_execution',  array( $this, 'untrack_action' ), 0, 0 );
+		add_action( 'action_scheduler_after_execute', array( $this, 'untrack_action' ), 0, 0 );
+		add_action( 'action_scheduler_execution_ignored', array( $this, 'untrack_action' ), 0, 0 );
+		add_action( 'action_scheduler_failed_execution', array( $this, 'untrack_action' ), 0, 0 );
 	}
 
 	/**
@@ -42,9 +42,9 @@ class ActionScheduler_FatalErrorMonitor {
 		$this->untrack_action();
 		remove_action( 'shutdown', array( $this, 'handle_unexpected_shutdown' ) );
 		remove_action( 'action_scheduler_before_execute', array( $this, 'track_current_action' ), 0 );
-		remove_action( 'action_scheduler_after_execute',  array( $this, 'untrack_action' ), 0 );
-		remove_action( 'action_scheduler_execution_ignored',  array( $this, 'untrack_action' ), 0 );
-		remove_action( 'action_scheduler_failed_execution',  array( $this, 'untrack_action' ), 0 );
+		remove_action( 'action_scheduler_after_execute', array( $this, 'untrack_action' ), 0 );
+		remove_action( 'action_scheduler_execution_ignored', array( $this, 'untrack_action' ), 0 );
+		remove_action( 'action_scheduler_failed_execution', array( $this, 'untrack_action' ), 0 );
 	}
 
 	/**

--- a/classes/ActionScheduler_FatalErrorMonitor.php
+++ b/classes/ActionScheduler_FatalErrorMonitor.php
@@ -4,11 +4,26 @@
  * Class ActionScheduler_FatalErrorMonitor
  */
 class ActionScheduler_FatalErrorMonitor {
-	/** @var ActionScheduler_ActionClaim */
+
+	/**
+	 * Claim instance.
+	 *
+	 * @var ActionScheduler_ActionClaim
+	 */
 	private $claim = null;
-	/** @var ActionScheduler_Store */
+
+	/**
+	 * Store instance.
+	 *
+	 * @var ActionScheduler_Store
+	 */
 	private $store = null;
-	/** @var int */
+
+	/**
+	 * Action ID.
+	 *
+	 * @var int
+	 */
 	private $action_id = 0;
 
 	/**

--- a/classes/ActionScheduler_FatalErrorMonitor.php
+++ b/classes/ActionScheduler_FatalErrorMonitor.php
@@ -5,9 +5,9 @@
  */
 class ActionScheduler_FatalErrorMonitor {
 	/** @var ActionScheduler_ActionClaim */
-	private $claim = NULL;
+	private $claim = null;
 	/** @var ActionScheduler_Store */
-	private $store = NULL;
+	private $store = null;
 	/** @var int */
 	private $action_id = 0;
 
@@ -38,7 +38,7 @@ class ActionScheduler_FatalErrorMonitor {
 	 * Stop monitoring.
 	 */
 	public function detach() {
-		$this->claim = NULL;
+		$this->claim = null;
 		$this->untrack_action();
 		remove_action( 'shutdown', array( $this, 'handle_unexpected_shutdown' ) );
 		remove_action( 'action_scheduler_before_execute', array( $this, 'track_current_action' ), 0 );

--- a/classes/ActionScheduler_ListTable.php
+++ b/classes/ActionScheduler_ListTable.php
@@ -2,6 +2,7 @@
 
 /**
  * Implements the admin view of the actions.
+ *
  * @codeCoverageIgnore
  */
 class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
@@ -50,8 +51,7 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 
 	/**
 	 * Bulk actions. The key of the array is the method name of the implementation:
-	 *
-	 *     bulk_<key>(array $ids, string $sql_in).
+	 * bulk_<key>(array $ids, string $sql_in).
 	 *
 	 * See the comments in the parent class for further details
 	 *

--- a/classes/ActionScheduler_ListTable.php
+++ b/classes/ActionScheduler_ListTable.php
@@ -362,7 +362,7 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 				if ( ! in_array( $wpdb->prefix . $table_name, $found_tables ) ) {
 					$this->admin_notices[] = array(
 						'class'   => 'error',
-						'message' => __( 'It appears one or more database tables were missing. Attempting to re-create the missing table(s).' , 'action-scheduler' ),
+						'message' => __( 'It appears one or more database tables were missing. Attempting to re-create the missing table(s).', 'action-scheduler' ),
 					);
 					$this->recreate_tables();
 					parent::display_admin_notices();

--- a/classes/ActionScheduler_ListTable.php
+++ b/classes/ActionScheduler_ListTable.php
@@ -224,7 +224,7 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 			return __( 'Now!', 'action-scheduler' );
 		}
 
-		$output = '';
+		$output           = '';
 		$num_time_periods = count( self::$time_periods );
 
 		for ( $time_period_index = 0, $periods_included = 0, $seconds_remaining = $interval; $time_period_index < $num_time_periods && $seconds_remaining > 0 && $periods_included < $periods_to_include; $time_period_index++ ) {
@@ -235,7 +235,7 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 				if ( ! empty( $output ) ) {
 					$output .= ' ';
 				}
-				$output .= sprintf( translate_nooped_plural( self::$time_periods[ $time_period_index ]['names'], $periods_in_interval, 'action-scheduler' ), $periods_in_interval );
+				$output            .= sprintf( translate_nooped_plural( self::$time_periods[ $time_period_index ]['names'], $periods_in_interval, 'action-scheduler' ), $periods_in_interval );
 				$seconds_remaining -= $periods_in_interval * self::$time_periods[ $time_period_index ]['seconds'];
 				$periods_included++;
 			}
@@ -393,7 +393,7 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 
 			// No lock set or lock expired.
 			if ( false === $async_request_lock_expiration || $async_request_lock_expiration < time() ) {
-				$in_progress_url       = add_query_arg( 'status', 'in-progress', remove_query_arg( 'status' ) );
+				$in_progress_url = add_query_arg( 'status', 'in-progress', remove_query_arg( 'status' ) );
 				/* translators: %s: process URL */
 				$async_request_message = sprintf( __( 'A new queue has begun processing. <a href="%s">View actions in-progress &raquo;</a>', 'action-scheduler' ), esc_url( $in_progress_url ) );
 			} else {
@@ -412,7 +412,7 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 		if ( is_array( $notification ) ) {
 			delete_transient( 'action_scheduler_admin_notice' );
 
-			$action = $this->store->fetch_action( $notification['action_id'] );
+			$action           = $this->store->fetch_action( $notification['action_id'] );
 			$action_hook_html = '<strong><code>' . $action->get_hook() . '</code></strong>';
 			if ( 1 == $notification['success'] ) {
 				$class = 'updated';
@@ -574,10 +574,10 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 					$this->store->cancel_action( $action_id );
 					break;
 			}
-			$success = 1;
+			$success       = 1;
 			$error_message = '';
 		} catch ( Exception $e ) {
-			$success = 0;
+			$success       = 0;
 			$error_message = $e->getMessage();
 		}
 

--- a/classes/ActionScheduler_LogEntry.php
+++ b/classes/ActionScheduler_LogEntry.php
@@ -6,16 +6,22 @@
 class ActionScheduler_LogEntry {
 
 	/**
+	 * Action ID.
+	 *
 	 * @var int $action_id
 	 */
 	protected $action_id =  '';
 
 	/**
+	 * Message.
+	 *
 	 * @var string $message
 	 */
 	protected $message =  '';
 
 	/**
+	 * Date.
+	 *
 	 * @var Datetime $date
 	 */
 	protected $date;

--- a/classes/ActionScheduler_OptionLock.php
+++ b/classes/ActionScheduler_OptionLock.php
@@ -5,6 +5,7 @@
  * for up-to a given duration.
  *
  * Class ActionScheduler_OptionLock
+ *
  * @since 3.0.0
  */
 class ActionScheduler_OptionLock extends ActionScheduler_Lock {

--- a/classes/ActionScheduler_QueueCleaner.php
+++ b/classes/ActionScheduler_QueueCleaner.php
@@ -31,10 +31,10 @@ class ActionScheduler_QueueCleaner {
 	 *
 	 * @var string[]
 	 */
-	private $default_statuses_to_purge = [
+	private $default_statuses_to_purge = array(
 		ActionScheduler_Store::STATUS_COMPLETE,
 		ActionScheduler_Store::STATUS_CANCELED,
-	];
+	);
 
 	/**
 	 * ActionScheduler_QueueCleaner constructor.
@@ -103,7 +103,7 @@ class ActionScheduler_QueueCleaner {
 			$statuses_to_purge = $this->default_statuses_to_purge;
 		}
 
-		$deleted_actions = [];
+		$deleted_actions = array();
 		foreach ( $statuses_to_purge as $status ) {
 			$actions_to_delete = $this->store->query_actions( array(
 				'status'           => $status,
@@ -128,7 +128,7 @@ class ActionScheduler_QueueCleaner {
 	 * @return array Deleted action IDs.
 	 */
 	private function delete_actions( array $actions_to_delete, $lifespan = null, $context = 'old' ) {
-		$deleted_actions = [];
+		$deleted_actions = array();
 		if ( $lifespan === null ) {
 			$lifespan = $this->month_in_seconds;
 		}

--- a/classes/ActionScheduler_QueueCleaner.php
+++ b/classes/ActionScheduler_QueueCleaner.php
@@ -33,7 +33,7 @@ class ActionScheduler_QueueCleaner {
 	 * @param int                   $batch_size The batch size.
 	 */
 	public function __construct( ActionScheduler_Store $store = null, $batch_size = 20 ) {
-		$this->store = $store ? $store : ActionScheduler_Store::instance();
+		$this->store      = $store ? $store : ActionScheduler_Store::instance();
 		$this->batch_size = $batch_size;
 	}
 
@@ -160,7 +160,7 @@ class ActionScheduler_QueueCleaner {
 		if ( $timeout < 0 ) {
 			return;
 		}
-		$cutoff = as_get_datetime_object($timeout . ' seconds ago');
+		$cutoff           = as_get_datetime_object($timeout . ' seconds ago');
 		$actions_to_reset = $this->store->query_actions( array(
 			'status'           => ActionScheduler_Store::STATUS_PENDING,
 			'modified'         => $cutoff,
@@ -190,7 +190,7 @@ class ActionScheduler_QueueCleaner {
 		if ( $timeout < 0 ) {
 			return;
 		}
-		$cutoff = as_get_datetime_object($timeout . ' seconds ago');
+		$cutoff           = as_get_datetime_object($timeout . ' seconds ago');
 		$actions_to_reset = $this->store->query_actions( array(
 			'status'           => ActionScheduler_Store::STATUS_RUNNING,
 			'modified'         => $cutoff,

--- a/classes/ActionScheduler_QueueCleaner.php
+++ b/classes/ActionScheduler_QueueCleaner.php
@@ -5,10 +5,18 @@
  */
 class ActionScheduler_QueueCleaner {
 
-	/** @var int */
+	/**
+	 * Batch size.
+	 *
+	 * @var int
+	 */
 	protected $batch_size;
 
-	/** @var ActionScheduler_Store */
+	/**
+	 * Store instance.
+	 *
+	 * @var ActionScheduler_Store
+	 */
 	private $store = null;
 
 	/**
@@ -19,7 +27,9 @@ class ActionScheduler_QueueCleaner {
 	private $month_in_seconds = 2678400;
 
 	/**
-	 * @var string[] Default list of statuses purged by the cleaner process.
+	 * Default list of statuses purged by the cleaner process.
+	 *
+	 * @var string[]
 	 */
 	private $default_statuses_to_purge = [
 		ActionScheduler_Store::STATUS_COMPLETE,
@@ -139,7 +149,6 @@ class ActionScheduler_QueueCleaner {
 				 * @param int $lifespan The retention period, in seconds, for old actions
 				 * @param int $count_of_actions_to_delete The number of old actions being deleted in this batch
 				 * @since 2.0.0
-				 *
 				 */
 				do_action( "action_scheduler_failed_{$context}_action_deletion", $action_id, $e, $lifespan, count( $actions_to_delete ) );
 			}

--- a/classes/ActionScheduler_QueueRunner.php
+++ b/classes/ActionScheduler_QueueRunner.php
@@ -8,16 +8,30 @@ class ActionScheduler_QueueRunner extends ActionScheduler_Abstract_QueueRunner {
 
 	const WP_CRON_SCHEDULE = 'every_minute';
 
-	/** @var ActionScheduler_AsyncRequest_QueueRunner */
+	/**
+	 * Async runner instance.
+	 *
+	 * @var ActionScheduler_AsyncRequest_QueueRunner
+	 */
 	protected $async_request;
 
-	/** @var ActionScheduler_QueueRunner  */
+	/**
+	 * Instance.
+	 *
+	 * @var ActionScheduler_QueueRunner
+	 */
 	private static $runner = null;
 
-	/** @var int  */
+	/**
+	 * Count of processed actions.
+	 *
+	 * @var int
+	 */
 	private $processed_actions_count = 0;
 
 	/**
+	 * Instance.
+	 *
 	 * @return ActionScheduler_QueueRunner
 	 * @codeCoverageIgnore
 	 */
@@ -48,6 +62,8 @@ class ActionScheduler_QueueRunner extends ActionScheduler_Abstract_QueueRunner {
 	}
 
 	/**
+	 * Initialize.
+	 *
 	 * @codeCoverageIgnore
 	 */
 	public function init() {
@@ -121,6 +137,7 @@ class ActionScheduler_QueueRunner extends ActionScheduler_Abstract_QueueRunner {
 	 * that was the only context in which this method was run, and the self::WP_CRON_HOOK hook had no context
 	 * passed along with it. New code calling this method directly, or by triggering the self::WP_CRON_HOOK,
 	 * should set a context as the first parameter. For an example of this, refer to the code seen in
+	 *
 	 * @see ActionScheduler_AsyncRequest_QueueRunner::handle()
 	 *
 	 * @param string $context Optional identifier for the context in which this action is being processed, e.g. 'WP CLI' or 'WP Cron'

--- a/classes/ActionScheduler_QueueRunner.php
+++ b/classes/ActionScheduler_QueueRunner.php
@@ -23,7 +23,7 @@ class ActionScheduler_QueueRunner extends ActionScheduler_Abstract_QueueRunner {
 	 */
 	public static function instance() {
 		if ( empty(self::$runner) ) {
-			$class = apply_filters('action_scheduler_queue_runner_class', 'ActionScheduler_QueueRunner');
+			$class        = apply_filters('action_scheduler_queue_runner_class', 'ActionScheduler_QueueRunner');
 			self::$runner = new $class();
 		}
 		return self::$runner;

--- a/classes/ActionScheduler_Versions.php
+++ b/classes/ActionScheduler_Versions.php
@@ -7,7 +7,7 @@ class ActionScheduler_Versions {
 	/**
 	 * @var ActionScheduler_Versions
 	 */
-	private static $instance = NULL;
+	private static $instance = null;
 
 	/** @var array<string, callable> */
 	private $versions = array();
@@ -20,10 +20,10 @@ class ActionScheduler_Versions {
 	 */
 	public function register( $version_string, $initialization_callback ) {
 		if ( isset($this->versions[$version_string]) ) {
-			return FALSE;
+			return false;
 		}
 		$this->versions[$version_string] = $initialization_callback;
-		return TRUE;
+		return true;
 	}
 
 	/**

--- a/classes/ActionScheduler_Versions.php
+++ b/classes/ActionScheduler_Versions.php
@@ -4,12 +4,19 @@
  * Class ActionScheduler_Versions
  */
 class ActionScheduler_Versions {
+
 	/**
+	 * Instance.
+	 *
 	 * @var ActionScheduler_Versions
 	 */
 	private static $instance = null;
 
-	/** @var array<string, callable> */
+	/**
+	 * Versions.
+	 *
+	 * @var array<string, callable>
+	 */
 	private $versions = array();
 
 	/**
@@ -57,6 +64,8 @@ class ActionScheduler_Versions {
 	}
 
 	/**
+	 * Instance.
+	 *
 	 * @return ActionScheduler_Versions
 	 * @codeCoverageIgnore
 	 */
@@ -68,6 +77,8 @@ class ActionScheduler_Versions {
 	}
 
 	/**
+	 * Initialize.
+	 *
 	 * @codeCoverageIgnore
 	 */
 	public static function initialize_latest_version() {

--- a/classes/WP_CLI/ActionScheduler_WPCLI_Clean_Command.php
+++ b/classes/WP_CLI/ActionScheduler_WPCLI_Clean_Command.php
@@ -58,7 +58,7 @@ class ActionScheduler_WPCLI_Clean_Command extends WP_CLI_Command {
 					sleep( $sleep );
 				}
 
-				$deleted = count( $cleaner->clean_actions( $status, $lifespan, null,'CLI' ) );
+				$deleted = count( $cleaner->clean_actions( $status, $lifespan, null, 'CLI' ) );
 				if ( $deleted <= 0 ) {
 					break;
 				}

--- a/classes/WP_CLI/ActionScheduler_WPCLI_Clean_Command.php
+++ b/classes/WP_CLI/ActionScheduler_WPCLI_Clean_Command.php
@@ -81,7 +81,7 @@ class ActionScheduler_WPCLI_Clean_Command extends WP_CLI_Command {
 	 *
 	 * @param int $batches_processed Number of batches processed.
 	 */
-	protected function print_total_batches( int $batches_processed ) {
+	protected function print_total_batches( $batches_processed ) {
 		WP_CLI::log(
 			sprintf(
 				/* translators: %d refers to the total number of batches processed */
@@ -113,7 +113,7 @@ class ActionScheduler_WPCLI_Clean_Command extends WP_CLI_Command {
 	 *
 	 * @param int $actions_deleted Number of deleted actions.
 	 */
-	protected function print_success( int $actions_deleted ) {
+	protected function print_success( $actions_deleted ) {
 		WP_CLI::success(
 			sprintf(
 				/* translators: %d refers to the total number of actions deleted */

--- a/classes/WP_CLI/ActionScheduler_WPCLI_QueueRunner.php
+++ b/classes/WP_CLI/ActionScheduler_WPCLI_QueueRunner.php
@@ -9,13 +9,25 @@ use Action_Scheduler\WP_CLI\ProgressBar;
  */
 class ActionScheduler_WPCLI_QueueRunner extends ActionScheduler_Abstract_QueueRunner {
 
-	/** @var array */
+	/**
+	 * Action IDs to execute.
+	 *
+	 * @var array
+	 */
 	protected $actions;
 
-	/** @var  ActionScheduler_ActionClaim */
+	/**
+	 * ActionClaim object.
+	 *
+	 * @var ActionScheduler_ActionClaim
+	 */
 	protected $claim;
 
-	/** @var \cli\progress\Bar */
+	/**
+	 * Progress bar object.
+	 *
+	 * @var \cli\progress\Bar
+	 */
 	protected $progress_bar;
 
 	/**

--- a/classes/WP_CLI/ActionScheduler_WPCLI_Scheduler_command.php
+++ b/classes/WP_CLI/ActionScheduler_WPCLI_Scheduler_command.php
@@ -134,7 +134,7 @@ class ActionScheduler_WPCLI_Scheduler_command extends WP_CLI_Command {
 	 *
 	 * @return array
 	 */
-	private function parse_comma_separated_string( $string ): array {
+	private function parse_comma_separated_string( $string ) {
 		return array_filter( str_getcsv( $string ) );
 	}
 

--- a/classes/WP_CLI/ActionScheduler_WPCLI_Scheduler_command.php
+++ b/classes/WP_CLI/ActionScheduler_WPCLI_Scheduler_command.php
@@ -92,7 +92,7 @@ class ActionScheduler_WPCLI_Scheduler_command extends WP_CLI_Command {
 		$batches_completed = 0;
 		$actions_completed = 0;
 		$unlimited         = $batches === 0;
-		if ( is_callable( [ ActionScheduler::store(), 'set_claim_filter' ] ) ) {
+		if ( is_callable( array( ActionScheduler::store(), 'set_claim_filter' ) ) ) {
 			$exclude_groups = $this->parse_comma_separated_string( $exclude_groups );
 
 			if ( ! empty( $exclude_groups ) ) {

--- a/classes/WP_CLI/Migration_Command.php
+++ b/classes/WP_CLI/Migration_Command.php
@@ -36,38 +36,38 @@ class Migration_Command extends WP_CLI_Command {
 			return;
 		}
 
-		WP_CLI::add_command( 'action-scheduler migrate', [ $this, 'migrate' ], [
+		WP_CLI::add_command( 'action-scheduler migrate', array( $this, 'migrate' ), array(
 			'shortdesc' => 'Migrates actions to the DB tables store',
-			'synopsis'  => [
-				[
+			'synopsis'  => array(
+				array(
 					'type'        => 'assoc',
 					'name'        => 'batch-size',
 					'optional'    => true,
 					'default'     => 100,
 					'description' => 'The number of actions to process in each batch',
-				],
-				[
+				),
+				array(
 					'type'        => 'assoc',
 					'name'        => 'free-memory-on',
 					'optional'    => true,
 					'default'     => 50,
 					'description' => 'The number of actions to process between freeing memory. 0 disables freeing memory',
-				],
-				[
+				),
+				array(
 					'type'        => 'assoc',
 					'name'        => 'pause',
 					'optional'    => true,
 					'default'     => 0,
 					'description' => 'The number of seconds to pause when freeing memory',
-				],
-				[
+				),
+				array(
 					'type'        => 'flag',
 					'name'        => 'dry-run',
 					'optional'    => true,
 					'description' => 'Reports on the actions that would have been migrated, but does not change any data',
-				],
-			],
-		] );
+				),
+			),
+		) );
 	}
 
 	/**
@@ -113,9 +113,9 @@ class Migration_Command extends WP_CLI_Command {
 	 * @return ActionScheduler\Migration\Config
 	 */
 	private function get_migration_config( $args ) {
-		$args = wp_parse_args( $args, [
+		$args = wp_parse_args( $args, array(
 			'dry-run' => false,
-		] );
+		) );
 
 		$config = Controller::instance()->get_migration_config_object();
 		$config->set_dry_run( ! empty( $args[ 'dry-run' ] ) );

--- a/classes/WP_CLI/Migration_Command.php
+++ b/classes/WP_CLI/Migration_Command.php
@@ -88,7 +88,7 @@ class Migration_Command extends WP_CLI_Command {
 		\ActionScheduler_DataController::set_sleep_time( $sleep );
 
 		do {
-			$actions_processed     = $runner->run( $batch_size );
+			$actions_processed      = $runner->run( $batch_size );
 			$this->total_processed += $actions_processed;
 		} while ( $actions_processed > 0 );
 

--- a/classes/WP_CLI/Migration_Command.php
+++ b/classes/WP_CLI/Migration_Command.php
@@ -21,7 +21,11 @@ use WP_CLI_Command;
  */
 class Migration_Command extends WP_CLI_Command {
 
-	/** @var int */
+	/**
+	 * Count of actions processed.
+	 *
+	 * @var int
+	 */
 	private $total_processed = 0;
 
 	/**

--- a/classes/WP_CLI/ProgressBar.php
+++ b/classes/WP_CLI/ProgressBar.php
@@ -17,19 +17,39 @@ namespace Action_Scheduler\WP_CLI;
  */
 class ProgressBar {
 
-	/** @var integer */
+	/**
+	 * Current count of ticks.
+	 *
+	 * @var integer
+	 */
 	protected $total_ticks;
 
-	/** @var integer */
+	/**
+	 * Total number of ticks to be performed.
+	 *
+	 * @var integer
+	 */
 	protected $count;
 
-	/** @var integer */
+	/**
+	 * Progress bar refresh interval.
+	 *
+	 * @var integer
+	 */
 	protected $interval;
 
-	/** @var string */
+	/**
+	 * Progress bar's message.
+	 *
+	 * @var string
+	 */
 	protected $message;
 
-	/** @var \cli\progress\Bar */
+	/**
+	 * Instance of WP CLI's progress\Bar object.
+	 *
+	 * @var \cli\progress\Bar
+	 */
 	protected $progress_bar;
 
 	/**

--- a/classes/WP_CLI/ProgressBar.php
+++ b/classes/WP_CLI/ProgressBar.php
@@ -38,7 +38,7 @@ class ProgressBar {
 	 * @param string  $message    Text to display before the progress bar.
 	 * @param integer $count      Total number of ticks to be performed.
 	 * @param integer $interval   Optional. The interval in milliseconds between updates. Default 100.
- 	 *
+	 *
 	 * @throws \Exception When this is not run within WP CLI.
 	 */
 	public function __construct( $message, $count, $interval = 100 ) {

--- a/classes/abstracts/ActionScheduler.php
+++ b/classes/abstracts/ActionScheduler.php
@@ -11,7 +11,7 @@ abstract class ActionScheduler {
 	/** @var string */
 	private static $plugin_file = '';
 	/** @var ActionScheduler_ActionFactory */
-	private static $factory = NULL;
+	private static $factory = null;
 	/** @var bool */
 	private static $data_store_initialized = false;
 

--- a/classes/abstracts/ActionScheduler.php
+++ b/classes/abstracts/ActionScheduler.php
@@ -5,14 +5,30 @@ use Action_Scheduler\Migration\Controller;
 
 /**
  * Class ActionScheduler
+ *
  * @codeCoverageIgnore
  */
 abstract class ActionScheduler {
-	/** @var string */
+
+	/**
+	 * Plugin file path.
+	 *
+	 * @var string
+	 */
 	private static $plugin_file = '';
-	/** @var ActionScheduler_ActionFactory */
+
+	/**
+	 * Factory instance.
+	 *
+	 * @var ActionScheduler_ActionFactory
+	 */
 	private static $factory = null;
-	/** @var bool */
+
+	/**
+	 * Data store init indicator.
+	 *
+	 * @var bool
+	 */
 	private static $data_store_initialized = false;
 
 	/**
@@ -62,6 +78,7 @@ abstract class ActionScheduler {
 
 	/**
 	 * Get the absolute system path to the plugin directory, or a file therein
+	 *
 	 * @static
 	 * @param string $path Path relative to plugin directory.
 	 * @return string
@@ -77,6 +94,7 @@ abstract class ActionScheduler {
 
 	/**
 	 * Get the absolute URL to the plugin directory, or a file therein
+	 *
 	 * @static
 	 * @param string $path Path relative to plugin directory.
 	 * @return string

--- a/classes/abstracts/ActionScheduler.php
+++ b/classes/abstracts/ActionScheduler.php
@@ -115,7 +115,7 @@ abstract class ActionScheduler {
 			$dir = $classes_dir . 'schema' . $d;
 		} elseif ( strpos( $class, 'ActionScheduler' ) === 0 ) {
 			$segments = explode( '_', $class );
-			$type = isset( $segments[ 1 ] ) ? $segments[ 1 ] : '';
+			$type     = isset( $segments[ 1 ] ) ? $segments[ 1 ] : '';
 
 			switch ( $type ) {
 				case 'WPCLI':
@@ -306,7 +306,7 @@ abstract class ActionScheduler {
 		);
 
 		$segments = explode( '_', $class );
-		$segment = isset( $segments[ 1 ] ) ? $segments[ 1 ] : $class;
+		$segment  = isset( $segments[ 1 ] ) ? $segments[ 1 ] : $class;
 
 		return isset( $migration_segments[ $segment ] ) && $migration_segments[ $segment ];
 	}
@@ -328,7 +328,7 @@ abstract class ActionScheduler {
 		);
 
 		$segments = explode( '_', $class );
-		$segment = isset( $segments[ 1 ] ) ? $segments[ 1 ] : $class;
+		$segment  = isset( $segments[ 1 ] ) ? $segments[ 1 ] : $class;
 
 		return isset( $cli_segments[ $segment ] ) && $cli_segments[ $segment ];
 	}

--- a/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php
+++ b/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php
@@ -5,13 +5,25 @@
  */
 abstract class ActionScheduler_Abstract_QueueRunner extends ActionScheduler_Abstract_QueueRunner_Deprecated {
 
-	/** @var ActionScheduler_QueueCleaner */
+	/**
+	 * Queue cleaner instance.
+	 *
+	 * @var ActionScheduler_QueueCleaner
+	 */
 	protected $cleaner;
 
-	/** @var ActionScheduler_FatalErrorMonitor */
+	/**
+	 * Fatal error monitor instance.
+	 *
+	 * @var ActionScheduler_FatalErrorMonitor
+	 */
 	protected $monitor;
 
-	/** @var ActionScheduler_Store */
+	/**
+	 * Store instance.
+	 *
+	 * @var ActionScheduler_Store
+	 */
 	protected $store;
 
 	/**

--- a/classes/abstracts/ActionScheduler_Abstract_RecurringSchedule.php
+++ b/classes/abstracts/ActionScheduler_Abstract_RecurringSchedule.php
@@ -73,7 +73,7 @@ abstract class ActionScheduler_Abstract_RecurringSchedule extends ActionSchedule
 	 * @return array
 	 */
 	public function __sleep() {
-		$sleep_params = parent::__sleep();
+		$sleep_params          = parent::__sleep();
 		$this->first_timestamp = $this->first_date->getTimestamp();
 		return array_merge( $sleep_params, array(
 			'first_timestamp',

--- a/classes/abstracts/ActionScheduler_Abstract_RecurringSchedule.php
+++ b/classes/abstracts/ActionScheduler_Abstract_RecurringSchedule.php
@@ -15,14 +15,14 @@ abstract class ActionScheduler_Abstract_RecurringSchedule extends ActionSchedule
 	 *
 	 * @var DateTime
 	 */
-	private $first_date = NULL;
+	private $first_date = null;
 
 	/**
 	 * Timestamp equivalent of @see $this->first_date
 	 *
 	 * @var int
 	 */
-	protected $first_timestamp = NULL;
+	protected $first_timestamp = null;
 
 	/**
 	 * The recurrence between each time an action is run using this schedule.

--- a/classes/abstracts/ActionScheduler_Abstract_RecurringSchedule.php
+++ b/classes/abstracts/ActionScheduler_Abstract_RecurringSchedule.php
@@ -35,6 +35,8 @@ abstract class ActionScheduler_Abstract_RecurringSchedule extends ActionSchedule
 	protected $recurrence;
 
 	/**
+	 * Construct.
+	 *
 	 * @param DateTime      $date The date & time to run the action.
 	 * @param mixed         $recurrence The data used to determine the schedule's recurrence.
 	 * @param DateTime|null $first (Optional) The date & time the first instance of this interval schedule ran. Default null, meaning this is the first instance.
@@ -46,6 +48,8 @@ abstract class ActionScheduler_Abstract_RecurringSchedule extends ActionSchedule
 	}
 
 	/**
+	 * Get recurring state.
+	 *
 	 * @return bool
 	 */
 	public function is_recurring() {
@@ -62,6 +66,8 @@ abstract class ActionScheduler_Abstract_RecurringSchedule extends ActionSchedule
 	}
 
 	/**
+	 * Get the recurrence between each time an action is run using this schedule.
+	 *
 	 * @return string
 	 */
 	public function get_recurrence() {
@@ -70,6 +76,7 @@ abstract class ActionScheduler_Abstract_RecurringSchedule extends ActionSchedule
 
 	/**
 	 * For PHP 5.2 compat, since DateTime objects can't be serialized
+	 *
 	 * @return array
 	 */
 	public function __sleep() {

--- a/classes/abstracts/ActionScheduler_Abstract_Schedule.php
+++ b/classes/abstracts/ActionScheduler_Abstract_Schedule.php
@@ -10,14 +10,14 @@ abstract class ActionScheduler_Abstract_Schedule extends ActionScheduler_Schedul
 	 *
 	 * @var DateTime
 	 */
-	private $scheduled_date = NULL;
+	private $scheduled_date = null;
 
 	/**
 	 * Timestamp equivalent of @see $this->scheduled_date
 	 *
 	 * @var int
 	 */
-	protected $scheduled_timestamp = NULL;
+	protected $scheduled_timestamp = null;
 
 	/**
 	 * @param DateTime $date The date & time to run the action.

--- a/classes/abstracts/ActionScheduler_Abstract_Schedule.php
+++ b/classes/abstracts/ActionScheduler_Abstract_Schedule.php
@@ -20,6 +20,8 @@ abstract class ActionScheduler_Abstract_Schedule extends ActionScheduler_Schedul
 	protected $scheduled_timestamp = null;
 
 	/**
+	 * Construct.
+	 *
 	 * @param DateTime $date The date & time to run the action.
 	 */
 	public function __construct( DateTime $date ) {
@@ -67,6 +69,7 @@ abstract class ActionScheduler_Abstract_Schedule extends ActionScheduler_Schedul
 
 	/**
 	 * For PHP 5.2 compat, since DateTime objects can't be serialized
+	 *
 	 * @return array
 	 */
 	public function __sleep() {

--- a/classes/abstracts/ActionScheduler_Abstract_Schema.php
+++ b/classes/abstracts/ActionScheduler_Abstract_Schema.php
@@ -13,17 +13,23 @@
 abstract class ActionScheduler_Abstract_Schema {
 
 	/**
-	 * @var int Increment this value in derived class to trigger a schema update.
+	 * Increment this value in derived class to trigger a schema update.
+	 *
+	 * @var int
 	 */
 	protected $schema_version = 1;
 
 	/**
-	 * @var string Schema version stored in database.
+	 * Schema version stored in database.
+	 *
+	 * @var string
 	 */
 	protected $db_version;
 
 	/**
-	 * @var array Names of tables that will be registered by this class.
+	 * Names of tables that will be registered by this class.
+	 *
+	 * @var array
 	 */
 	protected $tables = array();
 

--- a/classes/abstracts/ActionScheduler_Lock.php
+++ b/classes/abstracts/ActionScheduler_Lock.php
@@ -56,7 +56,7 @@ abstract class ActionScheduler_Lock {
 	 */
 	public static function instance() {
 		if ( empty( self::$locker ) ) {
-			$class = apply_filters( 'action_scheduler_lock_class', 'ActionScheduler_OptionLock' );
+			$class        = apply_filters( 'action_scheduler_lock_class', 'ActionScheduler_OptionLock' );
 			self::$locker = new $class();
 		}
 		return self::$locker;

--- a/classes/abstracts/ActionScheduler_Lock.php
+++ b/classes/abstracts/ActionScheduler_Lock.php
@@ -8,7 +8,7 @@
 abstract class ActionScheduler_Lock {
 
 	/** @var ActionScheduler_Lock */
-	private static $locker = NULL;
+	private static $locker = null;
 
 	/** @var int */
 	protected static $lock_duration = MINUTE_IN_SECONDS;

--- a/classes/abstracts/ActionScheduler_Lock.php
+++ b/classes/abstracts/ActionScheduler_Lock.php
@@ -7,10 +7,18 @@
  */
 abstract class ActionScheduler_Lock {
 
-	/** @var ActionScheduler_Lock */
+	/**
+	 * Instance.
+	 *
+	 * @var ActionScheduler_Lock
+	 */
 	private static $locker = null;
 
-	/** @var int */
+	/**
+	 * Duration of a lock.
+	 *
+	 * @var int
+	 */
 	protected static $lock_duration = MINUTE_IN_SECONDS;
 
 	/**
@@ -52,6 +60,8 @@ abstract class ActionScheduler_Lock {
 	}
 
 	/**
+	 * Instance.
+	 *
 	 * @return ActionScheduler_Lock
 	 */
 	public static function instance() {

--- a/classes/abstracts/ActionScheduler_Logger.php
+++ b/classes/abstracts/ActionScheduler_Logger.php
@@ -16,7 +16,7 @@ abstract class ActionScheduler_Logger {
 	 */
 	public static function instance() {
 		if ( empty(self::$logger) ) {
-			$class = apply_filters('action_scheduler_logger_class', 'ActionScheduler_wpCommentLogger');
+			$class        = apply_filters('action_scheduler_logger_class', 'ActionScheduler_wpCommentLogger');
 			self::$logger = new $class();
 		}
 		return self::$logger;

--- a/classes/abstracts/ActionScheduler_Logger.php
+++ b/classes/abstracts/ActionScheduler_Logger.php
@@ -7,7 +7,7 @@
 abstract class ActionScheduler_Logger {
 
 	/** @var null|self */
-	private static $logger = NULL;
+	private static $logger = null;
 
 	/**
 	 * Get instance.
@@ -31,7 +31,7 @@ abstract class ActionScheduler_Logger {
 	 *
 	 * @return string The log entry ID
 	 */
-	abstract public function log( $action_id, $message, DateTime $date = NULL );
+	abstract public function log( $action_id, $message, DateTime $date = null );
 
 	/**
 	 * Get action's log entry.
@@ -127,7 +127,7 @@ abstract class ActionScheduler_Logger {
 	 * @param null|ActionScheduler_Action $action Action.
 	 * @param string                      $context Action exeuction context.
 	 */
-	public function log_completed_action( $action_id, $action = NULL, $context = '' ) {
+	public function log_completed_action( $action_id, $action = null, $context = '' ) {
 		if ( ! empty( $context ) ) {
 			/* translators: %s: context */
 			$message = sprintf( __( 'action complete via %s', 'action-scheduler' ), $context );
@@ -210,7 +210,7 @@ abstract class ActionScheduler_Logger {
 	 * @param string         $action_id Action ID.
 	 * @param null|Exception $exception The exception which occurred when fetching the action. NULL by default for backward compatibility.
 	 */
-	public function log_failed_fetch_action( $action_id, Exception $exception = NULL ) {
+	public function log_failed_fetch_action( $action_id, Exception $exception = null ) {
 
 		if ( ! is_null( $exception ) ) {
 			/* translators: %s: exception message */

--- a/classes/abstracts/ActionScheduler_Logger.php
+++ b/classes/abstracts/ActionScheduler_Logger.php
@@ -2,11 +2,16 @@
 
 /**
  * Class ActionScheduler_Logger
+ *
  * @codeCoverageIgnore
  */
 abstract class ActionScheduler_Logger {
 
-	/** @var null|self */
+	/**
+	 * Instance.
+	 *
+	 * @var null|self
+	 */
 	private static $logger = null;
 
 	/**

--- a/classes/abstracts/ActionScheduler_Store.php
+++ b/classes/abstracts/ActionScheduler_Store.php
@@ -2,6 +2,7 @@
 
 /**
  * Class ActionScheduler_Store
+ *
  * @codeCoverageIgnore
  */
 abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
@@ -12,13 +13,23 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 	const STATUS_CANCELED = 'canceled';
 	const DEFAULT_CLASS   = 'ActionScheduler_wpPostStore';
 
-	/** @var ActionScheduler_Store */
+	/**
+	 * Store instance.
+	 *
+	 * @var ActionScheduler_Store
+	 */
 	private static $store = null;
 
-	/** @var int */
+	/**
+	 * Maximum length of arguments.
+	 *
+	 * @var int
+	 */
 	protected static $max_args_length = 191;
 
 	/**
+	 * Save action.
+	 *
 	 * @param ActionScheduler_Action $action Action to save.
 	 * @param null|DateTime          $scheduled_date Optional Date of the first instance
 	 *                                               to store. Otherwise uses the first date of the action's
@@ -470,6 +481,8 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 	public function mark_migrated( $action_id ) {}
 
 	/**
+	 * Instance.
+	 *
 	 * @return ActionScheduler_Store
 	 */
 	public static function instance() {

--- a/classes/abstracts/ActionScheduler_Store.php
+++ b/classes/abstracts/ActionScheduler_Store.php
@@ -474,7 +474,7 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 	 */
 	public static function instance() {
 		if ( empty( self::$store ) ) {
-			$class = apply_filters( 'action_scheduler_store_class', self::DEFAULT_CLASS );
+			$class       = apply_filters( 'action_scheduler_store_class', self::DEFAULT_CLASS );
 			self::$store = new $class();
 		}
 		return self::$store;

--- a/classes/abstracts/ActionScheduler_Store.php
+++ b/classes/abstracts/ActionScheduler_Store.php
@@ -13,7 +13,7 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 	const DEFAULT_CLASS   = 'ActionScheduler_wpPostStore';
 
 	/** @var ActionScheduler_Store */
-	private static $store = NULL;
+	private static $store = null;
 
 	/** @var int */
 	protected static $max_args_length = 191;
@@ -26,7 +26,7 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 	 *
 	 * @return int The action ID
 	 */
-	abstract public function save_action( ActionScheduler_Action $action, DateTime $scheduled_date = NULL );
+	abstract public function save_action( ActionScheduler_Action $action, DateTime $scheduled_date = null );
 
 	/**
 	 * Get action.
@@ -283,7 +283,7 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 	 * @param null|DateTime          $scheduled_date Action's schedule date (optional).
 	 * @return string
 	 */
-	protected function get_scheduled_date_string( ActionScheduler_Action $action, DateTime $scheduled_date = NULL ) {
+	protected function get_scheduled_date_string( ActionScheduler_Action $action, DateTime $scheduled_date = null ) {
 		$next = null === $scheduled_date ? $action->get_schedule()->get_date() : $scheduled_date;
 		if ( ! $next ) {
 			$next = date_create();
@@ -300,7 +300,7 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 	 * @param null|DateTime          $scheduled_date Action's scheduled date (optional).
 	 * @return string
 	 */
-	protected function get_scheduled_date_string_local( ActionScheduler_Action $action, DateTime $scheduled_date = NULL ) {
+	protected function get_scheduled_date_string_local( ActionScheduler_Action $action, DateTime $scheduled_date = null ) {
 		$next = null === $scheduled_date ? $action->get_schedule()->get_date() : $scheduled_date;
 		if ( ! $next ) {
 			$next = date_create();

--- a/classes/abstracts/ActionScheduler_TimezoneHelper.php
+++ b/classes/abstracts/ActionScheduler_TimezoneHelper.php
@@ -6,7 +6,7 @@
 abstract class ActionScheduler_TimezoneHelper {
 
 	/** @var null|DateTimeZone */
-	private static $local_timezone = NULL;
+	private static $local_timezone = null;
 
 	/**
 	 * Set a DateTime's timezone to the WordPress site's timezone, or a UTC offset
@@ -105,10 +105,10 @@ abstract class ActionScheduler_TimezoneHelper {
 	 * @param bool $reset Toggle to discard stored value.
 	 * @deprecated 2.1.0
 	 */
-	public static function get_local_timezone( $reset = FALSE ) {
+	public static function get_local_timezone( $reset = false ) {
 		_deprecated_function( __FUNCTION__, '2.1.0', 'ActionScheduler_TimezoneHelper::set_local_timezone()' );
 		if ( $reset ) {
-			self::$local_timezone = NULL;
+			self::$local_timezone = null;
 		}
 		if ( !isset(self::$local_timezone) ) {
 			$tzstring = get_option('timezone_string');

--- a/classes/abstracts/ActionScheduler_TimezoneHelper.php
+++ b/classes/abstracts/ActionScheduler_TimezoneHelper.php
@@ -119,7 +119,7 @@ abstract class ActionScheduler_TimezoneHelper {
 					$tzstring = 'UTC';
 				} else {
 					$gmt_offset *= HOUR_IN_SECONDS;
-					$tzstring   = timezone_name_from_abbr( '', $gmt_offset, 1 );
+					$tzstring    = timezone_name_from_abbr( '', $gmt_offset, 1 );
 
 					// If there's no timezone string, try again with no DST.
 					if ( false === $tzstring ) {

--- a/classes/abstracts/ActionScheduler_TimezoneHelper.php
+++ b/classes/abstracts/ActionScheduler_TimezoneHelper.php
@@ -5,7 +5,11 @@
  */
 abstract class ActionScheduler_TimezoneHelper {
 
-	/** @var null|DateTimeZone */
+	/**
+	 * Local timezone object.
+	 *
+	 * @var null|DateTimeZone
+	 */
 	private static $local_timezone = null;
 
 	/**

--- a/classes/actions/ActionScheduler_Action.php
+++ b/classes/actions/ActionScheduler_Action.php
@@ -9,7 +9,7 @@ class ActionScheduler_Action {
 	/** @var array<string, mixed> */
 	protected $args = array();
 	/** @var ActionScheduler_Schedule */
-	protected $schedule = NULL;
+	protected $schedule = null;
 	/** @var string */
 	protected $group = '';
 
@@ -34,7 +34,7 @@ class ActionScheduler_Action {
 	 * @param null|ActionScheduler_Schedule $schedule Action's schedule.
 	 * @param string                        $group Action's group.
 	 */
-	public function __construct( $hook, array $args = array(), ActionScheduler_Schedule $schedule = NULL, $group = '' ) {
+	public function __construct( $hook, array $args = array(), ActionScheduler_Schedule $schedule = null, $group = '' ) {
 		$schedule = empty( $schedule ) ? new ActionScheduler_NullSchedule() : $schedule;
 		$this->set_hook($hook);
 		$this->set_schedule($schedule);
@@ -135,7 +135,7 @@ class ActionScheduler_Action {
 	 * @return bool If the action has been finished
 	 */
 	public function is_finished() {
-		return FALSE;
+		return false;
 	}
 
 	/**

--- a/classes/actions/ActionScheduler_Action.php
+++ b/classes/actions/ActionScheduler_Action.php
@@ -4,13 +4,33 @@
  * Class ActionScheduler_Action
  */
 class ActionScheduler_Action {
-	/** @var string */
+
+	/**
+	 * Action's hook.
+	 *
+	 * @var string
+	 */
 	protected $hook = '';
-	/** @var array<string, mixed> */
+
+	/**
+	 * Action's arguments.
+	 *
+	 * @var array<string, mixed>
+	 */
 	protected $args = array();
-	/** @var ActionScheduler_Schedule */
+
+	/**
+	 * Action's schedule.
+	 *
+	 * @var ActionScheduler_Schedule
+	 */
 	protected $schedule = null;
-	/** @var string */
+
+	/**
+	 * Action's group.
+	 *
+	 * @var string
+	 */
 	protected $group = '';
 
 	/**
@@ -93,6 +113,8 @@ class ActionScheduler_Action {
 	}
 
 	/**
+	 * Get action's schedule.
+	 *
 	 * @return ActionScheduler_Schedule
 	 */
 	public function get_schedule() {
@@ -125,6 +147,8 @@ class ActionScheduler_Action {
 	}
 
 	/**
+	 * Get action's group.
+	 *
 	 * @return string
 	 */
 	public function get_group() {
@@ -132,6 +156,8 @@ class ActionScheduler_Action {
 	}
 
 	/**
+	 * Action is finished.
+	 *
 	 * @return bool If the action has been finished
 	 */
 	public function is_finished() {

--- a/classes/actions/ActionScheduler_FinishedAction.php
+++ b/classes/actions/ActionScheduler_FinishedAction.php
@@ -16,6 +16,6 @@ class ActionScheduler_FinishedAction extends ActionScheduler_Action {
 	 * Get finished state.
 	 */
 	public function is_finished() {
-		return TRUE;
+		return true;
 	}
 }

--- a/classes/actions/ActionScheduler_NullAction.php
+++ b/classes/actions/ActionScheduler_NullAction.php
@@ -12,7 +12,7 @@ class ActionScheduler_NullAction extends ActionScheduler_Action {
 	 * @param mixed[]                       $args Action arguments.
 	 * @param null|ActionScheduler_Schedule $schedule Action schedule.
 	 */
-	public function __construct( $hook = '', array $args = array(), ActionScheduler_Schedule $schedule = NULL ) {
+	public function __construct( $hook = '', array $args = array(), ActionScheduler_Schedule $schedule = null ) {
 		$this->set_schedule( new ActionScheduler_NullSchedule() );
 	}
 

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -38,11 +38,11 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 	 *
 	 * @var array
 	 */
-	protected $claim_filters = [
+	protected $claim_filters = array(
 		'group'          => '',
 		'hooks'          => '',
 		'exclude-groups' => '',
-	];
+	);
 
 	/**
 	 * Initialize the data store

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -19,13 +19,25 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 	 */
 	private $claim_before_date = null;
 
-	/** @var int */
+	/**
+	 * Max length of arguments.
+	 *
+	 * @var int
+	 */
 	protected static $max_args_length = 8000;
 
-	/** @var int */
+	/**
+	 * Maximum index length.
+	 *
+	 * @var int
+	 */
 	protected static $max_index_length = 191;
 
-	/** @var array List of claim filters. */
+	/**
+	 * List of claim filters.
+	 *
+	 * @var array
+	 */
 	protected $claim_filters = [
 		'group'          => '',
 		'hooks'          => '',
@@ -264,7 +276,11 @@ AND `group_id` = %d
 			return array();
 		}
 
-		/** @var \wpdb $wpdb */
+		/**
+		 * Global wpdb instance.
+		 *
+		 * @var \wpdb $wpdb
+		 */
 		global $wpdb;
 
 		foreach ( $slugs as $slug ) {
@@ -290,7 +306,11 @@ AND `group_id` = %d
 	 * @return int Group ID.
 	 */
 	protected function create_group( $slug ) {
-		/** @var \wpdb $wpdb */
+		/**
+		 * Global wpdb instance.
+		 *
+		 * @var \wpdb $wpdb
+		 */
 		global $wpdb;
 		$wpdb->insert( $wpdb->actionscheduler_groups, array( 'slug' => $slug ) );
 
@@ -305,7 +325,11 @@ AND `group_id` = %d
 	 * @return ActionScheduler_Action
 	 */
 	public function fetch_action( $action_id ) {
-		/** @var \wpdb $wpdb */
+		/**
+		 * Global wpdb instance.
+		 *
+		 * @var \wpdb $wpdb
+		 */
 		global $wpdb;
 		$data = $wpdb->get_row(
 			$wpdb->prepare(
@@ -414,7 +438,11 @@ AND `group_id` = %d
 			'order'                 => 'ASC',
 		 ) );
 
-		/** @var \wpdb $wpdb */
+		/**
+		 * Global wpdb instance.
+		 *
+		 * @var \wpdb $wpdb
+		 */
 		global $wpdb;
 
 		$db_server_info = is_callable( array( $wpdb, 'db_server_info' ) ) ? $wpdb->db_server_info() : $wpdb->db_version();
@@ -597,7 +625,11 @@ AND `group_id` = %d
 	 * @return string|array|null The IDs of actions matching the query. Null on failure.
 	 */
 	public function query_actions( $query = array(), $query_type = 'select' ) {
-		/** @var wpdb $wpdb */
+		/**
+		 * Global wpdb instance.
+		 *
+		 * @var \wpdb $wpdb
+		 */
 		global $wpdb;
 
 		$sql = $this->get_query_actions_sql( $query, $query_type );
@@ -639,7 +671,11 @@ AND `group_id` = %d
 	 * @throws \InvalidArgumentException If the action update failed.
 	 */
 	public function cancel_action( $action_id ) {
-		/** @var \wpdb $wpdb */
+		/**
+		 * Global wpdb instance.
+		 *
+		 * @var \wpdb $wpdb
+		 */
 		global $wpdb;
 
 		$updated = $wpdb->update(
@@ -688,7 +724,11 @@ AND `group_id` = %d
 	 * @param array $query_args Query parameters.
 	 */
 	protected function bulk_cancel_actions( $query_args ) {
-		/** @var \wpdb $wpdb */
+		/**
+		 * Global wpdb instance.
+		 *
+		 * @var \wpdb $wpdb
+		 */
 		global $wpdb;
 
 		if ( ! is_array( $query_args ) ) {
@@ -739,7 +779,11 @@ AND `group_id` = %d
 	 * @throws \InvalidArgumentException If the action deletion failed.
 	 */
 	public function delete_action( $action_id ) {
-		/** @var \wpdb $wpdb */
+		/**
+		 * Global wpdb instance.
+		 *
+		 * @var \wpdb $wpdb
+		 */
 		global $wpdb;
 		$deleted = $wpdb->delete( $wpdb->actionscheduler_actions, array( 'action_id' => $action_id ), array( '%d' ) );
 		if ( empty( $deleted ) ) {
@@ -771,7 +815,11 @@ AND `group_id` = %d
 	 * @return \DateTime The GMT date the action is scheduled to run, or the date that it ran.
 	 */
 	protected function get_date_gmt( $action_id ) {
-		/** @var \wpdb $wpdb */
+		/**
+		 * Global wpdb instance.
+		 *
+		 * @var \wpdb $wpdb
+		 */
 		global $wpdb;
 		$record = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$wpdb->actionscheduler_actions} WHERE action_id=%d", $action_id ) );
 		if ( empty( $record ) ) {
@@ -812,7 +860,11 @@ AND `group_id` = %d
 	 * @return int Claim ID.
 	 */
 	protected function generate_claim_id() {
-		/** @var \wpdb $wpdb */
+		/**
+		 * Global wpdb instance.
+		 *
+		 * @var \wpdb $wpdb
+		 */
 		global $wpdb;
 		$now = as_get_datetime_object();
 		$wpdb->insert( $wpdb->actionscheduler_claims, array( 'date_created_gmt' => $now->format( 'Y-m-d H:i:s' ) ) );
@@ -861,7 +913,11 @@ AND `group_id` = %d
 	 * @throws \RuntimeException Throws RuntimeException if unable to claim action.
 	 */
 	protected function claim_actions( $claim_id, $limit, \DateTime $before_date = null, $hooks = array(), $group = '' ) {
-		/** @var \wpdb $wpdb */
+		/**
+		 * Global wpdb instance.
+		 *
+		 * @var \wpdb $wpdb
+		 */
 		global $wpdb;
 
 		$now  = as_get_datetime_object();
@@ -975,7 +1031,11 @@ AND `group_id` = %d
 	 * @return mixed
 	 */
 	public function get_claim_id( $action_id ) {
-		/** @var \wpdb $wpdb */
+		/**
+		 * Global wpdb instance.
+		 *
+		 * @var \wpdb $wpdb
+		 */
 		global $wpdb;
 
 		$sql = "SELECT claim_id FROM {$wpdb->actionscheduler_actions} WHERE action_id=%d";
@@ -991,7 +1051,11 @@ AND `group_id` = %d
 	 * @return int[]
 	 */
 	public function find_actions_by_claim_id( $claim_id ) {
-		/** @var \wpdb $wpdb */
+		/**
+		 * Global wpdb instance.
+		 *
+		 * @var \wpdb $wpdb
+		 */
 		global $wpdb;
 
 		$action_ids  = array();
@@ -1021,7 +1085,11 @@ AND `group_id` = %d
 	 * @throws \RuntimeException When unable to release actions from claim.
 	 */
 	public function release_claim( ActionScheduler_ActionClaim $claim ) {
-		/** @var \wpdb $wpdb */
+		/**
+		 * Global wpdb instance.
+		 *
+		 * @var \wpdb $wpdb
+		 */
 		global $wpdb;
 		/**
 		 * Deadlock warning: This function modifies actions to release them from claims that have been processed. Earlier, we used to it in a atomic query, i.e. we would update all actions belonging to a particular claim_id with claim_id = 0.
@@ -1059,7 +1127,11 @@ AND `group_id` = %d
 	 * @return void
 	 */
 	public function unclaim_action( $action_id ) {
-		/** @var \wpdb $wpdb */
+		/**
+		 * Global wpdb instance.
+		 *
+		 * @var \wpdb $wpdb
+		 */
 		global $wpdb;
 		$wpdb->update(
 			$wpdb->actionscheduler_actions,
@@ -1077,7 +1149,11 @@ AND `group_id` = %d
 	 * @throws \InvalidArgumentException Throw an exception if action was not updated.
 	 */
 	public function mark_failure( $action_id ) {
-		/** @var \wpdb $wpdb */
+		/**
+		 * Global wpdb instance.
+		 *
+		 * @var \wpdb $wpdb
+		 */
 		global $wpdb;
 		$updated = $wpdb->update(
 			$wpdb->actionscheduler_actions,
@@ -1102,7 +1178,11 @@ AND `group_id` = %d
 	 * @return void
 	 */
 	public function log_execution( $action_id ) {
-		/** @var \wpdb $wpdb */
+		/**
+		 * Global wpdb instance.
+		 *
+		 * @var \wpdb $wpdb
+		 */
 		global $wpdb;
 
 		$sql = "UPDATE {$wpdb->actionscheduler_actions} SET attempts = attempts+1, status=%s, last_attempt_gmt = %s, last_attempt_local = %s WHERE action_id = %d";
@@ -1132,7 +1212,11 @@ AND `group_id` = %d
 	 * @throws \InvalidArgumentException Throw an exception if action was not updated.
 	 */
 	public function mark_complete( $action_id ) {
-		/** @var \wpdb $wpdb */
+		/**
+		 * Global wpdb instance.
+		 *
+		 * @var \wpdb $wpdb
+		 */
 		global $wpdb;
 		$updated = $wpdb->update(
 			$wpdb->actionscheduler_actions,
@@ -1170,7 +1254,11 @@ AND `group_id` = %d
 	 * @throws \RuntimeException Throw an exception if action status could not be retrieved.
 	 */
 	public function get_status( $action_id ) {
-		/** @var \wpdb $wpdb */
+		/**
+		 * Global wpdb instance.
+		 *
+		 * @var \wpdb $wpdb
+		 */
 		global $wpdb;
 		$sql    = "SELECT status FROM {$wpdb->actionscheduler_actions} WHERE action_id=%d";
 		$sql    = $wpdb->prepare( $sql, $action_id ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -147,7 +147,7 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 		$placeholder_sql = implode( ', ', $placeholders );
 		$where_clause    = $this->build_where_clause_for_insert( $data, $table_name, $unique );
 		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare	 -- $column_sql and $where_clause are already prepared. $placeholder_sql is hardcoded.
-		$insert_query    = $wpdb->prepare(
+		$insert_query = $wpdb->prepare(
 			"
 INSERT INTO $table_name ( $column_sql )
 SELECT $placeholder_sql FROM DUAL
@@ -429,7 +429,7 @@ AND `group_id` = %d
 		}
 
 		$sql        = ( 'count' === $select_or_count ) ? 'SELECT count(a.action_id)' : 'SELECT a.action_id';
-		$sql        .= " FROM {$wpdb->actionscheduler_actions} a";
+		$sql       .= " FROM {$wpdb->actionscheduler_actions} a";
 		$sql_params = array();
 
 		if ( ! empty( $query['group'] ) || 'group' === $query['orderby'] ) {
@@ -439,12 +439,12 @@ AND `group_id` = %d
 		$sql .= ' WHERE 1=1';
 
 		if ( ! empty( $query['group'] ) ) {
-			$sql          .= ' AND g.slug=%s';
+			$sql         .= ' AND g.slug=%s';
 			$sql_params[] = $query['group'];
 		}
 
 		if ( ! empty( $query['hook'] ) ) {
-			$sql          .= ' AND a.hook=%s';
+			$sql         .= ' AND a.hook=%s';
 			$sql_params[] = $query['hook'];
 		}
 
@@ -473,20 +473,20 @@ AND `group_id` = %d
 								$value_type
 							) );
 						}
-						$sql          .= ' AND JSON_EXTRACT(a.args, %s)=' . $placeholder;
+						$sql         .= ' AND JSON_EXTRACT(a.args, %s)=' . $placeholder;
 						$sql_params[] = '$.' . $key;
 						$sql_params[] = $value;
 					}
 					break;
 				case 'like':
 					foreach ( $query['args'] as $key => $value ) {
-						$sql          .= ' AND a.args LIKE %s';
+						$sql         .= ' AND a.args LIKE %s';
 						$json_partial = $wpdb->esc_like( trim( wp_json_encode( array( $key => $value ) ), '{}' ) );
 						$sql_params[] = "%{$json_partial}%";
 					}
 					break;
 				case 'off':
-					$sql          .= ' AND a.args=%s';
+					$sql         .= ' AND a.args=%s';
 					$sql_params[] = $this->get_args_for_query( $query['args'] );
 					break;
 				default:
@@ -864,8 +864,8 @@ AND `group_id` = %d
 		/** @var \wpdb $wpdb */
 		global $wpdb;
 
-		$now    = as_get_datetime_object();
-		$date   = is_null( $before_date ) ? $now : clone $before_date;
+		$now  = as_get_datetime_object();
+		$date = is_null( $before_date ) ? $now : clone $before_date;
 		// can't use $wpdb->update() because of the <= condition.
 		$update = "UPDATE {$wpdb->actionscheduler_actions} SET claim_id=%d, last_attempt_gmt=%s, last_attempt_local=%s";
 		$params = array(
@@ -892,13 +892,13 @@ AND `group_id` = %d
 
 		if ( ! empty( $hooks ) ) {
 			$placeholders = array_fill( 0, count( $hooks ), '%s' );
-			$where        .= ' AND hook IN (' . join( ', ', $placeholders ) . ')';
+			$where       .= ' AND hook IN (' . join( ', ', $placeholders ) . ')';
 			$params       = array_merge( $params, array_values( $hooks ) );
 		}
 
 		$group_operator = 'IN';
 		if ( empty( $group ) ) {
-			$group = $this->get_claim_filter( 'exclude-groups' );
+			$group          = $this->get_claim_filter( 'exclude-groups' );
 			$group_operator = 'NOT IN';
 		}
 
@@ -922,7 +922,7 @@ AND `group_id` = %d
 			}
 
 			$id_list = implode( ',', array_map( 'intval', $group_ids ) );
-			$where   .= " AND group_id {$group_operator} ( $id_list )";
+			$where  .= " AND group_id {$group_operator} ( $id_list )";
 		}
 
 		/**

--- a/classes/data-stores/ActionScheduler_HybridStore.php
+++ b/classes/data-stores/ActionScheduler_HybridStore.php
@@ -70,10 +70,10 @@ class ActionScheduler_HybridStore extends Store {
 	 * @codeCoverageIgnore
 	 */
 	public function init() {
-		add_action( 'action_scheduler/created_table', [ $this, 'set_autoincrement' ], 10, 2 );
+		add_action( 'action_scheduler/created_table', array( $this, 'set_autoincrement' ), 10, 2 );
 		$this->primary_store->init();
 		$this->secondary_store->init();
-		remove_action( 'action_scheduler/created_table', [ $this, 'set_autoincrement' ], 10 );
+		remove_action( 'action_scheduler/created_table', array( $this, 'set_autoincrement' ), 10 );
 	}
 
 	/**
@@ -109,7 +109,7 @@ class ActionScheduler_HybridStore extends Store {
 
 			$row_count = $wpdb->insert(
 				$wpdb->{ActionScheduler_StoreSchema::ACTIONS_TABLE},
-				[
+				array(
 					'action_id'            => $this->demarkation_id,
 					'hook'                 => '',
 					'status'               => '',
@@ -117,12 +117,12 @@ class ActionScheduler_HybridStore extends Store {
 					'scheduled_date_local' => $date_local,
 					'last_attempt_gmt'     => $date_gmt,
 					'last_attempt_local'   => $date_local,
-				]
+				)
 			);
 			if ( $row_count > 0 ) {
 				$wpdb->delete(
 					$wpdb->{ActionScheduler_StoreSchema::ACTIONS_TABLE},
-					[ 'action_id' => $this->demarkation_id ]
+					array( 'action_id' => $this->demarkation_id )
 				);
 			}
 		}
@@ -165,10 +165,10 @@ class ActionScheduler_HybridStore extends Store {
 	 *
 	 * @return string
 	 */
-	public function find_action( $hook, $params = [] ) {
+	public function find_action( $hook, $params = array() ) {
 		$found_unmigrated_action = $this->secondary_store->find_action( $hook, $params );
 		if ( ! empty( $found_unmigrated_action ) ) {
-			$this->migrate( [ $found_unmigrated_action ] );
+			$this->migrate( array( $found_unmigrated_action ) );
 		}
 
 		return $this->primary_store->find_action( $hook, $params );
@@ -184,7 +184,7 @@ class ActionScheduler_HybridStore extends Store {
 	 *
 	 * @return int[]
 	 */
-	public function query_actions( $query = [], $query_type = 'select' ) {
+	public function query_actions( $query = array(), $query_type = 'select' ) {
 		$found_unmigrated_actions = $this->secondary_store->query_actions( $query, 'select' );
 		if ( ! empty( $found_unmigrated_actions ) ) {
 			$this->migrate( $found_unmigrated_actions );
@@ -379,19 +379,19 @@ class ActionScheduler_HybridStore extends Store {
 	 */
 	protected function get_store_from_action_id( $action_id, $primary_first = false ) {
 		if ( $primary_first ) {
-			$stores = [
+			$stores = array(
 				$this->primary_store,
 				$this->secondary_store,
-			];
+			);
 		} elseif ( $action_id < $this->demarkation_id ) {
-			$stores = [
+			$stores = array(
 				$this->secondary_store,
 				$this->primary_store,
-			];
+			);
 		} else {
-			$stores = [
+			$stores = array(
 				$this->primary_store,
-			];
+			);
 		}
 
 		foreach ( $stores as $store ) {

--- a/classes/data-stores/ActionScheduler_HybridStore.php
+++ b/classes/data-stores/ActionScheduler_HybridStore.php
@@ -15,23 +15,37 @@ use Action_Scheduler\Migration\Controller;
 class ActionScheduler_HybridStore extends Store {
 	const DEMARKATION_OPTION = 'action_scheduler_hybrid_store_demarkation';
 
-	/** @var ActionScheduler_Store */
+	/**
+	 * Primary store instance.
+	 *
+	 * @var ActionScheduler_Store
+	 */
 	private $primary_store;
-	/** @var ActionScheduler_Store */
+
+	/**
+	 * Secondary store instance.
+	 *
+	 * @var ActionScheduler_Store
+	 */
 	private $secondary_store;
-	/** @var Action_Scheduler\Migration\Runner */
+
+	/**
+	 * Migration runner instance.
+	 *
+	 * @var Action_Scheduler\Migration\Runner
+	 */
 	private $migration_runner;
 
 	/**
-	 * @var int The dividing line between IDs of actions created
-	 *          by the primary and secondary stores.
-	 *
 	 * Methods that accept an action ID will compare the ID against
 	 * this to determine which store will contain that ID. In almost
 	 * all cases, the ID should come from the primary store, but if
 	 * client code is bypassing the API functions and fetching IDs
 	 * from elsewhere, then there is a chance that an unmigrated ID
 	 * might be requested.
+	 *
+	 * @var int The dividing line between IDs of actions created
+	 *          by the primary and secondary stores.
 	 */
 	private $demarkation_id = 0;
 
@@ -78,7 +92,11 @@ class ActionScheduler_HybridStore extends Store {
 			if ( empty( $this->demarkation_id ) ) {
 				$this->demarkation_id = $this->set_demarkation_id();
 			}
-			/** @var \wpdb $wpdb */
+			/**
+			 * Global wpdb instance.
+			 *
+			 * @var \wpdb $wpdb
+			 */
 			global $wpdb;
 			/**
 			 * A default date of '0000-00-00 00:00:00' is invalid in MySQL 5.7 when configured with
@@ -122,7 +140,11 @@ class ActionScheduler_HybridStore extends Store {
 	 */
 	private function set_demarkation_id( $id = null ) {
 		if ( empty( $id ) ) {
-			/** @var \wpdb $wpdb */
+			/**
+			 * Global wpdb instance.
+			 *
+			 * @var \wpdb $wpdb
+			 */
 			global $wpdb;
 			$id = (int) $wpdb->get_var( "SELECT MAX(ID) FROM $wpdb->posts" );
 			$id ++;

--- a/classes/data-stores/ActionScheduler_wpCommentLogger.php
+++ b/classes/data-stores/ActionScheduler_wpCommentLogger.php
@@ -16,7 +16,7 @@ class ActionScheduler_wpCommentLogger extends ActionScheduler_Logger {
 	 *
 	 * @return string The log entry ID
 	 */
-	public function log( $action_id, $message, DateTime $date = NULL ) {
+	public function log( $action_id, $message, DateTime $date = null ) {
 		if ( empty($date) ) {
 			$date = as_get_datetime_object();
 		} else {
@@ -118,7 +118,7 @@ class ActionScheduler_wpCommentLogger extends ActionScheduler_Logger {
 				return; // don't slow down queries that wouldn't include action_log comments anyway.
 			}
 		}
-		$query->query_vars['action_log_filter'] = TRUE;
+		$query->query_vars['action_log_filter'] = true;
 		add_filter( 'comments_clauses', array( $this, 'filter_comment_query_clauses' ), 10, 2 );
 	}
 

--- a/classes/data-stores/ActionScheduler_wpCommentLogger.php
+++ b/classes/data-stores/ActionScheduler_wpCommentLogger.php
@@ -5,7 +5,7 @@
  */
 class ActionScheduler_wpCommentLogger extends ActionScheduler_Logger {
 	const AGENT = 'ActionScheduler';
-	const TYPE = 'action_log';
+	const TYPE  = 'action_log';
 
 	/**
 	 * Create log entry.
@@ -86,7 +86,7 @@ class ActionScheduler_wpCommentLogger extends ActionScheduler_Logger {
 			'type' => self::TYPE,
 			'status' => $status,
 		));
-		$logs = array();
+		$logs     = array();
 		foreach ( $comments as $c ) {
 			$entry = $this->get_entry( $c );
 			if ( !empty($entry) ) {
@@ -196,8 +196,8 @@ class ActionScheduler_wpCommentLogger extends ActionScheduler_Logger {
 
 			$count = $wpdb->get_results( "SELECT comment_approved, COUNT( * ) AS num_comments FROM {$wpdb->comments} WHERE comment_type NOT IN('order_note','action_log') GROUP BY comment_approved", ARRAY_A );
 
-			$total = 0;
-			$stats = array();
+			$total    = 0;
+			$stats    = array();
 			$approved = array( '0' => 'moderated', '1' => 'approved', 'spam' => 'spam', 'trash' => 'trash', 'post-trashed' => 'post-trashed' );
 
 			foreach ( (array) $count as $row ) {

--- a/classes/data-stores/ActionScheduler_wpPostStore_PostStatusRegistrar.php
+++ b/classes/data-stores/ActionScheduler_wpPostStore_PostStatusRegistrar.php
@@ -2,6 +2,7 @@
 
 /**
  * Class ActionScheduler_wpPostStore_PostStatusRegistrar
+ *
  * @codeCoverageIgnore
  */
 class ActionScheduler_wpPostStore_PostStatusRegistrar {

--- a/classes/data-stores/ActionScheduler_wpPostStore_PostTypeRegistrar.php
+++ b/classes/data-stores/ActionScheduler_wpPostStore_PostTypeRegistrar.php
@@ -2,6 +2,7 @@
 
 /**
  * Class ActionScheduler_wpPostStore_PostTypeRegistrar
+ *
  * @codeCoverageIgnore
  */
 class ActionScheduler_wpPostStore_PostTypeRegistrar {

--- a/classes/data-stores/ActionScheduler_wpPostStore_TaxonomyRegistrar.php
+++ b/classes/data-stores/ActionScheduler_wpPostStore_TaxonomyRegistrar.php
@@ -2,6 +2,7 @@
 
 /**
  * Class ActionScheduler_wpPostStore_TaxonomyRegistrar
+ *
  * @codeCoverageIgnore
  */
 class ActionScheduler_wpPostStore_TaxonomyRegistrar {

--- a/classes/migration/ActionMigrator.php
+++ b/classes/migration/ActionMigrator.php
@@ -70,7 +70,7 @@ class ActionMigrator {
 			// delete it and move on.
 			try {
 				$this->source->delete_action( $source_action_id );
-			} catch ( \Exception $e ) {
+			} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
 				// nothing to do, it didn't exist in the first place.
 			}
 			do_action( 'action_scheduler/no_action_to_migrate', $source_action_id, $this->source, $this->destination );

--- a/classes/migration/ActionMigrator.php
+++ b/classes/migration/ActionMigrator.php
@@ -13,13 +13,25 @@ namespace Action_Scheduler\Migration;
  * @codeCoverageIgnore
  */
 class ActionMigrator {
-	/** @var ActionScheduler_Store */
+	/**
+	 * Source store instance.
+	 *
+	 * @var ActionScheduler_Store
+	 */
 	private $source;
 
-	/** @var ActionScheduler_Store */
+	/**
+	 * Destination store instance.
+	 *
+	 * @var ActionScheduler_Store
+	 */
 	private $destination;
 
-	/** @var LogMigrator */
+	/**
+	 * LogMigrator instance.
+	 *
+	 * @var LogMigrator
+	 */
 	private $log_migrator;
 
 	/**

--- a/classes/migration/ActionScheduler_DBStoreMigrator.php
+++ b/classes/migration/ActionScheduler_DBStoreMigrator.php
@@ -25,7 +25,11 @@ class ActionScheduler_DBStoreMigrator extends ActionScheduler_DBStore {
 	 */
 	public function save_action( ActionScheduler_Action $action, \DateTime $scheduled_date = null, \DateTime $last_attempt_date = null ) {
 		try {
-			/** @var \wpdb $wpdb */
+			/**
+			 * Global wpdb instance.
+			 *
+			 * @var \wpdb $wpdb
+			 */
 			global $wpdb;
 
 			$action_id = parent::save_action( $action, $scheduled_date );

--- a/classes/migration/ActionScheduler_DBStoreMigrator.php
+++ b/classes/migration/ActionScheduler_DBStoreMigrator.php
@@ -35,10 +35,10 @@ class ActionScheduler_DBStoreMigrator extends ActionScheduler_DBStore {
 			$action_id = parent::save_action( $action, $scheduled_date );
 
 			if ( null !== $last_attempt_date ) {
-				$data = [
+				$data = array(
 					'last_attempt_gmt'   => $this->get_scheduled_date_string( $action, $last_attempt_date ),
 					'last_attempt_local' => $this->get_scheduled_date_string_local( $action, $last_attempt_date ),
-				];
+				);
 
 				$wpdb->update( $wpdb->actionscheduler_actions, $data, array( 'action_id' => $action_id ), array( '%s', '%s' ), array( '%d' ) );
 			}

--- a/classes/migration/ActionScheduler_DBStoreMigrator.php
+++ b/classes/migration/ActionScheduler_DBStoreMigrator.php
@@ -23,7 +23,7 @@ class ActionScheduler_DBStoreMigrator extends ActionScheduler_DBStore {
 	 * @return string The action ID
 	 * @throws \RuntimeException When the action is not saved.
 	 */
-	public function save_action( ActionScheduler_Action $action, \DateTime $scheduled_date = null, \DateTime $last_attempt_date = null ){
+	public function save_action( ActionScheduler_Action $action, \DateTime $scheduled_date = null, \DateTime $last_attempt_date = null ) {
 		try {
 			/** @var \wpdb $wpdb */
 			global $wpdb;

--- a/classes/migration/BatchFetcher.php
+++ b/classes/migration/BatchFetcher.php
@@ -48,7 +48,7 @@ class BatchFetcher {
 			}
 		}
 
-		return [];
+		return array();
 	}
 
 	/**
@@ -60,32 +60,32 @@ class BatchFetcher {
 	 */
 	private function get_query_strategies( $count ) {
 		$now  = as_get_datetime_object();
-		$args = [
+		$args = array(
 			'date'     => $now,
 			'per_page' => $count,
 			'offset'   => 0,
 			'orderby'  => 'date',
 			'order'    => 'ASC',
-		];
+		);
 
-		$priorities = [
+		$priorities = array(
 			Store::STATUS_PENDING,
 			Store::STATUS_FAILED,
 			Store::STATUS_CANCELED,
 			Store::STATUS_COMPLETE,
 			Store::STATUS_RUNNING,
 			'', // any other unanticipated status.
-		];
+		);
 
 		foreach ( $priorities as $status ) {
-			yield wp_parse_args( [
+			yield wp_parse_args( array(
 				'status'       => $status,
 				'date_compare' => '<=',
-			], $args );
-			yield wp_parse_args( [
+			), $args );
+			yield wp_parse_args( array(
 				'status'       => $status,
 				'date_compare' => '>=',
-			], $args );
+			), $args );
 		}
 	}
 }

--- a/classes/migration/BatchFetcher.php
+++ b/classes/migration/BatchFetcher.php
@@ -16,7 +16,12 @@ use ActionScheduler_Store as Store;
  * @codeCoverageIgnore
  */
 class BatchFetcher {
-	/** @var ActionScheduler_Store */
+
+	/**
+	 * Store instance.
+	 *
+	 * @var ActionScheduler_Store
+	 */
 	private $store;
 
 	/**

--- a/classes/migration/Config.php
+++ b/classes/migration/Config.php
@@ -17,22 +17,47 @@ use ActionScheduler_Store as Store;
  * A config builder for the ActionScheduler\Migration\Runner class
  */
 class Config {
-	/** @var ActionScheduler_Store */
+
+	/**
+	 * Source store instance.
+	 *
+	 * @var ActionScheduler_Store
+	 */
 	private $source_store;
 
-	/** @var ActionScheduler_Logger */
+	/**
+	 * Source logger instance.
+	 *
+	 * @var ActionScheduler_Logger
+	 */
 	private $source_logger;
 
-	/** @var ActionScheduler_Store */
+	/**
+	 * Destination store instance.
+	 *
+	 * @var ActionScheduler_Store
+	 */
 	private $destination_store;
 
-	/** @var ActionScheduler_Logger */
+	/**
+	 * Destination logger instance.
+	 *
+	 * @var ActionScheduler_Logger
+	 */
 	private $destination_logger;
 
-	/** @var Progress bar */
+	/**
+	 * Progress bar instance.
+	 *
+	 * @var Progress bar
+	 */
 	private $progress_bar;
 
-	/** @var bool */
+	/**
+	 * Dry run flag.
+	 *
+	 * @var bool
+	 */
 	private $dry_run = false;
 
 	/**

--- a/classes/migration/Controller.php
+++ b/classes/migration/Controller.php
@@ -19,19 +19,40 @@ use Action_Scheduler\WP_CLI\ProgressBar;
  * @codeCoverageIgnore
  */
 class Controller {
-	/** @var self */
+
+	/**
+	 * Instance.
+	 *
+	 * @var self
+	 */
 	private static $instance;
 
-	/** @var Action_Scheduler\Migration\Scheduler */
+	/**
+	 * Migration scheduler instance.
+	 *
+	 * @var Action_Scheduler\Migration\Scheduler
+	 */
 	private $migration_scheduler;
 
-	/** @var string */
+	/**
+	 * Store class name.
+	 *
+	 * @var string
+	 */
 	private $store_classname;
 
-	/** @var string */
+	/**
+	 * Logger class name.
+	 *
+	 * @var string
+	 */
 	private $logger_classname;
 
-	/** @var bool */
+	/**
+	 * Switch to migrate custom store.
+	 *
+	 * @var bool
+	 */
 	private $migrate_custom_store;
 
 	/**

--- a/classes/migration/LogMigrator.php
+++ b/classes/migration/LogMigrator.php
@@ -15,10 +15,18 @@ use ActionScheduler_Logger;
  * @codeCoverageIgnore
  */
 class LogMigrator {
-	/** @var ActionScheduler_Logger */
+	/**
+	 * Source logger instance.
+	 *
+	 * @var ActionScheduler_Logger
+	 */
 	private $source;
 
-	/** @var ActionScheduler_Logger */
+	/**
+	 * Destination logger instance.
+	 *
+	 * @var ActionScheduler_Logger
+	 */
 	private $destination;
 
 	/**

--- a/classes/migration/Runner.php
+++ b/classes/migration/Runner.php
@@ -13,28 +13,61 @@ namespace Action_Scheduler\Migration;
  * @codeCoverageIgnore
  */
 class Runner {
-	/** @var ActionScheduler_Store */
+
+	/**
+	 * Source store instance.
+	 *
+	 * @var ActionScheduler_Store
+	 */
 	private $source_store;
 
-	/** @var ActionScheduler_Store */
+	/**
+	 * Destination store instance.
+	 *
+	 * @var ActionScheduler_Store
+	 */
 	private $destination_store;
 
-	/** @var ActionScheduler_Logger */
+	/**
+	 * Source logger instance.
+	 *
+	 * @var ActionScheduler_Logger
+	 */
 	private $source_logger;
 
-	/** @var ActionScheduler_Logger */
+	/**
+	 * Destination logger instance.
+	 *
+	 * @var ActionScheduler_Logger
+	 */
 	private $destination_logger;
 
-	/** @var BatchFetcher */
+	/**
+	 * BatchFetcher instance.
+	 *
+	 * @var BatchFetcher
+	 */
 	private $batch_fetcher;
 
-	/** @var ActionMigrator */
+	/**
+	 * ActionMigrator instance.
+	 *
+	 * @var ActionMigrator
+	 */
 	private $action_migrator;
 
-	/** @var LogMigrator */
+	/**
+	 * LogMigrator instance.
+	 *
+	 * @var LogMigrator
+	 */
 	private $log_migrator;
 
-	/** @var ProgressBar */
+	/**
+	 * ProgressBar instance.
+	 *
+	 * @var ProgressBar
+	 */
 	private $progress_bar;
 
 	/**

--- a/classes/migration/Runner.php
+++ b/classes/migration/Runner.php
@@ -70,7 +70,7 @@ class Runner {
 	 * @return int Size of batch processed.
 	 */
 	public function run( $batch_size = 10 ) {
-		$batch = $this->batch_fetcher->fetch( $batch_size );
+		$batch      = $this->batch_fetcher->fetch( $batch_size );
 		$batch_size = count( $batch );
 
 		if ( ! $batch_size ) {

--- a/classes/migration/Scheduler.php
+++ b/classes/migration/Scheduler.php
@@ -14,10 +14,10 @@ namespace Action_Scheduler\Migration;
  */
 class Scheduler {
 	/** Migration action hook. */
-	const HOOK            = 'action_scheduler/migration_hook';
+	const HOOK = 'action_scheduler/migration_hook';
 
 	/** Migration action group. */
-	const GROUP           = 'action-scheduler-migration';
+	const GROUP = 'action-scheduler-migration';
 
 	/**
 	 * Set up the callback for the scheduled job.

--- a/classes/schedules/ActionScheduler_CanceledSchedule.php
+++ b/classes/schedules/ActionScheduler_CanceledSchedule.php
@@ -10,7 +10,7 @@ class ActionScheduler_CanceledSchedule extends ActionScheduler_SimpleSchedule {
 	 *
 	 * @var null
 	 */
-	private $timestamp = NULL;
+	private $timestamp = null;
 
 	/**
 	 * @param DateTime $after Timestamp.

--- a/classes/schedules/ActionScheduler_CanceledSchedule.php
+++ b/classes/schedules/ActionScheduler_CanceledSchedule.php
@@ -13,6 +13,9 @@ class ActionScheduler_CanceledSchedule extends ActionScheduler_SimpleSchedule {
 	private $timestamp = null;
 
 	/**
+	 * Calculate when this schedule should start after a given date & time using
+	 * the number of seconds between recurrences.
+	 *
 	 * @param DateTime $after Timestamp.
 	 *
 	 * @return DateTime|null
@@ -33,6 +36,8 @@ class ActionScheduler_CanceledSchedule extends ActionScheduler_SimpleSchedule {
 	}
 
 	/**
+	 * Check if a recurring action.
+	 *
 	 * @return bool
 	 */
 	public function is_recurring() {

--- a/classes/schedules/ActionScheduler_CronSchedule.php
+++ b/classes/schedules/ActionScheduler_CronSchedule.php
@@ -53,6 +53,8 @@ class ActionScheduler_CronSchedule extends ActionScheduler_Abstract_RecurringSch
 	}
 
 	/**
+	 * Get the recurrence between each time an action is run using this schedule.
+	 *
 	 * @return string
 	 */
 	public function get_recurrence() {

--- a/classes/schedules/ActionScheduler_CronSchedule.php
+++ b/classes/schedules/ActionScheduler_CronSchedule.php
@@ -10,14 +10,14 @@ class ActionScheduler_CronSchedule extends ActionScheduler_Abstract_RecurringSch
 	 *
 	 * @var null
 	 */
-	private $start_timestamp = NULL;
+	private $start_timestamp = null;
 
 	/**
 	 * Deprecated property @see $this->__wakeup() for details.
 	 *
 	 * @var null
 	 */
-	private $cron = NULL;
+	private $cron = null;
 
 	/**
 	 * Wrapper for parent constructor to accept a cron expression string and map it to a CronExpression for this

--- a/classes/schedules/ActionScheduler_IntervalSchedule.php
+++ b/classes/schedules/ActionScheduler_IntervalSchedule.php
@@ -10,14 +10,14 @@ class ActionScheduler_IntervalSchedule extends ActionScheduler_Abstract_Recurrin
 	 *
 	 * @var null
 	 */
-	private $start_timestamp = NULL;
+	private $start_timestamp = null;
 
 	/**
 	 * Deprecated property @see $this->__wakeup() for details.
 	 *
 	 * @var null
 	 */
-	private $interval_in_seconds = NULL;
+	private $interval_in_seconds = null;
 
 	/**
 	 * Calculate when this schedule should start after a given date & time using

--- a/classes/schedules/ActionScheduler_IntervalSchedule.php
+++ b/classes/schedules/ActionScheduler_IntervalSchedule.php
@@ -32,6 +32,8 @@ class ActionScheduler_IntervalSchedule extends ActionScheduler_Abstract_Recurrin
 	}
 
 	/**
+	 * Get the recurrence between each time an action is run using this schedule.
+	 *
 	 * @return int
 	 */
 	public function interval_in_seconds() {

--- a/classes/schedules/ActionScheduler_NullSchedule.php
+++ b/classes/schedules/ActionScheduler_NullSchedule.php
@@ -5,7 +5,11 @@
  */
 class ActionScheduler_NullSchedule extends ActionScheduler_SimpleSchedule {
 
-	/** @var DateTime|null */
+	/**
+	 * Action's scheduled date.
+	 *
+	 * @var DateTime|null
+	 */
 	protected $scheduled_date;
 
 	/**
@@ -18,7 +22,8 @@ class ActionScheduler_NullSchedule extends ActionScheduler_SimpleSchedule {
 	}
 
 	/**
-	 * This schedule has no scheduled DateTime, so we need to override the parent __sleep()
+	 * This schedule has no scheduled DateTime, so we need to override the parent __sleep().
+	 *
 	 * @return array
 	 */
 	public function __sleep() {

--- a/classes/schedules/ActionScheduler_Schedule.php
+++ b/classes/schedules/ActionScheduler_Schedule.php
@@ -5,12 +5,17 @@
  */
 interface ActionScheduler_Schedule {
 	/**
+	 * Get the date & time this schedule was created to run, or calculate when it should be run
+	 * after a given date & time.
+	 *
 	 * @param null|DateTime $after Timestamp.
 	 * @return DateTime|null
 	 */
 	public function next( DateTime $after = null );
 
 	/**
+	 * Check if action is recurring.
+	 *
 	 * @return bool
 	 */
 	public function is_recurring();

--- a/classes/schedules/ActionScheduler_Schedule.php
+++ b/classes/schedules/ActionScheduler_Schedule.php
@@ -8,7 +8,7 @@ interface ActionScheduler_Schedule {
 	 * @param null|DateTime $after Timestamp.
 	 * @return DateTime|null
 	 */
-	public function next( DateTime $after = NULL );
+	public function next( DateTime $after = null );
 
 	/**
 	 * @return bool

--- a/classes/schedules/ActionScheduler_SimpleSchedule.php
+++ b/classes/schedules/ActionScheduler_SimpleSchedule.php
@@ -13,6 +13,9 @@ class ActionScheduler_SimpleSchedule extends ActionScheduler_Abstract_Schedule {
 	private $timestamp = null;
 
 	/**
+	 * Get the date & time this schedule was created to run, or calculate when it should be run
+	 * after a given date & time.
+	 *
 	 * @param DateTime $after Timestamp.
 	 *
 	 * @return DateTime|null
@@ -22,6 +25,8 @@ class ActionScheduler_SimpleSchedule extends ActionScheduler_Abstract_Schedule {
 	}
 
 	/**
+	 * Check if action is recurring.
+	 *
 	 * @return bool
 	 */
 	public function is_recurring() {

--- a/classes/schedules/ActionScheduler_SimpleSchedule.php
+++ b/classes/schedules/ActionScheduler_SimpleSchedule.php
@@ -10,7 +10,7 @@ class ActionScheduler_SimpleSchedule extends ActionScheduler_Abstract_Schedule {
 	 *
 	 * @var null|DateTime
 	 */
-	private $timestamp = NULL;
+	private $timestamp = null;
 
 	/**
 	 * @param DateTime $after Timestamp.

--- a/classes/schema/ActionScheduler_LoggerSchema.php
+++ b/classes/schema/ActionScheduler_LoggerSchema.php
@@ -21,9 +21,9 @@ class ActionScheduler_LoggerSchema extends ActionScheduler_Abstract_Schema {
 	 * Construct.
 	 */
 	public function __construct() {
-		$this->tables = [
+		$this->tables = array(
 			self::LOG_TABLE,
-		];
+		);
 	}
 
 	/**

--- a/classes/schema/ActionScheduler_LoggerSchema.php
+++ b/classes/schema/ActionScheduler_LoggerSchema.php
@@ -38,8 +38,8 @@ class ActionScheduler_LoggerSchema extends ActionScheduler_Abstract_Schema {
 	 */
 	protected function get_table_definition( $table ) {
 		global $wpdb;
-		$table_name       = $wpdb->$table;
-		$charset_collate  = $wpdb->get_charset_collate();
+		$table_name      = $wpdb->$table;
+		$charset_collate = $wpdb->get_charset_collate();
 		switch ( $table ) {
 
 			case self::LOG_TABLE:

--- a/classes/schema/ActionScheduler_LoggerSchema.php
+++ b/classes/schema/ActionScheduler_LoggerSchema.php
@@ -11,7 +11,9 @@ class ActionScheduler_LoggerSchema extends ActionScheduler_Abstract_Schema {
 	const LOG_TABLE = 'actionscheduler_logs';
 
 	/**
-	 * @var int Increment this value to trigger a schema update.
+	 * Increment this value to trigger a schema update.
+	 *
+	 * @var int
 	 */
 	protected $schema_version = 3;
 

--- a/classes/schema/ActionScheduler_StoreSchema.php
+++ b/classes/schema/ActionScheduler_StoreSchema.php
@@ -24,11 +24,11 @@ class ActionScheduler_StoreSchema extends ActionScheduler_Abstract_Schema {
 	 * Construct.
 	 */
 	public function __construct() {
-		$this->tables = [
+		$this->tables = array(
 			self::ACTIONS_TABLE,
 			self::CLAIMS_TABLE,
 			self::GROUPS_TABLE,
-		];
+		);
 	}
 
 	/**

--- a/classes/schema/ActionScheduler_StoreSchema.php
+++ b/classes/schema/ActionScheduler_StoreSchema.php
@@ -43,12 +43,15 @@ class ActionScheduler_StoreSchema extends ActionScheduler_Abstract_Schema {
 	 */
 	protected function get_table_definition( $table ) {
 		global $wpdb;
-		$table_name       = $wpdb->$table;
-		$charset_collate  = $wpdb->get_charset_collate();
+		$table_name      = $wpdb->$table;
+		$charset_collate = $wpdb->get_charset_collate();
+		$default_date    = self::DEFAULT_DATE;
+
 		// phpcs:ignore Squiz.PHP.CommentedOutCode
 		$max_index_length = 191; // @see wp_get_db_schema()
+
 		$hook_status_scheduled_date_gmt_max_index_length = $max_index_length - 20 - 8; // - status, - scheduled_date_gmt
-		$default_date     = self::DEFAULT_DATE;
+
 		switch ( $table ) {
 
 			case self::ACTIONS_TABLE:

--- a/classes/schema/ActionScheduler_StoreSchema.php
+++ b/classes/schema/ActionScheduler_StoreSchema.php
@@ -14,7 +14,9 @@ class ActionScheduler_StoreSchema extends ActionScheduler_Abstract_Schema {
 	const DEFAULT_DATE  = '0000-00-00 00:00:00';
 
 	/**
-	 * @var int Increment this value to trigger a schema update.
+	 * Increment this value to trigger a schema update.
+	 *
+	 * @var int
 	 */
 	protected $schema_version = 7;
 


### PR DESCRIPTION
Eliminates most smells from the `PHPCompatibility` and `Generic` standards.

See https://github.com/woocommerce/action-scheduler/issues/971.