### PR TITLE
Added SVN to the environment to fix the CI fail

### DIFF
--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -81,6 +81,9 @@ jobs:
             mv /tmp/phpunit ./vendor/bin/phpunit
           fi
 
+      - name: Install Subversion
+        run: sudo apt-get update && sudo apt-get install -y subversion
+
       - name: Init DB and WP
         run: ./tests/bin/install.sh woo_test root root 127.0.0.1 ${{ matrix.wp }}
 


### PR DESCRIPTION
We have CI failing due to SVN missing from the environment. This PR adds it for the workflow run.

## Test

CI passes for this PR, but fails for other PRs