### PR TITLE
Release/3.9.0

### DIFF
--- a/action-scheduler.php
+++ b/action-scheduler.php
@@ -5,9 +5,9 @@
  * Description: A robust scheduling library for use in WordPress plugins.
  * Author: Automattic
  * Author URI: https://automattic.com/
- * Version: 3.8.2
+ * Version: 3.9.0
  * License: GPLv3
- * Requires at least: 6.4
+ * Requires at least: 6.5
  * Tested up to: 6.7
  * Requires PHP: 7.1
  *

--- a/action-scheduler.php
+++ b/action-scheduler.php
@@ -29,29 +29,29 @@
  * @package ActionScheduler
  */
 
-if ( ! function_exists( 'action_scheduler_register_3_dot_8_dot_2' ) && function_exists( 'add_action' ) ) { // WRCS: DEFINED_VERSION.
+if ( ! function_exists( 'action_scheduler_register_3_dot_9_dot_0' ) && function_exists( 'add_action' ) ) { // WRCS: DEFINED_VERSION.
 
 	if ( ! class_exists( 'ActionScheduler_Versions', false ) ) {
 		require_once __DIR__ . '/classes/ActionScheduler_Versions.php';
 		add_action( 'plugins_loaded', array( 'ActionScheduler_Versions', 'initialize_latest_version' ), 1, 0 );
 	}
 
-	add_action( 'plugins_loaded', 'action_scheduler_register_3_dot_8_dot_2', 0, 0 ); // WRCS: DEFINED_VERSION.
+	add_action( 'plugins_loaded', 'action_scheduler_register_3_dot_9_dot_0', 0, 0 ); // WRCS: DEFINED_VERSION.
 
 	// phpcs:disable Generic.Functions.OpeningFunctionBraceKernighanRitchie.ContentAfterBrace
 	/**
 	 * Registers this version of Action Scheduler.
 	 */
-	function action_scheduler_register_3_dot_8_dot_2() { // WRCS: DEFINED_VERSION.
+	function action_scheduler_register_3_dot_9_dot_0() { // WRCS: DEFINED_VERSION.
 		$versions = ActionScheduler_Versions::instance();
-		$versions->register( '3.8.2', 'action_scheduler_initialize_3_dot_8_dot_2' ); // WRCS: DEFINED_VERSION.
+		$versions->register( '3.9.0', 'action_scheduler_initialize_3_dot_9_dot_0' ); // WRCS: DEFINED_VERSION.
 	}
 
 	// phpcs:disable Generic.Functions.OpeningFunctionBraceKernighanRitchie.ContentAfterBrace
 	/**
 	 * Initializes this version of Action Scheduler.
 	 */
-	function action_scheduler_initialize_3_dot_8_dot_2() { // WRCS: DEFINED_VERSION.
+	function action_scheduler_initialize_3_dot_9_dot_0() { // WRCS: DEFINED_VERSION.
 		// A final safety check is required even here, because historic versions of Action Scheduler
 		// followed a different pattern (in some unusual cases, we could reach this point and the
 		// ActionScheduler class is already defined—so we need to guard against that).
@@ -63,7 +63,7 @@ if ( ! function_exists( 'action_scheduler_register_3_dot_8_dot_2' ) && function_
 
 	// Support usage in themes - load this version if no plugin has loaded a version yet.
 	if ( did_action( 'plugins_loaded' ) && ! doing_action( 'plugins_loaded' ) && ! class_exists( 'ActionScheduler', false ) ) {
-		action_scheduler_initialize_3_dot_8_dot_2(); // WRCS: DEFINED_VERSION.
+		action_scheduler_initialize_3_dot_9_dot_0(); // WRCS: DEFINED_VERSION.
 		do_action( 'action_scheduler_pre_theme_init' );
 		ActionScheduler_Versions::initialize_latest_version();
 	}

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,13 @@
 *** Changelog ***
 
+= 3.9.0 - 2024-11-14 =  
+* Minimum required version of PHP is now 7.1.  
+* Performance improvements for the `as_pending_actions_due()` function.  
+* Existing filter hook `action_scheduler_claim_actions_order_by` enhanced to provide callbacks with additional information.  
+* Improved compatibility with PHP 8.4, specifically by making implicitly nullable parameters explicitly nullable.  
+* A large number of coding standards-enhancements, to help reduce friction when submitting plugins to marketplaces and plugin directories. Special props @crstauf for this effort.  
+* Minor documentation tweaks and improvements.
+
 = 3.8.2 - 2024-09-12 =
 * Add missing parameter to the `pre_as_enqueue_async_action` hook.
 * Bump minimum PHP version to 7.0.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "action-scheduler",
-  "version": "3.8.2",
+  "version": "3.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "action-scheduler",
   "title": "Action Scheduler",
-  "version": "3.8.2",
+  "version": "3.9.0",
   "homepage": "https://actionscheduler.org/",
   "repository": {
     "type": "git",

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Action Scheduler ===
 Contributors: Automattic, wpmuguru, claudiosanches, peterfabian1000, vedjain, jamosova, obliviousharmony, konamiman, sadowski, royho, barryhughes-1
 Tags: scheduler, cron
-Stable tag: 3.8.2
+Stable tag: 3.9.0
 License: GPLv3
 Requires at least: 6.5
 Tested up to: 6.7

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: Automattic, wpmuguru, claudiosanches, peterfabian1000, vedjain, ja
 Tags: scheduler, cron
 Stable tag: 3.8.2
 License: GPLv3
-Requires at least: 6.4
+Requires at least: 6.5
 Tested up to: 6.7
 Requires PHP: 7.1
 
@@ -46,6 +46,14 @@ Action Scheduler is developed and maintained by [Automattic](http://automattic.c
 Collaboration is cool. We'd love to work with you to improve Action Scheduler. [Pull Requests](https://github.com/woocommerce/action-scheduler/pulls) welcome.
 
 == Changelog ==
+
+= 3.9.0 - 2024-11-14 =  
+* Minimum required version of PHP is now 7.1.  
+* Performance improvements for the `as_pending_actions_due()` function.  
+* Existing filter hook `action_scheduler_claim_actions_order_by` enhanced to provide callbacks with additional information.  
+* Improved compatibility with PHP 8.4, specifically by making implicitly nullable parameters explicitly nullable.  
+* A large number of coding standards-enhancements, to help reduce friction when submitting plugins to marketplaces and plugin directories. Special props @crstauf for this effort.  
+* Minor documentation tweaks and improvements.
 
 = 3.8.2 - 2024-09-12 =
 * Add missing parameter to the `pre_as_enqueue_async_action` hook.


### PR DESCRIPTION
Brings `trunk` up-to-date with changes shipped in [3.9.0](https://github.com/woocommerce/action-scheduler/releases/tag/3.9.0) (ie, version number bumps and changelog entries).