### PR TITLE
Make nullable parameters explicitly nullable

### DIFF
--- a/classes/ActionScheduler_QueueCleaner.php
+++ b/classes/ActionScheduler_QueueCleaner.php
@@ -39,10 +39,10 @@ class ActionScheduler_QueueCleaner {
 	/**
 	 * ActionScheduler_QueueCleaner constructor.
 	 *
-	 * @param ActionScheduler_Store $store      The store instance.
-	 * @param int                   $batch_size The batch size.
+	 * @param ActionScheduler_Store|null $store      The store instance.
+	 * @param int                        $batch_size The batch size.
 	 */
-	public function __construct( ActionScheduler_Store $store = null, $batch_size = 20 ) {
+	public function __construct( ?ActionScheduler_Store $store = null, $batch_size = 20 ) {
 		$this->store      = $store ? $store : ActionScheduler_Store::instance();
 		$this->batch_size = $batch_size;
 	}

--- a/classes/ActionScheduler_QueueRunner.php
+++ b/classes/ActionScheduler_QueueRunner.php
@@ -47,12 +47,12 @@ class ActionScheduler_QueueRunner extends ActionScheduler_Abstract_QueueRunner {
 	/**
 	 * ActionScheduler_QueueRunner constructor.
 	 *
-	 * @param ActionScheduler_Store                    $store Store object.
-	 * @param ActionScheduler_FatalErrorMonitor        $monitor Monitor object.
-	 * @param ActionScheduler_QueueCleaner             $cleaner Cleaner object.
-	 * @param ActionScheduler_AsyncRequest_QueueRunner $async_request Async request runner object.
+	 * @param ActionScheduler_Store|null                    $store Store object.
+	 * @param ActionScheduler_FatalErrorMonitor|null        $monitor Monitor object.
+	 * @param ActionScheduler_QueueCleaner|null             $cleaner Cleaner object.
+	 * @param ActionScheduler_AsyncRequest_QueueRunner|null $async_request Async request runner object.
 	 */
-	public function __construct( ActionScheduler_Store $store = null, ActionScheduler_FatalErrorMonitor $monitor = null, ActionScheduler_QueueCleaner $cleaner = null, ActionScheduler_AsyncRequest_QueueRunner $async_request = null ) {
+	public function __construct( ?ActionScheduler_Store $store = null, ?ActionScheduler_FatalErrorMonitor $monitor = null, ?ActionScheduler_QueueCleaner $cleaner = null, ?ActionScheduler_AsyncRequest_QueueRunner $async_request = null ) {
 		parent::__construct( $store, $monitor, $cleaner );
 
 		if ( is_null( $async_request ) ) {

--- a/classes/WP_CLI/ActionScheduler_WPCLI_QueueRunner.php
+++ b/classes/WP_CLI/ActionScheduler_WPCLI_QueueRunner.php
@@ -33,13 +33,13 @@ class ActionScheduler_WPCLI_QueueRunner extends ActionScheduler_Abstract_QueueRu
 	/**
 	 * ActionScheduler_WPCLI_QueueRunner constructor.
 	 *
-	 * @param ActionScheduler_Store             $store Store object.
-	 * @param ActionScheduler_FatalErrorMonitor $monitor Monitor object.
-	 * @param ActionScheduler_QueueCleaner      $cleaner Cleaner object.
+	 * @param ActionScheduler_Store|null             $store Store object.
+	 * @param ActionScheduler_FatalErrorMonitor|null $monitor Monitor object.
+	 * @param ActionScheduler_QueueCleaner|null      $cleaner Cleaner object.
 	 *
 	 * @throws Exception When this is not run within WP CLI.
 	 */
-	public function __construct( ActionScheduler_Store $store = null, ActionScheduler_FatalErrorMonitor $monitor = null, ActionScheduler_QueueCleaner $cleaner = null ) {
+	public function __construct( ?ActionScheduler_Store $store = null, ?ActionScheduler_FatalErrorMonitor $monitor = null, ?ActionScheduler_QueueCleaner $cleaner = null ) {
 		if ( ! ( defined( 'WP_CLI' ) && WP_CLI ) ) {
 			/* translators: %s php class name */
 			throw new Exception( sprintf( __( 'The %s class can only be run within WP CLI.', 'action-scheduler' ), __CLASS__ ) );

--- a/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php
+++ b/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php
@@ -39,11 +39,11 @@ abstract class ActionScheduler_Abstract_QueueRunner extends ActionScheduler_Abst
 	/**
 	 * ActionScheduler_Abstract_QueueRunner constructor.
 	 *
-	 * @param ActionScheduler_Store             $store Store object.
-	 * @param ActionScheduler_FatalErrorMonitor $monitor Monitor object.
-	 * @param ActionScheduler_QueueCleaner      $cleaner Cleaner object.
+	 * @param ActionScheduler_Store|null             $store Store object.
+	 * @param ActionScheduler_FatalErrorMonitor|null $monitor Monitor object.
+	 * @param ActionScheduler_QueueCleaner|null      $cleaner Cleaner object.
 	 */
-	public function __construct( ActionScheduler_Store $store = null, ActionScheduler_FatalErrorMonitor $monitor = null, ActionScheduler_QueueCleaner $cleaner = null ) {
+	public function __construct( ?ActionScheduler_Store $store = null, ?ActionScheduler_FatalErrorMonitor $monitor = null, ?ActionScheduler_QueueCleaner $cleaner = null ) {
 
 		$this->created_time = microtime( true );
 

--- a/classes/abstracts/ActionScheduler_Abstract_RecurringSchedule.php
+++ b/classes/abstracts/ActionScheduler_Abstract_RecurringSchedule.php
@@ -41,7 +41,7 @@ abstract class ActionScheduler_Abstract_RecurringSchedule extends ActionSchedule
 	 * @param mixed         $recurrence The data used to determine the schedule's recurrence.
 	 * @param DateTime|null $first (Optional) The date & time the first instance of this interval schedule ran. Default null, meaning this is the first instance.
 	 */
-	public function __construct( DateTime $date, $recurrence, DateTime $first = null ) {
+	public function __construct( DateTime $date, $recurrence, ?DateTime $first = null ) {
 		parent::__construct( $date );
 		$this->first_date = empty( $first ) ? $date : $first;
 		$this->recurrence = $recurrence;

--- a/classes/abstracts/ActionScheduler_Logger.php
+++ b/classes/abstracts/ActionScheduler_Logger.php
@@ -30,13 +30,13 @@ abstract class ActionScheduler_Logger {
 	/**
 	 * Create log entry.
 	 *
-	 * @param string   $action_id Action ID.
-	 * @param string   $message   Log message.
-	 * @param DateTime $date      Log date.
+	 * @param string        $action_id Action ID.
+	 * @param string        $message   Log message.
+	 * @param DateTime|null $date      Log date.
 	 *
 	 * @return string The log entry ID
 	 */
-	abstract public function log( $action_id, $message, DateTime $date = null );
+	abstract public function log( $action_id, $message, ?DateTime $date = null );
 
 	/**
 	 * Get action's log entry.
@@ -215,7 +215,7 @@ abstract class ActionScheduler_Logger {
 	 * @param string         $action_id Action ID.
 	 * @param null|Exception $exception The exception which occurred when fetching the action. NULL by default for backward compatibility.
 	 */
-	public function log_failed_fetch_action( $action_id, Exception $exception = null ) {
+	public function log_failed_fetch_action( $action_id, ?Exception $exception = null ) {
 
 		if ( ! is_null( $exception ) ) {
 			/* translators: %s: exception message */

--- a/classes/abstracts/ActionScheduler_Store.php
+++ b/classes/abstracts/ActionScheduler_Store.php
@@ -37,7 +37,7 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 	 *
 	 * @return int The action ID
 	 */
-	abstract public function save_action( ActionScheduler_Action $action, DateTime $scheduled_date = null );
+	abstract public function save_action( ActionScheduler_Action $action, ?DateTime $scheduled_date = null );
 
 	/**
 	 * Get action.
@@ -202,14 +202,14 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 	/**
 	 * Make a claim.
 	 *
-	 * @param int      $max_actions Maximum number of actions to claim.
-	 * @param DateTime $before_date Claim only actions schedule before the given date. Defaults to now.
-	 * @param array    $hooks       Claim only actions with a hook or hooks.
-	 * @param string   $group       Claim only actions in the given group.
+	 * @param int           $max_actions Maximum number of actions to claim.
+	 * @param DateTime|null $before_date Claim only actions schedule before the given date. Defaults to now.
+	 * @param array         $hooks       Claim only actions with a hook or hooks.
+	 * @param string        $group       Claim only actions in the given group.
 	 *
 	 * @return ActionScheduler_ActionClaim
 	 */
-	abstract public function stake_claim( $max_actions = 10, DateTime $before_date = null, $hooks = array(), $group = '' );
+	abstract public function stake_claim( $max_actions = 10, ?DateTime $before_date = null, $hooks = array(), $group = '' );
 
 	/**
 	 * Get claim count.
@@ -298,7 +298,7 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 	 * @param null|DateTime          $scheduled_date Action's schedule date (optional).
 	 * @return string
 	 */
-	protected function get_scheduled_date_string( ActionScheduler_Action $action, DateTime $scheduled_date = null ) {
+	protected function get_scheduled_date_string( ActionScheduler_Action $action, ?DateTime $scheduled_date = null ) {
 		$next = is_null( $scheduled_date ) ? $action->get_schedule()->get_date() : $scheduled_date;
 
 		if ( ! $next ) {
@@ -313,11 +313,11 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 	/**
 	 * Get the time MySQL formatted date/time string for an action's (next) scheduled date.
 	 *
-	 * @param ActionScheduler_Action $action Action.
-	 * @param null|DateTime          $scheduled_date Action's scheduled date (optional).
+	 * @param ActionScheduler_Action|null $action Action.
+	 * @param null|DateTime               $scheduled_date Action's scheduled date (optional).
 	 * @return string
 	 */
-	protected function get_scheduled_date_string_local( ActionScheduler_Action $action, DateTime $scheduled_date = null ) {
+	protected function get_scheduled_date_string_local( ActionScheduler_Action $action, ?DateTime $scheduled_date = null ) {
 		$next = is_null( $scheduled_date ) ? $action->get_schedule()->get_date() : $scheduled_date;
 
 		if ( ! $next ) {

--- a/classes/actions/ActionScheduler_Action.php
+++ b/classes/actions/ActionScheduler_Action.php
@@ -53,7 +53,7 @@ class ActionScheduler_Action {
 	 * @param null|ActionScheduler_Schedule $schedule Action's schedule.
 	 * @param string                        $group Action's group.
 	 */
-	public function __construct( $hook, array $args = array(), ActionScheduler_Schedule $schedule = null, $group = '' ) {
+	public function __construct( $hook, array $args = array(), ?ActionScheduler_Schedule $schedule = null, $group = '' ) {
 		$schedule = empty( $schedule ) ? new ActionScheduler_NullSchedule() : $schedule;
 		$this->set_hook( $hook );
 		$this->set_schedule( $schedule );

--- a/classes/actions/ActionScheduler_CanceledAction.php
+++ b/classes/actions/ActionScheduler_CanceledAction.php
@@ -16,7 +16,7 @@ class ActionScheduler_CanceledAction extends ActionScheduler_FinishedAction {
 	 * @param null|ActionScheduler_Schedule $schedule Action's schedule.
 	 * @param string                        $group Action's group.
 	 */
-	public function __construct( $hook, array $args = array(), ActionScheduler_Schedule $schedule = null, $group = '' ) {
+	public function __construct( $hook, array $args = array(), ?ActionScheduler_Schedule $schedule = null, $group = '' ) {
 		parent::__construct( $hook, $args, $schedule, $group );
 		if ( is_null( $schedule ) ) {
 			$this->set_schedule( new ActionScheduler_NullSchedule() );

--- a/classes/actions/ActionScheduler_NullAction.php
+++ b/classes/actions/ActionScheduler_NullAction.php
@@ -12,7 +12,7 @@ class ActionScheduler_NullAction extends ActionScheduler_Action {
 	 * @param mixed[]                       $args Action arguments.
 	 * @param null|ActionScheduler_Schedule $schedule Action schedule.
 	 */
-	public function __construct( $hook = '', array $args = array(), ActionScheduler_Schedule $schedule = null ) {
+	public function __construct( $hook = '', array $args = array(), ?ActionScheduler_Schedule $schedule = null ) {
 		$this->set_schedule( new ActionScheduler_NullSchedule() );
 	}
 

--- a/classes/data-stores/ActionScheduler_DBLogger.php
+++ b/classes/data-stores/ActionScheduler_DBLogger.php
@@ -12,13 +12,13 @@ class ActionScheduler_DBLogger extends ActionScheduler_Logger {
 	/**
 	 * Add a record to an action log.
 	 *
-	 * @param int      $action_id Action ID.
-	 * @param string   $message Message to be saved in the log entry.
-	 * @param DateTime $date Timestamp of the log entry.
+	 * @param int           $action_id Action ID.
+	 * @param string        $message Message to be saved in the log entry.
+	 * @param DateTime|null $date Timestamp of the log entry.
 	 *
 	 * @return int     The log entry ID.
 	 */
-	public function log( $action_id, $message, DateTime $date = null ) {
+	public function log( $action_id, $message, ?DateTime $date = null ) {
 		if ( empty( $date ) ) {
 			$date = as_get_datetime_object();
 		} else {

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -59,12 +59,12 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 	 * Save an action, checks if this is a unique action before actually saving.
 	 *
 	 * @param ActionScheduler_Action $action         Action object.
-	 * @param \DateTime              $scheduled_date Optional schedule date. Default null.
+	 * @param DateTime|null          $scheduled_date Optional schedule date. Default null.
 	 *
 	 * @return int                  Action ID.
 	 * @throws RuntimeException     Throws exception when saving the action fails.
 	 */
-	public function save_unique_action( ActionScheduler_Action $action, \DateTime $scheduled_date = null ) {
+	public function save_unique_action( ActionScheduler_Action $action, ?DateTime $scheduled_date = null ) {
 		return $this->save_action_to_db( $action, $scheduled_date, true );
 	}
 
@@ -72,12 +72,12 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 	 * Save an action. Can save duplicate action as well, prefer using `save_unique_action` instead.
 	 *
 	 * @param ActionScheduler_Action $action Action object.
-	 * @param \DateTime              $scheduled_date Optional schedule date. Default null.
+	 * @param DateTime|null          $scheduled_date Optional schedule date. Default null.
 	 *
 	 * @return int Action ID.
 	 * @throws RuntimeException     Throws exception when saving the action fails.
 	 */
-	public function save_action( ActionScheduler_Action $action, \DateTime $scheduled_date = null ) {
+	public function save_action( ActionScheduler_Action $action, ?DateTime $scheduled_date = null ) {
 		return $this->save_action_to_db( $action, $scheduled_date, false );
 	}
 
@@ -91,7 +91,7 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 	 * @return int Action ID.
 	 * @throws \RuntimeException     Throws exception when saving the action fails.
 	 */
-	private function save_action_to_db( ActionScheduler_Action $action, DateTime $date = null, $unique = false ) {
+	private function save_action_to_db( ActionScheduler_Action $action, ?DateTime $date = null, $unique = false ) {
 		global $wpdb;
 
 		try {
@@ -847,14 +847,14 @@ AND `group_id` = %d
 	/**
 	 * Stake a claim on actions.
 	 *
-	 * @param int       $max_actions Maximum number of action to include in claim.
-	 * @param \DateTime $before_date Jobs must be schedule before this date. Defaults to now.
-	 * @param array     $hooks Hooks to filter for.
-	 * @param string    $group Group to filter for.
+	 * @param int           $max_actions Maximum number of action to include in claim.
+	 * @param DateTime|null $before_date Jobs must be schedule before this date. Defaults to now.
+	 * @param array         $hooks Hooks to filter for.
+	 * @param string        $group Group to filter for.
 	 *
 	 * @return ActionScheduler_ActionClaim
 	 */
-	public function stake_claim( $max_actions = 10, \DateTime $before_date = null, $hooks = array(), $group = '' ) {
+	public function stake_claim( $max_actions = 10, ?DateTime $before_date = null, $hooks = array(), $group = '' ) {
 		$claim_id = $this->generate_claim_id();
 
 		$this->claim_before_date = $before_date;
@@ -914,17 +914,17 @@ AND `group_id` = %d
 	/**
 	 * Mark actions claimed.
 	 *
-	 * @param string    $claim_id Claim Id.
-	 * @param int       $limit Number of action to include in claim.
-	 * @param \DateTime $before_date Should use UTC timezone.
-	 * @param array     $hooks Hooks to filter for.
-	 * @param string    $group Group to filter for.
+	 * @param string        $claim_id Claim Id.
+	 * @param int           $limit Number of action to include in claim.
+	 * @param DateTime|null $before_date Should use UTC timezone.
+	 * @param array         $hooks Hooks to filter for.
+	 * @param string        $group Group to filter for.
 	 *
 	 * @return int The number of actions that were claimed.
 	 * @throws \InvalidArgumentException Throws InvalidArgumentException if group doesn't exist.
 	 * @throws \RuntimeException Throws RuntimeException if unable to claim action.
 	 */
-	protected function claim_actions( $claim_id, $limit, \DateTime $before_date = null, $hooks = array(), $group = '' ) {
+	protected function claim_actions( $claim_id, $limit, ?DateTime $before_date = null, $hooks = array(), $group = '' ) {
 		/**
 		 * Global.
 		 *

--- a/classes/data-stores/ActionScheduler_HybridStore.php
+++ b/classes/data-stores/ActionScheduler_HybridStore.php
@@ -54,9 +54,9 @@ class ActionScheduler_HybridStore extends Store {
 	/**
 	 * ActionScheduler_HybridStore constructor.
 	 *
-	 * @param Config $config Migration config object.
+	 * @param Config|null $config Migration config object.
 	 */
-	public function __construct( Config $config = null ) {
+	public function __construct( ?Config $config = null ) {
 		$this->demarkation_id = (int) get_option( self::DEMARKATION_OPTION, 0 );
 		if ( empty( $config ) ) {
 			$config = Controller::instance()->get_migration_config_object();
@@ -240,7 +240,7 @@ class ActionScheduler_HybridStore extends Store {
 	 *
 	 * @return ActionScheduler_ActionClaim
 	 */
-	public function stake_claim( $max_actions = 10, DateTime $before_date = null, $hooks = array(), $group = '' ) {
+	public function stake_claim( $max_actions = 10, ?DateTime $before_date = null, $hooks = array(), $group = '' ) {
 		$claim = $this->secondary_store->stake_claim( $max_actions, $before_date, $hooks, $group );
 
 		$claimed_actions = $claim->get_actions();
@@ -266,11 +266,11 @@ class ActionScheduler_HybridStore extends Store {
 	 * Save an action to the primary store.
 	 *
 	 * @param ActionScheduler_Action $action Action object to be saved.
-	 * @param DateTime               $date Optional. Schedule date. Default null.
+	 * @param DateTime|null          $date Optional. Schedule date. Default null.
 	 *
 	 * @return int The action ID
 	 */
-	public function save_action( ActionScheduler_Action $action, DateTime $date = null ) {
+	public function save_action( ActionScheduler_Action $action, ?DateTime $date = null ) {
 		return $this->primary_store->save_action( $action, $date );
 	}
 

--- a/classes/data-stores/ActionScheduler_wpCommentLogger.php
+++ b/classes/data-stores/ActionScheduler_wpCommentLogger.php
@@ -10,13 +10,13 @@ class ActionScheduler_wpCommentLogger extends ActionScheduler_Logger {
 	/**
 	 * Create log entry.
 	 *
-	 * @param string   $action_id Action ID.
-	 * @param string   $message   Action log's message.
-	 * @param DateTime $date      Action log's timestamp.
+	 * @param string        $action_id Action ID.
+	 * @param string        $message   Action log's message.
+	 * @param DateTime|null $date      Action log's timestamp.
 	 *
 	 * @return string The log entry ID
 	 */
-	public function log( $action_id, $message, DateTime $date = null ) {
+	public function log( $action_id, $message, ?DateTime $date = null ) {
 		if ( empty( $date ) ) {
 			$date = as_get_datetime_object();
 		} else {

--- a/classes/data-stores/ActionScheduler_wpPostStore.php
+++ b/classes/data-stores/ActionScheduler_wpPostStore.php
@@ -30,12 +30,12 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 	 * Save action.
 	 *
 	 * @param ActionScheduler_Action $action Scheduled Action.
-	 * @param DateTime               $scheduled_date Scheduled Date.
+	 * @param DateTime|null          $scheduled_date Scheduled Date.
 	 *
 	 * @throws RuntimeException Throws an exception if the action could not be saved.
 	 * @return int
 	 */
-	public function save_action( ActionScheduler_Action $action, DateTime $scheduled_date = null ) {
+	public function save_action( ActionScheduler_Action $action, ?DateTime $scheduled_date = null ) {
 		try {
 			$this->validate_action( $action );
 			$post_array = $this->create_post_array( $action, $scheduled_date );
@@ -54,11 +54,11 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 	 * Create post array.
 	 *
 	 * @param ActionScheduler_Action $action Scheduled Action.
-	 * @param DateTime               $scheduled_date Scheduled Date.
+	 * @param DateTime|null          $scheduled_date Scheduled Date.
 	 *
 	 * @return array Returns an array of post data.
 	 */
-	protected function create_post_array( ActionScheduler_Action $action, DateTime $scheduled_date = null ) {
+	protected function create_post_array( ActionScheduler_Action $action, ?DateTime $scheduled_date = null ) {
 		$post = array(
 			'post_type'     => self::POST_TYPE,
 			'post_title'    => $action->get_hook(),
@@ -573,16 +573,16 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 	/**
 	 * Stake claim.
 	 *
-	 * @param int      $max_actions Maximum number of actions.
-	 * @param DateTime $before_date Jobs must be schedule before this date. Defaults to now.
-	 * @param array    $hooks       Claim only actions with a hook or hooks.
-	 * @param string   $group       Claim only actions in the given group.
+	 * @param int           $max_actions Maximum number of actions.
+	 * @param DateTime|null $before_date Jobs must be schedule before this date. Defaults to now.
+	 * @param array         $hooks       Claim only actions with a hook or hooks.
+	 * @param string        $group       Claim only actions in the given group.
 	 *
 	 * @return ActionScheduler_ActionClaim
 	 * @throws RuntimeException When there is an error staking a claim.
 	 * @throws InvalidArgumentException When the given group is not valid.
 	 */
-	public function stake_claim( $max_actions = 10, DateTime $before_date = null, $hooks = array(), $group = '' ) {
+	public function stake_claim( $max_actions = 10, ?DateTime $before_date = null, $hooks = array(), $group = '' ) {
 		$this->claim_before_date = $before_date;
 		$claim_id                = $this->generate_claim_id();
 		$this->claim_actions( $claim_id, $max_actions, $before_date, $hooks, $group );
@@ -622,16 +622,16 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 	/**
 	 * Claim actions.
 	 *
-	 * @param string   $claim_id    Claim ID.
-	 * @param int      $limit       Limit.
-	 * @param DateTime $before_date Should use UTC timezone.
-	 * @param array    $hooks       Claim only actions with a hook or hooks.
-	 * @param string   $group       Claim only actions in the given group.
+	 * @param string        $claim_id    Claim ID.
+	 * @param int           $limit       Limit.
+	 * @param DateTime|null $before_date Should use UTC timezone.
+	 * @param array         $hooks       Claim only actions with a hook or hooks.
+	 * @param string        $group       Claim only actions in the given group.
 	 *
 	 * @return int The number of actions that were claimed.
 	 * @throws RuntimeException  When there is a database error.
 	 */
-	protected function claim_actions( $claim_id, $limit, DateTime $before_date = null, $hooks = array(), $group = '' ) {
+	protected function claim_actions( $claim_id, $limit, ?DateTime $before_date = null, $hooks = array(), $group = '' ) {
 		// Set up initial variables.
 		$date      = null === $before_date ? as_get_datetime_object() : clone $before_date;
 		$limit_ids = ! empty( $group );

--- a/classes/migration/ActionScheduler_DBStoreMigrator.php
+++ b/classes/migration/ActionScheduler_DBStoreMigrator.php
@@ -3,7 +3,7 @@
 /**
  * Class ActionScheduler_DBStoreMigrator
  *
- * A  class for direct saving of actions to the table data store during migration.
+ * A class for direct saving of actions to the table data store during migration.
  *
  * @since 3.0.0
  */
@@ -17,13 +17,13 @@ class ActionScheduler_DBStoreMigrator extends ActionScheduler_DBStore {
 	 * that when first saving the action.
 	 *
 	 * @param ActionScheduler_Action $action Action to migrate.
-	 * @param null|\DateTime         $scheduled_date Optional date of the first instance to store.
-	 * @param null|\DateTime         $last_attempt_date Optional date the action was last attempted.
+	 * @param null|DateTime          $scheduled_date Optional date of the first instance to store.
+	 * @param null|DateTime          $last_attempt_date Optional date the action was last attempted.
 	 *
 	 * @return string The action ID
 	 * @throws \RuntimeException When the action is not saved.
 	 */
-	public function save_action( ActionScheduler_Action $action, \DateTime $scheduled_date = null, \DateTime $last_attempt_date = null ) {
+	public function save_action( ActionScheduler_Action $action, ?DateTime $scheduled_date = null, ?DateTime $last_attempt_date = null ) {
 		try {
 			/**
 			 * Global.

--- a/classes/schedules/ActionScheduler_CronSchedule.php
+++ b/classes/schedules/ActionScheduler_CronSchedule.php
@@ -27,7 +27,7 @@ class ActionScheduler_CronSchedule extends ActionScheduler_Abstract_RecurringSch
 	 * @param CronExpression|string $recurrence The CronExpression used to calculate the schedule's next instance.
 	 * @param DateTime|null         $first (Optional) The date & time the first instance of this interval schedule ran. Default null, meaning this is the first instance.
 	 */
-	public function __construct( DateTime $start, $recurrence, DateTime $first = null ) {
+	public function __construct( DateTime $start, $recurrence, ?DateTime $first = null ) {
 		if ( ! is_a( $recurrence, 'CronExpression' ) ) {
 			$recurrence = CronExpression::factory( $recurrence );
 		}

--- a/classes/schedules/ActionScheduler_NullSchedule.php
+++ b/classes/schedules/ActionScheduler_NullSchedule.php
@@ -17,7 +17,7 @@ class ActionScheduler_NullSchedule extends ActionScheduler_SimpleSchedule {
 	 *
 	 * @param null|DateTime $date The date & time to run the action.
 	 */
-	public function __construct( DateTime $date = null ) {
+	public function __construct( ?DateTime $date = null ) {
 		$this->scheduled_date = null;
 	}
 

--- a/classes/schedules/ActionScheduler_Schedule.php
+++ b/classes/schedules/ActionScheduler_Schedule.php
@@ -11,7 +11,7 @@ interface ActionScheduler_Schedule {
 	 * @param null|DateTime $after Timestamp.
 	 * @return DateTime|null
 	 */
-	public function next( DateTime $after = null );
+	public function next( ?DateTime $after = null );
 
 	/**
 	 * Identify the schedule as (not) recurring.


### PR DESCRIPTION
For improved compatibility with PHP 8.4, and to reduce the amount of error noise we see when running under that version, this change fixes a number of method signatures where parameters are implicitly nullable. For example:

```php
public function __construct( ActionScheduler_Store $store = null, $batch_size = 20 )
```

`$store` must be of type `ActionScheduler_Store`, but if not specified by the caller it is set to `null`. This is fine, but as of PHP 8.4 we are encouraged to be explicit about it, so we need:

```php
public function __construct( ?ActionScheduler_Store $store = null, $batch_size = 20 ) {
```

The problem with the above is that `?Type` is only valid [from PHP 7.1 onwards](https://www.php.net/manual/en/migration71.new-features.php), whereas we still support PHP 7.0. We also cannot yet use type unions. So, we have a decision to make:

- Bump the minimum supported version of PHP (feels reasonable if it's a small adjustment, from 7.0 to 7.1).
- Dispense with this change and put up with the warning/error noise.
