### PR TITLE
Add index to actionscheduler_actions table to support prioritized claims

### DIFF
--- a/classes/schema/ActionScheduler_StoreSchema.php
+++ b/classes/schema/ActionScheduler_StoreSchema.php
@@ -20,7 +20,7 @@ class ActionScheduler_StoreSchema extends ActionScheduler_Abstract_Schema {
 	 *
 	 * @var int
 	 */
-	protected $schema_version = 7;
+	protected $schema_version = 8;
 
 	/**
 	 * Construct.
@@ -80,7 +80,7 @@ class ActionScheduler_StoreSchema extends ActionScheduler_Abstract_Schema {
 				        KEY args (args($max_index_length)),
 				        KEY group_id (group_id),
 				        KEY last_attempt_gmt (last_attempt_gmt),
-				        KEY `claim_id_status_scheduled_date_gmt` (`claim_id`, `status`, `scheduled_date_gmt`)
+				        KEY `claim_id_status_priority_attempts_scheduled_date_gmt` (`claim_id`, `status`, `priority`, attempts`, `scheduled_date_gmt`)
 				        ) $charset_collate";
 
 			case self::CLAIMS_TABLE:

--- a/classes/schema/ActionScheduler_StoreSchema.php
+++ b/classes/schema/ActionScheduler_StoreSchema.php
@@ -80,7 +80,7 @@ class ActionScheduler_StoreSchema extends ActionScheduler_Abstract_Schema {
 				        KEY args (args($max_index_length)),
 				        KEY group_id (group_id),
 				        KEY last_attempt_gmt (last_attempt_gmt),
-				        KEY `claim_id_status_priority_attempts_scheduled_date_gmt` (`claim_id`, `status`, `priority`, attempts`, `scheduled_date_gmt`)
+				        KEY `claim_id_status_priority_attempts_scheduled_date_gmt` (`claim_id`, `status`, `priority`, `attempts`, `scheduled_date_gmt`)
 				        ) $charset_collate";
 
 			case self::CLAIMS_TABLE:


### PR DESCRIPTION
Fixes #1104

This adds an index on wp_actionscheduler_actions that is able to support the query used to claim actions when running the queue.  The current default query runs as follows:

```
UPDATE wp_actionscheduler_actions SET claim_id=XXX, last_attempt_gmt='XXXX-XX-XX XX:XX:XX', last_attempt_local='XXXX-XX-XX XX:XX:XX' WHERE claim_id = 0 AND scheduled_date_gmt <= 'XXXX-XX-XX XX:XX:XX' AND status='pending' ORDER BY priority ASC, attempts ASC, scheduled_date_gmt ASC, action_id ASC LIMIT XX 
```

However, there is no query to support the ordering of these actions causing the table to lock for longer periods of time.

#921 Added priorities to scheduled actions and set the default order by clause to include the priority of actions when being claimed, `'ORDER BY priority ASC, attempts ASC, scheduled_date_gmt ASC, action_id ASC'`.  Though, I believe the locking was already an issue before that because there was no support for the `attempts` column.

The new `claim_id_status_priority_attempts_scheduled_date_gmt ` index replaces the previous `claim_id_status_scheduled_date_gmt` index.  I didn't come across any usage where the latter was needed.  Please help me verify.

Below is the analysis of both, the first using the new index while the second is the previous:

```
mysql> EXPLAIN ANALYZE select action_id from wp_actionscheduler_actions WHERE claim_id = 0 AND scheduled_date_gmt <= '2025-04-17 16:21:20' AND status='pending' ORDER BY priority ASC, attempts ASC, scheduled_date_gmt ASC, action_id ASC LIMIT 2\G
*************************** 1. row ***************************
EXPLAIN: -> Limit: 2 row(s)  (cost=119 rows=2) (actual time=0.121..0.136 rows=2 loops=1)
    -> Filter: ((wp_actionscheduler_actions.claim_id = 0) and (wp_actionscheduler_actions.scheduled_date_gmt <= TIMESTAMP'2025-04-17 16:21:20') and (wp_actionscheduler_actions.`status` = 'pending'))  (cost=119 rows=439) (actual time=0.117..0.131 rows=2 loops=1)
        -> Covering index skip scan on wp_actionscheduler_actions using claim_id_status_priority_attempts_scheduled_date_gmt over claim_id = 0, status = 'pending', NULL < scheduled_date_gmt <= '2025-04-17 16:21:20'  (cost=119 rows=439) (actual time=0.103..0.117 rows=2 loops=1)

1 row in set (0.00 sec)

mysql> EXPLAIN ANALYZE select action_id from wp_actionscheduler_actions USE INDEX (claim_id_status_scheduled_date_gmt) WHERE claim_id = 0 AND scheduled_date_gmt <= '2025-04-17 16:21:20' AND status='pending' ORDER BY priority ASC, attempts ASC, scheduled_date_gmt ASC, action_id ASC LIMIT 2\G
*************************** 1. row ***************************
EXPLAIN: -> Limit: 2 row(s)  (cost=1544 rows=2) (actual time=1.88..1.88 rows=2 loops=1)
    -> Sort: wp_actionscheduler_actions.priority, wp_actionscheduler_actions.attempts, wp_actionscheduler_actions.scheduled_date_gmt, wp_actionscheduler_actions.action_id, limit input to 2 row(s) per chunk  (cost=1544 rows=1320) (actual time=1.88..1.88 rows=2 loops=1)
        -> Index range scan on wp_actionscheduler_actions using claim_id_status_scheduled_date_gmt over (claim_id = 0 AND status = 'pending' AND NULL < scheduled_date_gmt <= '2025-04-17 16:21:20'), with index condition: ((wp_actionscheduler_actions.claim_id = 0) and (wp_actionscheduler_actions.scheduled_date_gmt <= TIMESTAMP'2025-04-17 16:21:20') and (wp_actionscheduler_actions.`status` = 'pending'))  (cost=1544 rows=1320) (actual time=0.173..1.62 rows=1320 loops=1)

1 row in set (0.00 sec)
```

Note, that DBDelta will not automatically delete the previous index from existing installs.  This will prevent the index from being removed if any sites have already added filters to the order by clause to address the performance issue.