### PR TITLE
Update compatibility for WordPress 6.7

### DIFF
--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -16,6 +16,8 @@ jobs:
         exclude:
           # WordPress 6.6+ requires PHP 7.2+
           - php: 7.0
+            wp: 6.6
+          - php: 7.0
             wp: latest
           - php: 7.0
             wp: nightly

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -44,14 +44,19 @@ jobs:
           php --version
           composer --version
 
-      - name: Get cached composer directories
-        uses: actions/cache@v2
-        with:
-          path: ./vendor
-          key: ${{ runner.os }}-${{ hashFiles('./composer.lock') }}
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
-      - name: Setup and install composer
-        run: composer install
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Install dependencies
+        run: composer install --prefer-dist
 
       - name: Setup PHPUnit 
         run: |

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         # We test against the earliest and latest PHP versions for each major supported version.
         php: [ '7.0', '7.4', '8.0', '8.3' ]
-        wp: [ '6.4', '6.5', 'latest', 'nightly' ]
+        wp: [ '6.4', '6.5', '6.6', 'latest', 'nightly' ]
         multisite: [ '0', '1' ]
         exclude:
           # WordPress 6.6+ requires PHP 7.2+

--- a/action-scheduler.php
+++ b/action-scheduler.php
@@ -8,7 +8,7 @@
  * Version: 3.8.2
  * License: GPLv3
  * Requires at least: 6.4
- * Tested up to: 6.6
+ * Tested up to: 6.7
  * Requires PHP: 7.0
  *
  * Copyright 2019 Automattic, Inc.  (https://automattic.com/contact/)

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: scheduler, cron
 Stable tag: 3.8.2
 License: GPLv3
 Requires at least: 6.4
-Tested up to: 6.6
+Tested up to: 6.7
 Requires PHP: 7.0
 
 Action Scheduler - Job Queue for WordPress


### PR DESCRIPTION
Some repo maintenance.

🧪 Test matrix revised → Added `6.6` since `latest` will be `6.7`,

📝 Readme and plugin header → Update `Tested up to` to `6.7`.