### PR TITLE
Update minimum versions and test matrix.

### DIFF
--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -10,8 +10,8 @@ jobs:
       fail-fast: false
       matrix:
         # We test against the earliest and latest PHP versions for each major supported version.
-        php: [ '7.0', '7.4', '8.0', '8.1', '8.2' ]
-        wp: [ '6.3', '6.4', '6.5', 'latest', 'nightly' ]
+        php: [ '7.4', '8.0', '8.3' ]
+        wp: [ '6.4', '6.5', 'latest', 'nightly' ]
         multisite: [ '0', '1' ]
         exclude:
           # WordPress 6.6+ requires PHP 7.2+

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         # We test against the earliest and latest PHP versions for each major supported version.
-        php: [ '7.4', '8.0', '8.3' ]
+        php: [ '7.0', '7.4', '8.0', '8.3' ]
         wp: [ '6.4', '6.5', 'latest', 'nightly' ]
         multisite: [ '0', '1' ]
             

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -13,12 +13,6 @@ jobs:
         php: [ '7.4', '8.0', '8.3' ]
         wp: [ '6.4', '6.5', 'latest', 'nightly' ]
         multisite: [ '0', '1' ]
-        exclude:
-          # WordPress 6.6+ requires PHP 7.2+
-          - php: 7.0
-            wp: latest
-          - php: 7.0
-            wp: nightly
             
     services:
       database:

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -13,7 +13,12 @@ jobs:
         php: [ '7.0', '7.4', '8.0', '8.3' ]
         wp: [ '6.4', '6.5', 'latest', 'nightly' ]
         multisite: [ '0', '1' ]
-            
+        exclude:
+          # WordPress 6.6+ requires PHP 7.2+
+          - php: 7.0
+            wp: latest
+          - php: 7.0
+            wp: nightly
     services:
       database:
         image: mysql:5.6

--- a/action-scheduler.php
+++ b/action-scheduler.php
@@ -7,8 +7,8 @@
  * Author URI: https://automattic.com/
  * Version: 3.8.1
  * License: GPLv3
- * Requires at least: 6.2
- * Tested up to: 6.5
+ * Requires at least: 6.4
+ * Tested up to: 6.6
  * Requires PHP: 5.6
  *
  * Copyright 2019 Automattic, Inc.  (https://automattic.com/contact/)

--- a/action-scheduler.php
+++ b/action-scheduler.php
@@ -9,7 +9,7 @@
  * License: GPLv3
  * Requires at least: 6.4
  * Tested up to: 6.6
- * Requires PHP: 5.6
+ * Requires PHP: 7.0
  *
  * Copyright 2019 Automattic, Inc.  (https://automattic.com/contact/)
  *

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: Automattic, wpmuguru, claudiosanches, peterfabian1000, vedjain, ja
 Tags: scheduler, cron
 Stable tag: 3.8.1
 License: GPLv3
-Requires at least: 6.3
-Tested up to: 6.5
+Requires at least: 6.4
+Tested up to: 6.6
 Requires PHP: 7.0
 
 Action Scheduler - Job Queue for WordPress


### PR DESCRIPTION
Some repo maintenance.

🧪 **Test matrix revised** → The versions we should now test against are 7.0 and 7.4, plus 8.0 and 8.3. 

📝 **Readme and plugin header** → Our policy for supporting WordPress is [L-2](https://developer.woocommerce.com/2023/10/24/action-scheduler-to-adopt-l-2-dependency-version-policy/), which means WP 6.4 is our current minimum. We've also had real world exposure and testing (via WooCommerce) under WP 6.6, so I've bumped *'tested up to'.*