### PR TITLE
Added $claim_id and $hooks as params to action_scheduler_claim_actions_order_by filter

### DIFF
--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -932,7 +932,7 @@ AND `group_id` = %d
 		 *
 		 * @param string $order_by_sql
 		 */
-		$order    = apply_filters( 'action_scheduler_claim_actions_order_by', 'ORDER BY priority ASC, attempts ASC, scheduled_date_gmt ASC, action_id ASC' );
+		$order    = apply_filters( 'action_scheduler_claim_actions_order_by', 'ORDER BY priority ASC, attempts ASC, scheduled_date_gmt ASC, action_id ASC', $claim_id, $hooks );
 		$params[] = $limit;
 
 		$sql           = $wpdb->prepare( "{$update} {$where} {$order} LIMIT %d", $params ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -931,6 +931,8 @@ AND `group_id` = %d
 		 * @since 3.4.0
 		 *
 		 * @param string $order_by_sql
+		 * @param string $claim_id Claim Id.
+		 * @param array  $hooks Hooks to filter for.
 		 */
 		$order    = apply_filters( 'action_scheduler_claim_actions_order_by', 'ORDER BY priority ASC, attempts ASC, scheduled_date_gmt ASC, action_id ASC', $claim_id, $hooks );
 		$params[] = $limit;

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -929,6 +929,7 @@ AND `group_id` = %d
 		 * Sets the order-by clause used in the action claim query.
 		 *
 		 * @since 3.4.0
+		 * @since 3.8.3 Made $claim_id and $hooks available.
 		 *
 		 * @param string $order_by_sql
 		 * @param string $claim_id Claim Id.


### PR DESCRIPTION
Allows toggling order by statement on the basis of the specific action. Allows skipping where not needed and benefiting from performance

See #773 from @glagonikas & @barryhughes 