### PR TITLE
Revise PHPCS rules relating to PHP compatibility (min: PHP 7.0)

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -9,7 +9,7 @@
 
 	<!-- Configs -->
 	<config name="minimum_supported_wp_version" value="4.7" />
-	<config name="testVersion" value="5.6-" />
+	<config name="testVersion" value="7.0-" />
 
 	<!-- Rules -->
 	<rule ref="WooCommerce-Core" />


### PR DESCRIPTION
Tweaks our PHPCS config so that we allow valid [PHP 7.0+ syntax](https://github.com/woocommerce/action-scheduler/blob/3.8.1/readme.txt#L8) (sometimes, currently, we warn about various constructs that are invalid only when using PHP 5.6 or lower).

### Steps to replicate

1. Checkout the current `trunk` code (ie, without this change) and run PHPCS.
2. If you specifically run `composer run phpcs classes/WP_CLI/ActionScheduler_WPCLI_Clean_Command.php` you will see various warnings. For the purposes of this PR, we are interested errors such as this one:

```
  84 | ERROR | [ ] 'int' type declaration is not present in PHP version 5.6 or earlier
     |       |     (PHPCompatibility.FunctionDeclarations.NewParamTypeDeclarations.intFound)
```

3. This should not be an error: type declarations are desirable and not something we want to remove. The above is flagged because our PHPCS config is looking for code that is incompatible with PHP 5.6, which is no longer a concern for this project.
4. Check out this branch, and re-run the above command: those particular warnings should no longer appear.

### Changelog

No changelog needed, this is a dev-facing change.
