### PR TITLE
Assume an action is valid until proven otherwise

### DIFF
--- a/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php
+++ b/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php
@@ -86,15 +86,16 @@ abstract class ActionScheduler_Abstract_QueueRunner extends ActionScheduler_Abst
 		 */
 		try {
 			try {
-				$valid_action = false;
+				$valid_action = true;
+
 				do_action( 'action_scheduler_before_execute', $action_id, $context );
 
 				if ( ActionScheduler_Store::STATUS_PENDING !== $this->store->get_status( $action_id ) ) {
+					$valid_action = false;
 					do_action( 'action_scheduler_execution_ignored', $action_id, $context );
 					return;
 				}
 
-				$valid_action = true;
 				do_action( 'action_scheduler_begin_execute', $action_id, $context );
 
 				$action = $this->store->fetch_action( $action_id );


### PR DESCRIPTION
This way, if an error is thrown before the validation happens, the error handler will still attempt to set the action's status as failed instead of just skipping over it.

Fixes #1245

## To test

Follow the reproduction steps in #1245. With this PR branch checked out, instead of an endless loop, you should get some error messages in the cli buffer, and the actions should only get processed once.