### PR TITLE
Make version/source information available via new class

### DIFF
--- a/classes/ActionScheduler_AdminView.php
+++ b/classes/ActionScheduler_AdminView.php
@@ -251,8 +251,8 @@ class ActionScheduler_AdminView extends ActionScheduler_AdminView_Deprecated {
 		}
 
 		$as_version       = ActionScheduler_Versions::instance()->latest_version();
-		$as_source        = ActionScheduler_Versions::instance()->active_source();
-		$as_source_path   = ActionScheduler_Versions::instance()->active_source_path();
+		$as_source        = ActionScheduler_SystemInformation::active_source();
+		$as_source_path   = ActionScheduler_SystemInformation::active_source_path();
 		$as_source_markup = sprintf( '<code>%s</code>', esc_html( $as_source_path ) );
 
 		if ( ! empty( $as_source ) ) {

--- a/classes/ActionScheduler_SystemInformation.php
+++ b/classes/ActionScheduler_SystemInformation.php
@@ -80,6 +80,10 @@ class ActionScheduler_SystemInformation {
 	/**
 	 * Get registered sources.
 	 *
+	 * It is not always possible to obtain this information. For instance, if earlier versions (<=3.9.0) of
+	 * Action Scheduler register themselves first, then the necessary data about registered sources will
+	 * not be available.
+	 *
 	 * @return array<string, string>
 	 */
 	public static function get_sources() {

--- a/classes/ActionScheduler_SystemInformation.php
+++ b/classes/ActionScheduler_SystemInformation.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * Provides information about active and registered instances of Action Scheduler.
+ */
+class ActionScheduler_SystemInformation {
+	/**
+	 * Returns information about the plugin or theme which contains the current active version
+	 * of Action Scheduler.
+	 *
+	 * If this cannot be determined, or if Action Scheduler is being loaded via some other
+	 * method, then it will return an empty array. Otherwise, if populated, the array will
+	 * look like the following:
+	 *
+	 *     [
+	 *         'type' => 'plugin', # or 'theme'
+	 *         'name' => 'Name',
+	 *     ]
+	 *
+	 * @return array
+	 */
+	public static function active_source(): array {
+		$plugins      = get_plugins();
+		$plugin_files = array_keys( $plugins );
+
+		foreach ( $plugin_files as $plugin_file ) {
+			$plugin_path = trailingslashit( WP_PLUGIN_DIR ) . dirname( $plugin_file );
+			$plugin_file = trailingslashit( WP_PLUGIN_DIR ) . $plugin_file;
+
+			if ( 0 !== strpos( dirname( __DIR__ ), $plugin_path ) ) {
+				continue;
+			}
+
+			$plugin_data = get_plugin_data( $plugin_file );
+
+			if ( ! is_array( $plugin_data ) || empty( $plugin_data['Name'] ) ) {
+				continue;
+			}
+
+			return array(
+				'type' => 'plugin',
+				'name' => $plugin_data['Name'],
+			);
+		}
+
+		$themes = (array) search_theme_directories();
+
+		foreach ( $themes as $slug => $data ) {
+			$needle = trailingslashit( $data['theme_root'] ) . $slug . '/';
+
+			if ( 0 !== strpos( __FILE__, $needle ) ) {
+				continue;
+			}
+
+			$theme = wp_get_theme( $slug );
+
+			if ( ! is_object( $theme ) || ! is_a( $theme, \WP_Theme::class ) ) {
+				continue;
+			}
+
+			return array(
+				'type' => 'theme',
+				// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+				'name' => $theme->Name,
+			);
+		}
+
+		return array();
+	}
+
+	/**
+	 * Returns the directory path for the currently active installation of Action Scheduler.
+	 *
+	 * @return string
+	 */
+	public static function active_source_path(): string {
+		return trailingslashit( dirname( __DIR__ ) );
+	}
+
+	/**
+	 * Get registered sources.
+	 *
+	 * @return array<string, string>
+	 */
+	public static function get_sources() {
+		$versions = ActionScheduler_Versions::instance();
+		return method_exists( $versions, 'get_sources' ) ? $versions->get_sources() : array();
+	}
+}

--- a/classes/ActionScheduler_Versions.php
+++ b/classes/ActionScheduler_Versions.php
@@ -133,7 +133,7 @@ class ActionScheduler_Versions {
 	 * @return array
 	 */
 	public function active_source(): array {
-		_deprecated_function( __METHOD__, '3.9.1', 'ActionScheduler_SystemInformation::active_source()' );
+		_deprecated_function( __METHOD__, '3.9.2', 'ActionScheduler_SystemInformation::active_source()' );
 		return ActionScheduler_SystemInformation::active_source();
 	}
 

--- a/classes/ActionScheduler_Versions.php
+++ b/classes/ActionScheduler_Versions.php
@@ -145,7 +145,7 @@ class ActionScheduler_Versions {
 	 * @return string
 	 */
 	public function active_source_path(): string {
-		_deprecated_function( __METHOD__, '3.9.1', 'ActionScheduler_SystemInformation::active_source_path()' );
+		_deprecated_function( __METHOD__, '3.9.2', 'ActionScheduler_SystemInformation::active_source_path()' );
 		return ActionScheduler_SystemInformation::active_source_path();
 	}
 }

--- a/classes/ActionScheduler_Versions.php
+++ b/classes/ActionScheduler_Versions.php
@@ -55,6 +55,12 @@ class ActionScheduler_Versions {
 	/**
 	 * Get registered sources.
 	 *
+	 * Use with caution: this method is only available as of Action Scheduler's 3.9.1
+	 * release and, owing to the way Action Scheduler is loaded, it's possible that the
+	 * class definition used at runtime will belong to an earlier version.
+	 *
+	 * @since 3.9.1
+	 *
 	 * @return array<string, string>
 	 */
 	public function get_sources() {
@@ -122,65 +128,24 @@ class ActionScheduler_Versions {
 	 *         'name' => 'Name',
 	 *     ]
 	 *
+	 * @deprecated 3.9.1 Use ActionScheduler_SystemInformation::active_source().
+	 *
 	 * @return array
 	 */
 	public function active_source(): array {
-		$file         = __FILE__;
-		$dir          = __DIR__;
-		$plugins      = get_plugins();
-		$plugin_files = array_keys( $plugins );
-
-		foreach ( $plugin_files as $plugin_file ) {
-			$plugin_path = trailingslashit( WP_PLUGIN_DIR ) . dirname( $plugin_file );
-			$plugin_file = trailingslashit( WP_PLUGIN_DIR ) . $plugin_file;
-
-			if ( 0 !== strpos( dirname( $dir ), $plugin_path ) ) {
-				continue;
-			}
-
-			$plugin_data = get_plugin_data( $plugin_file );
-
-			if ( ! is_array( $plugin_data ) || empty( $plugin_data['Name'] ) ) {
-				continue;
-			}
-
-			return array(
-				'type' => 'plugin',
-				'name' => $plugin_data['Name'],
-			);
-		}
-
-		$themes = (array) search_theme_directories();
-
-		foreach ( $themes as $slug => $data ) {
-			$needle = trailingslashit( $data['theme_root'] ) . $slug . '/';
-
-			if ( 0 !== strpos( $file, $needle ) ) {
-				continue;
-			}
-
-			$theme = wp_get_theme( $slug );
-
-			if ( ! is_object( $theme ) || ! is_a( $theme, \WP_Theme::class ) ) {
-				continue;
-			}
-
-			return array(
-				'type' => 'theme',
-				// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-				'name' => $theme->Name,
-			);
-		}
-
-		return array();
+		_deprecated_function( __METHOD__, '3.9.1', 'ActionScheduler_SystemInformation::active_source()' );
+		return ActionScheduler_SystemInformation::active_source();
 	}
 
 	/**
 	 * Returns the directory path for the currently active installation of Action Scheduler.
 	 *
+	 * @deprecated 3.9.2 Use ActionScheduler_SystemInformation::active_source_path().
+	 *
 	 * @return string
 	 */
 	public function active_source_path(): string {
-		return trailingslashit( dirname( __DIR__ ) );
+		_deprecated_function( __METHOD__, '3.9.1', 'ActionScheduler_SystemInformation::active_source_path()' );
+		return ActionScheduler_SystemInformation::active_source_path();
 	}
 }

--- a/classes/ActionScheduler_Versions.php
+++ b/classes/ActionScheduler_Versions.php
@@ -128,7 +128,7 @@ class ActionScheduler_Versions {
 	 *         'name' => 'Name',
 	 *     ]
 	 *
-	 * @deprecated 3.9.1 Use ActionScheduler_SystemInformation::active_source().
+	 * @deprecated 3.9.2 Use ActionScheduler_SystemInformation::active_source().
 	 *
 	 * @return array
 	 */

--- a/classes/WP_CLI/System_Command.php
+++ b/classes/WP_CLI/System_Command.php
@@ -5,6 +5,7 @@ namespace Action_Scheduler\WP_CLI;
 // phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaping output is not necessary in WP CLI.
 
 use ActionScheduler_SystemInformation;
+use WP_CLI;
 use function \WP_CLI\Utils\get_flag_value;
 
 /**
@@ -161,7 +162,13 @@ class System_Command {
 		}
 
 		$sources = ActionScheduler_SystemInformation::get_sources();
-		$rows    = array();
+
+		if ( empty( $sources ) ) {
+			WP_CLI::log( __( 'Detailed information about registered sources is not currently available.', 'action-scheduler' ) );
+			return;
+		}
+
+		$rows = array();
 
 		foreach ( $sources as $check_source => $version ) {
 			$active = dirname( $check_source ) === $source;

--- a/classes/WP_CLI/System_Command.php
+++ b/classes/WP_CLI/System_Command.php
@@ -4,6 +4,7 @@ namespace Action_Scheduler\WP_CLI;
 
 // phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaping output is not necessary in WP CLI.
 
+use ActionScheduler_SystemInformation;
 use function \WP_CLI\Utils\get_flag_value;
 
 /**
@@ -99,7 +100,7 @@ class System_Command {
 	 */
 	public function version( array $args, array $assoc_args ) {
 		$all    = (bool) get_flag_value( $assoc_args, 'all' );
-		$latest = $this->get_latest_version( $instance );
+		$latest = $this->get_latest_version();
 
 		if ( ! $all ) {
 			echo $latest;
@@ -139,7 +140,7 @@ class System_Command {
 	 *
 	 * @param array $args       Positional args.
 	 * @param array $assoc_args Keyed args.
-	 * @uses \ActionScheduler_Versions::get_sources()
+	 * @uses ActionScheduler_SystemInformation::active_source_path()
 	 * @uses \WP_CLI\Formatter::display_items()
 	 * @uses $this->get_latest_version()
 	 * @return void
@@ -147,8 +148,7 @@ class System_Command {
 	public function source( array $args, array $assoc_args ) {
 		$all      = (bool) get_flag_value( $assoc_args, 'all' );
 		$fullpath = (bool) get_flag_value( $assoc_args, 'fullpath' );
-		$versions = \ActionScheduler_Versions::instance();
-		$source   = $versions->active_source_path();
+		$source   = ActionScheduler_SystemInformation::active_source_path();
 		$path     = $source;
 
 		if ( ! $fullpath ) {
@@ -160,7 +160,7 @@ class System_Command {
 			\WP_CLI::halt( 0 );
 		}
 
-		$sources = $versions->get_sources();
+		$sources = ActionScheduler_SystemInformation::get_sources();
 		$rows    = array();
 
 		foreach ( $sources as $check_source => $version ) {


### PR DESCRIPTION
It was though that it could be helpful to add additional information to the *help* pull down (in the **Tools ‣ Scheduled Actions** screen) and via WP CLI about the current version and registered sources of Action Scheduler. This work mostly happened via:

- https://github.com/woocommerce/action-scheduler/pull/1218
- https://github.com/woocommerce/action-scheduler/pull/1219

<div align="center"><img src="https://github.com/user-attachments/assets/efa844e5-e99d-4531-b37c-8dfef1df7ddc" width="600" alt="'Help' pulldown, showing information about the Action Scheduler version" /></div>

As noted in the [linked issue](https://github.com/woocommerce/action-scheduler/issues/1236), however, this causes a problem because the methods newly added to `ActionScheduler_Versions` will not always be available (if an older version of Action Scheduler is the first to be initialized, then *its* version of that class is the one that is defined). In such a case, we experience fatal errors:

- When the **Tools ‣ Scheduled Actions** screen is visited.
- When a user executes `wp action-scheduler sources`.

This PR attempts to correct the problem by:

- Moving the new methods to a new class. We can be confident this will be available and will belong to the active version of Action Scheduler.
- Deprecates the corresponding methods in `ActionScheduler_Versions` (with one exception, where we add a warning).

However, I also understand it may be preferable to simply revert the changes (...though, the longer 3.9.1 is live, the more problematic it is to strip out public methods).

Closes https://github.com/woocommerce/action-scheduler/issues/1236.

---

### Testing instructions

1. Create a plugin as follows, and run `composer install`. I recommend initially creating it within a folder named `aaa-test`. The main plugin file can simply be named `test.php`.

```php
<?php
/**
 * Plugin name: Test plugin
 */

require __DIR__ . '/vendor/woocommerce/action-scheduler/action-scheduler.php';
```

```json
{
    "require": {
        "woocommerce/action-scheduler": "3.8.2"
    }
}
```

2. Go ahead and activate it, then install and activate Action Scheduler as a standalone plugin. To avoid confusion, deactivate any other plugins besides these two.
3. Visit **Tools ‣ Scheduled Actions**:
    1. Without this branch, it will be broken (fatal error).
    2. With this branch, there should be no problem.
4. Run `wp action-scheduler source --all`:
    1. Without this branch, it will be broken (fatal error).
    2. With this branch, it should inform you that _detailed information about registered sources is not currently available._
5. Rename `aaa-test` to `zzz-test` and reactivate it.
6. Repeat the above tests:
    1. With and without this branch, there should be no fatal errors (that's because the *newer* versions class has been loaded).
    2. There is a slight difference in the case of the WP CLI command. This time you should get a list detailing both plugins:

```
% wp action-scheduler source --all

Please note there can only be one unique registered instance of Action Scheduler per 
version number, so this list may not include all the currently present copies of 
Action Scheduler.

+------------------------------------------------------------------------------------+---------+--------+
| source                                                                             | version | active |
+------------------------------------------------------------------------------------+---------+--------+
| wp-content/plugins/action-scheduler/action-scheduler.php                           | 3.9.0   | no     |
| wp-content/plugins/zztest/vendor/woocommerce/action-scheduler/action-scheduler.php | 3.8.2   | no     |
+------------------------------------------------------------------------------------+---------+--------+
```