### PR TITLE
Make some other nullable parameters explicitly nullable

### DIFF
--- a/classes/ActionScheduler_ActionFactory.php
+++ b/classes/ActionScheduler_ActionFactory.php
@@ -8,17 +8,17 @@ class ActionScheduler_ActionFactory {
 	/**
 	 * Return stored actions for given params.
 	 *
-	 * @param string                   $status The action's status in the data store.
-	 * @param string                   $hook The hook to trigger when this action runs.
-	 * @param array                    $args Args to pass to callbacks when the hook is triggered.
-	 * @param ActionScheduler_Schedule $schedule The action's schedule.
-	 * @param string                   $group A group to put the action in.
+	 * @param string                        $status The action's status in the data store.
+	 * @param string                        $hook The hook to trigger when this action runs.
+	 * @param array                         $args Args to pass to callbacks when the hook is triggered.
+	 * @param ActionScheduler_Schedule|null $schedule The action's schedule.
+	 * @param string                        $group A group to put the action in.
 	 * phpcs:ignore Squiz.Commenting.FunctionComment.ExtraParamComment
-	 * @param int                      $priority The action priority.
+	 * @param int                           $priority The action priority.
 	 *
 	 * @return ActionScheduler_Action An instance of the stored action.
 	 */
-	public function get_stored_action( $status, $hook, array $args = array(), ActionScheduler_Schedule $schedule = null, $group = '' ) {
+	public function get_stored_action( $status, $hook, array $args = array(), ?ActionScheduler_Schedule $schedule = null, $group = '' ) {
 		// The 6th parameter ($priority) is not formally declared in the method signature to maintain compatibility with
 		// third-party subclasses created before this param was added.
 		$priority = func_num_args() >= 6 ? (int) func_get_arg( 5 ) : 10;

--- a/deprecated/ActionScheduler_Schedule_Deprecated.php
+++ b/deprecated/ActionScheduler_Schedule_Deprecated.php
@@ -13,7 +13,7 @@ abstract class ActionScheduler_Schedule_Deprecated implements ActionScheduler_Sc
 	 *
 	 * @return DateTime|null
 	 */
-	public function next( DateTime $after = null ) {
+	public function next( ?DateTime $after = null ) {
 		if ( empty( $after ) ) {
 			$return_value       = $this->get_date();
 			$replacement_method = 'get_date()';

--- a/lib/cron-expression/CronExpression.php
+++ b/lib/cron-expression/CronExpression.php
@@ -54,7 +54,7 @@ class CronExpression
      *
      * @return CronExpression
      */
-    public static function factory($expression, CronExpression_FieldFactory $fieldFactory = null)
+    public static function factory($expression, ?CronExpression_FieldFactory $fieldFactory = null)
     {
         $mappings = array(
             '@yearly' => '0 0 1 1 *',

--- a/tests/ActionScheduler_UnitTestCase.php
+++ b/tests/ActionScheduler_UnitTestCase.php
@@ -44,7 +44,7 @@ class ActionScheduler_UnitTestCase extends WP_UnitTestCase {
 	 *
 	 * @param null|\PHPUnit\Framework\TestResult $result Test result.
 	 */
-	public function run( PHPUnit\Framework\TestResult $result = null ): \PHPUnit\Framework\TestResult {
+	public function run( ?PHPUnit\Framework\TestResult $result = null ): \PHPUnit\Framework\TestResult {
 
 		if ( is_null( $result ) ) {
 			$result = $this->createResult();

--- a/tests/phpunit/ActionScheduler_Mocker.php
+++ b/tests/phpunit/ActionScheduler_Mocker.php
@@ -12,7 +12,7 @@ class ActionScheduler_Mocker {
 	 *
 	 * @param null|ActionScheduler_Store $store Store instance.
 	 */
-	public static function get_queue_runner( ActionScheduler_Store $store = null ) {
+	public static function get_queue_runner( ?ActionScheduler_Store $store = null ) {
 
 		if ( ! $store ) {
 			$store = ActionScheduler_Store::instance();

--- a/tests/phpunit/deprecated/ActionScheduler_UnitTestCase.php
+++ b/tests/phpunit/deprecated/ActionScheduler_UnitTestCase.php
@@ -45,7 +45,7 @@ class ActionScheduler_UnitTestCase extends WP_UnitTestCase {
 	 *
 	 * @param null|PHPUnit_Framework_TestResult $result Test result.
 	 */
-	public function run( PHPUnit_Framework_TestResult $result = null ) {
+	public function run( ?PHPUnit_Framework_TestResult $result = null ) {
 
 		if ( is_null( $result ) ) {
 			$result = $this->createResult();


### PR DESCRIPTION
Here we continue the work started in #1205, where most function parameters that are implicitly nullable were explicitly marked as nullable. That is, function definitions such as 

```
public function __construct( ActionScheduler_Store $store = null, $batch_size = 20 )
```

were turned into

```
public function __construct( ?ActionScheduler_Store $store = null, $batch_size = 20 ) {
```

(Notice the type change in the `$store` argument).

We missed a couple instances of these nullable args in the prior PR and so that's what this one adds. The aim is to reduce noise when running A-S (or a plugin that bundles A-S) under PHP 8.4.
