### PR TITLE
Prepare for 3.9.0 release (changelogs, versions).

### DIFF
--- a/action-scheduler.php
+++ b/action-scheduler.php
@@ -5,9 +5,9 @@
  * Description: A robust scheduling library for use in WordPress plugins.
  * Author: Automattic
  * Author URI: https://automattic.com/
- * Version: 3.8.2
+ * Version: 3.9.0
  * License: GPLv3
- * Requires at least: 6.4
+ * Requires at least: 6.5
  * Tested up to: 6.7
  * Requires PHP: 7.1
  *

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,13 @@
 *** Changelog ***
 
+= 3.9.0 - 2024-11-14 =  
+* Minimum required version of PHP is now 7.1.  
+* Performance improvements for the `as_pending_actions_due()` function.  
+* Existing filter hook `action_scheduler_claim_actions_order_by` enhanced to provide callbacks with additional information.  
+* Improved compatibility with PHP 8.4, specifically by making implicitly nullable parameters explicitly nullable.  
+* A large number of coding standards-enhancements, to help reduce friction when submitting plugins to marketplaces and plugin directories. Special props @crstauf for this effort.  
+* Minor documentation tweaks and improvements.
+
 = 3.8.2 - 2024-09-12 =
 * Add missing parameter to the `pre_as_enqueue_async_action` hook.
 * Bump minimum PHP version to 7.0.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: Automattic, wpmuguru, claudiosanches, peterfabian1000, vedjain, ja
 Tags: scheduler, cron
 Stable tag: 3.8.2
 License: GPLv3
-Requires at least: 6.4
+Requires at least: 6.5
 Tested up to: 6.7
 Requires PHP: 7.1
 
@@ -46,6 +46,14 @@ Action Scheduler is developed and maintained by [Automattic](http://automattic.c
 Collaboration is cool. We'd love to work with you to improve Action Scheduler. [Pull Requests](https://github.com/woocommerce/action-scheduler/pulls) welcome.
 
 == Changelog ==
+
+= 3.9.0 - 2024-11-14 =  
+* Minimum required version of PHP is now 7.1.  
+* Performance improvements for the `as_pending_actions_due()` function.  
+* Existing filter hook `action_scheduler_claim_actions_order_by` enhanced to provide callbacks with additional information.  
+* Improved compatibility with PHP 8.4, specifically by making implicitly nullable parameters explicitly nullable.  
+* A large number of coding standards-enhancements, to help reduce friction when submitting plugins to marketplaces and plugin directories. Special props @crstauf for this effort.  
+* Minor documentation tweaks and improvements.
 
 = 3.8.2 - 2024-09-12 =
 * Add missing parameter to the `pre_as_enqueue_async_action` hook.


### PR DESCRIPTION
- Preparation for 3.9.0.
- Note the `Requires at least: 6.5` change is in line with our L-2 policy.