### PR TITLE
Display name of source of Action Scheduler library

### DIFF
--- a/classes/ActionScheduler_AdminView.php
+++ b/classes/ActionScheduler_AdminView.php
@@ -250,8 +250,19 @@ class ActionScheduler_AdminView extends ActionScheduler_AdminView_Deprecated {
 			return;
 		}
 
-		$as_version = ActionScheduler_Versions::instance()->latest_version();
-		$as_source  = ActionScheduler_Versions::instance()->active_source();
+		$as_version       = ActionScheduler_Versions::instance()->latest_version();
+		$as_source        = ActionScheduler_Versions::instance()->active_source();
+		$as_source_path   = ActionScheduler_Versions::instance()->active_source_path();
+		$as_source_markup = sprintf( '<code>%s</code>', esc_html( $as_source_path ) );
+
+		if ( ! empty( $as_source ) ) {
+			$as_source_markup = sprintf(
+				'%s: <abbr title="%s">%s</abbr>',
+				ucfirst( $as_source['type'] ),
+				esc_attr( $as_source_path ),
+				esc_html( $as_source['name'] )
+			);
+		}
 
 		$screen->add_help_tab(
 			array(
@@ -267,7 +278,7 @@ class ActionScheduler_AdminView extends ActionScheduler_AdminView_Deprecated {
 					'<p>' .
 						esc_html__( 'Action Scheduler is currently being loaded from the following location. This can be useful when debugging, or if requested by the support team.', 'action-scheduler' ) .
 					'</p>' .
-					'<p><code>' . esc_html( $as_source ) . '</code></p>' .
+					'<p>' . $as_source_markup . '</p>' .
 					'<h3>' . esc_html__( 'WP CLI', 'action-scheduler' ) . '</h3>' .
 					'<p>' .
 						sprintf(

--- a/classes/ActionScheduler_Versions.php
+++ b/classes/ActionScheduler_Versions.php
@@ -110,11 +110,21 @@ class ActionScheduler_Versions {
 	}
 
 	/**
-	 * Get directory of active source.
+	 * Returns information about the plugin or theme which contains the current active version
+	 * of Action Scheduler.
 	 *
-	 * @return string
+	 * If this cannot be determined, or if Action Scheduler is being loaded via some other
+	 * method, then it will return an empty array. Otherwise, if populated, the array will
+	 * look like the following:
+	 *
+	 *     [
+	 *         'type' => 'plugin', # or 'theme'
+	 *         'name' => 'Name',
+	 *     ]
+	 *
+	 * @return array
 	 */
-	public function active_source() {
+	public function active_source(): array {
 		$file         = __FILE__;
 		$dir          = __DIR__;
 		$plugins      = get_plugins();
@@ -157,6 +167,7 @@ class ActionScheduler_Versions {
 
 			return array(
 				'type' => 'theme',
+				// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 				'name' => $theme->Name,
 			);
 		}
@@ -164,7 +175,12 @@ class ActionScheduler_Versions {
 		return array();
 	}
 
-	public function active_source_path() {
+	/**
+	 * Returns the directory path for the currently active installation of Action Scheduler.
+	 *
+	 * @return string
+	 */
+	public function active_source_path(): string {
 		return trailingslashit( dirname( __DIR__ ) );
 	}
 }

--- a/classes/ActionScheduler_Versions.php
+++ b/classes/ActionScheduler_Versions.php
@@ -115,6 +115,58 @@ class ActionScheduler_Versions {
 	 * @return string
 	 */
 	public function active_source() {
+		$file   = __FILE__;
+		$dir    = __DIR__;
+		$path   = $this->active_source_path();
+		$themes = (array) search_theme_directories();
+
+		foreach ( $themes as $slug => $data ) {
+			$needle = trailingslashit( $data['theme_root'] ) . $slug . '/';
+
+			if ( 0 !== strpos( $file, $needle ) ) {
+				continue;
+			}
+
+			$theme = wp_get_theme( $slug );
+
+			if ( ! is_object( $theme ) || ! is_a( $theme, \WP_Theme::class ) ) {
+				continue;
+			}
+
+			return array(
+				'type' => 'theme',
+				'name' => $theme->Name,
+			);
+		}
+
+		$plugins      = get_plugins();
+		$plugin_files = array_keys( $plugins );
+		$plugin_paths = array();
+
+		foreach ( $plugin_files as $plugin_file ) {
+			$plugin_path = trailingslashit( WP_PLUGIN_DIR ) . dirname( $plugin_file );
+			$plugin_file = trailingslashit( WP_PLUGIN_DIR ) . $plugin_file;
+
+			if ( 0 !== strpos( dirname( $dir ), $plugin_path ) ) {
+				continue;
+			}
+
+			$plugin_data = get_plugin_data( $plugin_file );
+
+			if ( ! is_array( $plugin_data ) || empty( $plugin_data['Name'] ) ) {
+				continue;
+			}
+
+			return array(
+				'type' => 'plugin',
+				'name' => $plugin_data['Name'],
+			);
+		}
+
+		return array();
+	}
+
+	public function active_source_path() {
 		return trailingslashit( dirname( __DIR__ ) );
 	}
 }

--- a/classes/ActionScheduler_Versions.php
+++ b/classes/ActionScheduler_Versions.php
@@ -117,7 +117,6 @@ class ActionScheduler_Versions {
 	public function active_source() {
 		$file   = __FILE__;
 		$dir    = __DIR__;
-		$path   = $this->active_source_path();
 		$themes = (array) search_theme_directories();
 
 		foreach ( $themes as $slug => $data ) {
@@ -141,7 +140,6 @@ class ActionScheduler_Versions {
 
 		$plugins      = get_plugins();
 		$plugin_files = array_keys( $plugins );
-		$plugin_paths = array();
 
 		foreach ( $plugin_files as $plugin_file ) {
 			$plugin_path = trailingslashit( WP_PLUGIN_DIR ) . dirname( $plugin_file );

--- a/classes/ActionScheduler_Versions.php
+++ b/classes/ActionScheduler_Versions.php
@@ -115,29 +115,8 @@ class ActionScheduler_Versions {
 	 * @return string
 	 */
 	public function active_source() {
-		$file   = __FILE__;
-		$dir    = __DIR__;
-		$themes = (array) search_theme_directories();
-
-		foreach ( $themes as $slug => $data ) {
-			$needle = trailingslashit( $data['theme_root'] ) . $slug . '/';
-
-			if ( 0 !== strpos( $file, $needle ) ) {
-				continue;
-			}
-
-			$theme = wp_get_theme( $slug );
-
-			if ( ! is_object( $theme ) || ! is_a( $theme, \WP_Theme::class ) ) {
-				continue;
-			}
-
-			return array(
-				'type' => 'theme',
-				'name' => $theme->Name,
-			);
-		}
-
+		$file         = __FILE__;
+		$dir          = __DIR__;
 		$plugins      = get_plugins();
 		$plugin_files = array_keys( $plugins );
 
@@ -158,6 +137,27 @@ class ActionScheduler_Versions {
 			return array(
 				'type' => 'plugin',
 				'name' => $plugin_data['Name'],
+			);
+		}
+
+		$themes = (array) search_theme_directories();
+
+		foreach ( $themes as $slug => $data ) {
+			$needle = trailingslashit( $data['theme_root'] ) . $slug . '/';
+
+			if ( 0 !== strpos( $file, $needle ) ) {
+				continue;
+			}
+
+			$theme = wp_get_theme( $slug );
+
+			if ( ! is_object( $theme ) || ! is_a( $theme, \WP_Theme::class ) ) {
+				continue;
+			}
+
+			return array(
+				'type' => 'theme',
+				'name' => $theme->Name,
 			);
 		}
 

--- a/classes/WP_CLI/System_Command.php
+++ b/classes/WP_CLI/System_Command.php
@@ -148,7 +148,7 @@ class System_Command {
 		$all      = (bool) get_flag_value( $assoc_args, 'all' );
 		$fullpath = (bool) get_flag_value( $assoc_args, 'fullpath' );
 		$versions = \ActionScheduler_Versions::instance();
-		$source   = $versions->active_source();
+		$source   = $versions->active_source_path();
 		$path     = $source;
 
 		if ( ! $fullpath ) {


### PR DESCRIPTION
See #772.

---

![as-help-pulldown](https://github.com/user-attachments/assets/481e386d-afe3-4ca2-82c0-2efd81892d69)

Information about the active version of Action Scheduler can now be found under the **Source** heading, via the **Help** pulldown found in the **Tools ‣ Scheduled Actions** screen.

### Changelog

> Add - Added additional information about the active copy of Action Scheduler to the Help pulldown.