### PR TITLE
Increase minimum required version of PHP to 7.1 (up from 7.0).

### DIFF
--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -10,16 +10,16 @@ jobs:
       fail-fast: false
       matrix:
         # We test against the earliest and latest PHP versions for each major supported version.
-        php: [ '7.0', '7.4', '8.0', '8.3' ]
+        php: [ '7.1', '7.4', '8.0', '8.3' ]
         wp: [ '6.4', '6.5', '6.6', 'latest', 'nightly' ]
         multisite: [ '0', '1' ]
         exclude:
           # WordPress 6.6+ requires PHP 7.2+
-          - php: 7.0
+          - php: 7.1
             wp: 6.6
-          - php: 7.0
+          - php: 7.1
             wp: latest
-          - php: 7.0
+          - php: 7.1
             wp: nightly
     services:
       database:
@@ -62,12 +62,8 @@ jobs:
 
       - name: Setup PHPUnit 
         run: |
-          # PHPUnit 5.7 when using PHP 5.6 - 7.0.
-          if [ "$(php -r "echo version_compare( PHP_VERSION, '7.1', '<' );")" ]; then
-            curl -L https://phar.phpunit.de/phpunit-5.7.phar -o /tmp/phpunit
-            OVERWRITE=1
           # PHPUnit 7.5 when using PHP 7.1 - 7.4.
-          elif [ "$(php -r "echo version_compare( PHP_VERSION, '8.0', '<' );")" ]; then
+          if [ "$(php -r "echo version_compare( PHP_VERSION, '8.0', '<' );")" ]; then
             curl -L https://phar.phpunit.de/phpunit-7.5.phar -o /tmp/phpunit
             OVERWRITE=1
           # PHPUnit 7.5 (Custom Fork) when using PHP 8.0+.

--- a/action-scheduler.php
+++ b/action-scheduler.php
@@ -9,7 +9,7 @@
  * License: GPLv3
  * Requires at least: 6.4
  * Tested up to: 6.7
- * Requires PHP: 7.0
+ * Requires PHP: 7.1
  *
  * Copyright 2019 Automattic, Inc.  (https://automattic.com/contact/)
  *

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "prefer-stable": true,
   "minimum-stability": "dev",
   "require": {
-    "php": ">=7.0"
+    "php": ">=7.1"
   },
   "require-dev": {
     "phpunit/phpunit": "^7.5",

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Stable tag: 3.8.2
 License: GPLv3
 Requires at least: 6.4
 Tested up to: 6.7
-Requires PHP: 7.0
+Requires PHP: 7.1
 
 Action Scheduler - Job Queue for WordPress
 


### PR DESCRIPTION
We are increasing the minimum required version of PHP. Functionally, nothing has changed (but we will take advantage of this in some upcoming PRs, to address problems that occur when using PHP 8.4).

Closes #1211.

### 🥼 Testing

1. As noted above, functionally, nothing has changed. As a minimum, we still expect the test suite to pass without errors.
2. A high level review or 'smoketest' of the plugin is probably useful:
    1. Activate the plugin (as a top-level, standalone plugin).
    2. Ensure the **Tools ‣ Scheduled Actions** admin screen is still present and functions as normal.
3. Feel free to do any other exploratory testing you feel may be useful.

### :memo: Changelog

> Bump minimum PHP version to 7.1.