### PR TITLE
Only release claims on pending actions.

### DIFF
--- a/classes/ActionScheduler_wcSystemStatus.php
+++ b/classes/ActionScheduler_wcSystemStatus.php
@@ -76,7 +76,6 @@ class ActionScheduler_wcSystemStatus {
 
 		$action = $this->store->query_actions(
 			array(
-				'claimed'  => false,
 				'status'   => $status,
 				'per_page' => 1,
 				'order'    => $order,

--- a/classes/WP_CLI/System_Command.php
+++ b/classes/WP_CLI/System_Command.php
@@ -262,7 +262,6 @@ class System_Command {
 		$order = 'oldest' === $date_type ? 'ASC' : 'DESC';
 
 		$args = array(
-			'claimed'  => false,
 			'status'   => $status,
 			'per_page' => 1,
 			'order'    => $order,

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -1094,7 +1094,7 @@ AND `group_id` = %d
 	}
 
 	/**
-	 * Release actions from a claim and delete the claim.
+	 * Release pending actions from a claim and delete the claim.
 	 *
 	 * @param ActionScheduler_ActionClaim $claim Claim object.
 	 * @throws \RuntimeException When unable to release actions from claim.
@@ -1107,14 +1107,21 @@ AND `group_id` = %d
 		 */
 		global $wpdb;
 
+		if ( 0 === intval( $claim->get_id() ) ) {
+			// Verify that the claim_id is valid before attempting to release it.
+			return;
+		}
+
 		/**
 		 * Deadlock warning: This function modifies actions to release them from claims that have been processed. Earlier, we used to it in a atomic query, i.e. we would update all actions belonging to a particular claim_id with claim_id = 0.
 		 * While this was functionally correct, it would cause deadlock, since this update query will hold a lock on the claim_id_.. index on the action table.
 		 * This allowed the possibility of a race condition, where the claimer query is also running at the same time, then the claimer query will also try to acquire a lock on the claim_id_.. index, and in this case if claim release query has already progressed to the point of acquiring the lock, but have not updated yet, it would cause a deadlock.
 		 *
 		 * We resolve this by getting all the actions_id that we want to release claim from in a separate query, and then releasing the claim on each of them. This way, our lock is acquired on the action_id index instead of the claim_id index. Note that the lock on claim_id will still be acquired, but it will only when we actually make the update, rather than when we select the actions.
+		 *
+		 * We only release pending actions in order for them to be claimed by another process.
 		 */
-		$action_ids = $wpdb->get_col( $wpdb->prepare( "SELECT action_id FROM {$wpdb->actionscheduler_actions} WHERE claim_id = %d", $claim->get_id() ) );
+		$action_ids = $wpdb->get_col( $wpdb->prepare( "SELECT action_id FROM {$wpdb->actionscheduler_actions} WHERE claim_id = %d AND status = %s", $claim->get_id(), self::STATUS_PENDING ) );
 
 		$row_updates = 0;
 		if ( count( $action_ids ) > 0 ) {

--- a/classes/data-stores/ActionScheduler_HybridStore.php
+++ b/classes/data-stores/ActionScheduler_HybridStore.php
@@ -432,7 +432,7 @@ class ActionScheduler_HybridStore extends Store {
 	}
 
 	/**
-	 * Release a claim in the table data store.
+	 * Release a claim in the table data store on any pending actions.
 	 *
 	 * @param ActionScheduler_ActionClaim $claim Claim object.
 	 */


### PR DESCRIPTION
Fixes: #1105, improves #1104

The current query for claiming actions can get really slow for a sites that process a ton of actions.  Part of the cause to this is that all actions are reset back to claim_id `0` after a batch is processed.  This increases the amount of time needed to query the pending actions that need to be claimed because the initial segment of the index used to claim actions is heavily seeded with `0` values causing the optimizer to frequently choose a less performant index.

This improves that by no longer resetting the claim_id of completed or running actions back to `0` when a claim is released.  Since only `pending` actions are still processed, leaving these with their old shouldn't cause any side-effects, and if anything improves debugging potential issues since the original claim that processed any actions will still be present.

Testing Instructions:

1. Clear out any existing completed or failed actions that are already set to `claim_id=0` or take note of the current count to verify the results of the changes later:
  ```sql
-- Remove Existing:
DELETE from wp_actionscheduler_actions where claim_id = 0 and status != 'pending';
 -- Get the count:
SELECT count(*) from wp_actionscheduler_actions where claim_id = 0 and status != 'pending';
  ```
2. Generate actions to be processed.  You can use the code below in a `mu-plugins` file and a wp-cli command `wp generate_actions` to create a bunch of pseudo actions to be processed.

```php
/**
 * Actions used for testing.
 */
function schedule_random_action() {

	$foo         = rand( 0, 10000 );
	$priority    = rand( 0, 255 );
	$time_offset = rand( 1, 24 ) * HOUR_IN_SECONDS;

	return as_schedule_single_action( time() + $time_offset, 'as_performance_testing_action', array( 'foo' => $foo ), '', false, $priority );
}

// The action has to have a callback to avoid being marked as failed.
add_action( 'as_performance_testing_action', function() {
  // do nothing.
});


if ( class_exists( 'WP_CLI' ) ) {
	/**
	 * Generate 50K actions for testing.  These are no-op callbacks so that we're testing the load of scheduling, not the actions themselves.
	 *
	 * Example:
	 *  wp generate_actions
	 */
	WP_CLI::add_command(
		'generate_actions',
		function () {
			if ( ! did_action( 'action_scheduler_init' ) ) {
				WP_CLI::error( 'ActionScheduler is not initialized!!!' );
			}

			global $wpdb;
			WP_CLI::line( ' current actions: ' . $wpdb->get_var( "SELECT COUNT(*) FROM wp_actionscheduler_actions" ) );

			$num_to_create = 50000;

			for ( $i = 0; $i < $num_to_create; $i ++ ) {
				if ( ! schedule_random_action() ) {
					WP_CLI::warning( 'action not created' );
				}
			}
			WP_CLI::success( "Created $num_to_create actions" );
		}
	);
}
```
3. Open the admin and allow the queue to process over time.
4. Verify that no new non-pending actions have a claim_id = 0:  `SELECT count(*) from wp_actionscheduler_actions where claim_id = 0 and status != 'pending'`.

Note that these changes will not effect actions that have already been completed or failed as those really no longer matter to the system and are only retained for a period of time for admin review.  They will eventually get cleaned up via a job.