### PR TITLE
Address deadlocking and performance issues around existing indexes and claiming process.

### DIFF
--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -3,7 +3,7 @@ on:
   pull_request
 jobs:
   test:
-    name: PHP ${{ matrix.php }} WP ${{ matrix.wp }} MU ${{ matrix.multisite }}
+    name: PHP ${{ matrix.php }} WP ${{ matrix.wp }} MU ${{ matrix.multisite }} DB ${{ matrix.db }}
     timeout-minutes: 15
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -30,8 +30,7 @@ jobs:
         ports:
           - 3306:3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5 --entrypoint mysqld
-        command: >-
-          --default-authentication-plugin=mysql_native_password
+        command: --default-authentication-plugin=mysql_native_password
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -29,8 +29,7 @@ jobs:
           MYSQL_ROOT_PASSWORD: root
         ports:
           - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5 --entrypoint mysqld
-        command: --default-authentication-plugin=mysql_native_password
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -87,7 +86,12 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y subversion
 
       - name: Init DB and WP
-        run: ./tests/bin/install.sh woo_test root root 127.0.0.1 ${{ matrix.wp }}
+        run: |
+          # Use mysql_native_password when using PHP < 7.4.
+          if [ "$(php -r "echo version_compare( PHP_VERSION, '7.4', '<' );")" ]; then
+            mysql -uroot -proot -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root'; FLUSH PRIVILEGES;"
+          fi
+          ./tests/bin/install.sh woo_test root root 127.0.0.1 ${{ matrix.wp }}
 
       - name: Run tests
         run: |

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -11,7 +11,8 @@ jobs:
       matrix:
         # We test against the earliest and latest PHP versions for each major supported version.
         php: [ '7.1', '7.4', '8.0', '8.3' ]
-        wp: [ '6.4', '6.5', '6.6', 'latest', 'nightly' ]
+        wp: [ '6.5', '6.6', 'latest', 'nightly' ]
+        db: [ 'mysql:5.6', 'mysql:8.1', 'mariadb:10.4', 'mariadb:10.6']
         multisite: [ '0', '1' ]
         exclude:
           # WordPress 6.6+ requires PHP 7.2+
@@ -23,7 +24,7 @@ jobs:
             wp: nightly
     services:
       database:
-        image: mysql:5.6
+        image: ${{ matrix.db }}
         env:
           MYSQL_ROOT_PASSWORD: root
         ports:

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Init DB and WP
         run: |
           # Use mysql_native_password when using PHP < 7.4.
-          f [ "$(php -r 'echo version_compare(PHP_VERSION, \"7.4\", \"<\");')" -eq 1 ] && [ "${{ matrix.db }}" == "mysql:8.1" ]; then
+          if [ "$(php -r 'echo version_compare(PHP_VERSION, \"7.4\", \"<\");')" -eq 1 ] && [ "${{ matrix.db }}" == "mysql:8.1" ]; then
             mysql -uroot -proot -h127.0.0.1 -e "ALTER USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root'; FLUSH PRIVILEGES;"
           fi
           ./tests/bin/install.sh woo_test root root 127.0.0.1 ${{ matrix.wp }}

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Init DB and WP
         run: |
           # Use mysql_native_password when using PHP < 7.4.
-          if [ "$(php -r 'echo version_compare(PHP_VERSION, \"7.4\", \"<\");')" -eq 1 ] && [ "${{ matrix.db }}" == "mysql:8.1" ]; then
+          if [ "$(php -r 'echo version_compare(PHP_VERSION, "7.4", "<");')" -eq 1 ] && [ "${{ matrix.db }}" == "mysql:8.1" ]; then
             mysql -uroot -proot -h127.0.0.1 -e "ALTER USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root'; FLUSH PRIVILEGES;"
           fi
           ./tests/bin/install.sh woo_test root root 127.0.0.1 ${{ matrix.wp }}

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -88,8 +88,8 @@ jobs:
       - name: Init DB and WP
         run: |
           # Use mysql_native_password when using PHP < 7.4.
-          if [ "$(php -r "echo version_compare( PHP_VERSION, '7.4', '<' );")" ]; then
-            mysql -uroot -proot -h127.0.0.1 -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root'; FLUSH PRIVILEGES;"
+          if [ "$(php -r "echo version_compare( PHP_VERSION, '7.4', '<' );")" &&  "${{ matrix.db }}" == "mysql:5.6" ]; then
+            mysql -uroot -proot -h127.0.0.1 -e "ALTER USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root'; FLUSH PRIVILEGES;"
           fi
           ./tests/bin/install.sh woo_test root root 127.0.0.1 ${{ matrix.wp }}
 

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -29,7 +29,9 @@ jobs:
           MYSQL_ROOT_PASSWORD: root
         ports:
           - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5 --default-authentication-plugin=mysql_native_password
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5 --entrypoint mysqld
+        command: >-
+          --default-authentication-plugin=mysql_native_password
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -89,7 +89,7 @@ jobs:
         run: |
           # Use mysql_native_password when using PHP < 7.4.
           if [ "$(php -r "echo version_compare( PHP_VERSION, '7.4', '<' );")" ]; then
-            mysql -uroot -proot -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root'; FLUSH PRIVILEGES;"
+            mysql -uroot -proot -h127.0.0.1 -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root'; FLUSH PRIVILEGES;"
           fi
           ./tests/bin/install.sh woo_test root root 127.0.0.1 ${{ matrix.wp }}
 

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -29,7 +29,7 @@ jobs:
           MYSQL_ROOT_PASSWORD: root
         ports:
           - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=5 --default-authentication-plugin=mysql_native_password
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Init DB and WP
         run: |
           # Use mysql_native_password when using PHP < 7.4.
-          if [ "$(php -r "echo version_compare( PHP_VERSION, '7.4', '<' );")" &&  "${{ matrix.db }}" == "mysql:8.1" ]; then
+          f [ "$(php -r 'echo version_compare(PHP_VERSION, \"7.4\", \"<\");')" -eq 1 ] && [ "${{ matrix.db }}" == "mysql:8.1" ]; then
             mysql -uroot -proot -h127.0.0.1 -e "ALTER USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root'; FLUSH PRIVILEGES;"
           fi
           ./tests/bin/install.sh woo_test root root 127.0.0.1 ${{ matrix.wp }}

--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Init DB and WP
         run: |
           # Use mysql_native_password when using PHP < 7.4.
-          if [ "$(php -r "echo version_compare( PHP_VERSION, '7.4', '<' );")" &&  "${{ matrix.db }}" == "mysql:5.6" ]; then
+          if [ "$(php -r "echo version_compare( PHP_VERSION, '7.4', '<' );")" &&  "${{ matrix.db }}" == "mysql:8.1" ]; then
             mysql -uroot -proot -h127.0.0.1 -e "ALTER USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'root'; FLUSH PRIVILEGES;"
           fi
           ./tests/bin/install.sh woo_test root root 127.0.0.1 ${{ matrix.wp }}

--- a/classes/ActionScheduler_DataController.php
+++ b/classes/ActionScheduler_DataController.php
@@ -162,10 +162,18 @@ class ActionScheduler_DataController {
 			return;
 		}
 
-		$wp_object_cache->group_ops      = array();
-		$wp_object_cache->stats          = array();
-		$wp_object_cache->memcache_debug = array();
-		$wp_object_cache->cache          = array();
+		if ( property_exists( $wp_object_cache, 'group_ops' ) ) {
+			$wp_object_cache->group_ops = array();
+		}
+		if ( property_exists( $wp_object_cache, 'stats' ) ) {
+			$wp_object_cache->stats = array();
+		}
+		if ( property_exists( $wp_object_cache, 'memcache_debug' ) ) {
+			$wp_object_cache->memcache_debug = array();
+		}
+		if ( property_exists( $wp_object_cache, 'cache' ) ) {
+			$wp_object_cache->cache = array();
+		}
 
 		if ( is_callable( array( $wp_object_cache, '__remoteset' ) ) ) {
 			call_user_func( array( $wp_object_cache, '__remoteset' ) ); // important!

--- a/classes/ActionScheduler_QueueCleaner.php
+++ b/classes/ActionScheduler_QueueCleaner.php
@@ -184,7 +184,7 @@ class ActionScheduler_QueueCleaner {
 				'modified_compare' => '<=',
 				'claimed'          => true,
 				'per_page'         => $this->get_batch_size(),
-				'orderby'          => 'none',
+				'orderby'          => 'modified', // ordering by modified coerces the optimizer to use `status_last_attempt_gmt` index.
 			)
 		);
 

--- a/classes/ActionScheduler_wcSystemStatus.php
+++ b/classes/ActionScheduler_wcSystemStatus.php
@@ -76,7 +76,6 @@ class ActionScheduler_wcSystemStatus {
 
 		$action = $this->store->query_actions(
 			array(
-				'claimed'  => false,
 				'status'   => $status,
 				'per_page' => 1,
 				'order'    => $order,

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -1004,8 +1004,7 @@ AND `group_id` = %d
 		 *
 		 * @since 3.4.0
 		 */
-		$order           = apply_filters( 'action_scheduler_claim_actions_order_by', 'ORDER BY priority ASC, attempts ASC, scheduled_date_gmt ASC, action_id ASC', $claim_id, $hooks );
-
+		$order       = apply_filters( 'action_scheduler_claim_actions_order_by', 'ORDER BY priority ASC, attempts ASC, scheduled_date_gmt ASC, action_id ASC', $claim_id, $hooks );
 		$skip_locked = $this->db_supports_skip_locked() ? ' SKIP LOCKED' : '';
 
 		// Selecting the action_ids that we plan to claim, while skipping any locked rows to avoid deadlocking.
@@ -1018,7 +1017,7 @@ AND `group_id` = %d
 			$now->format( 'Y-m-d H:i:s' ),
 			current_time( 'mysql' ),
 		);
-		$rows_affected =  $wpdb->query( $wpdb->prepare( $update_sql, $update_params ) );
+		$rows_affected = $wpdb->query( $wpdb->prepare( $update_sql, $update_params ) );
 		if ( false === $rows_affected ) {
 			$error = empty( $wpdb->last_error )
 				? _x( 'unknown', 'database error', 'action-scheduler' )
@@ -1066,7 +1065,7 @@ AND `group_id` = %d
 		 */
 		if ( $is_mariadb && version_compare( $db_version, '10.6.0', '>=' ) ) {
 			$is_supported = true;
-		} elseif ( version_compare( $db_version, '8.0.1', '>=' ) ) {
+		} elseif ( ! $is_mariadb && version_compare( $db_version, '8.0.1', '>=' ) ) {
 			/**
 			 * SKIP_LOCKED support was added to MySQL in 8.0.1
 			 */

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -936,12 +936,13 @@ AND `group_id` = %d
 		$date = is_null( $before_date ) ? $now : clone $before_date;
 		// can't use $wpdb->update() because of the <= condition.
 		$update = "UPDATE {$wpdb->actionscheduler_actions} SET claim_id=%d, last_attempt_gmt=%s, last_attempt_local=%s";
-		$params = array(
+		$update_params = array(
 			$claim_id,
 			$now->format( 'Y-m-d H:i:s' ),
 			current_time( 'mysql' ),
 		);
 
+		$where_params = array();
 		// Set claim filters.
 		if ( ! empty( $hooks ) ) {
 			$this->set_claim_filter( 'hooks', $hooks );
@@ -955,13 +956,13 @@ AND `group_id` = %d
 		}
 
 		$where    = 'WHERE claim_id = 0 AND scheduled_date_gmt <= %s AND status=%s';
-		$params[] = $date->format( 'Y-m-d H:i:s' );
-		$params[] = self::STATUS_PENDING;
+		$where_params[] = $date->format( 'Y-m-d H:i:s' );
+		$where_params[] = self::STATUS_PENDING;
 
 		if ( ! empty( $hooks ) ) {
 			$placeholders = array_fill( 0, count( $hooks ), '%s' );
 			$where       .= ' AND hook IN (' . join( ', ', $placeholders ) . ')';
-			$params       = array_merge( $params, array_values( $hooks ) );
+			$where_params       = array_merge( $where_params, array_values( $hooks ) );
 		}
 
 		$group_operator = 'IN';
@@ -977,7 +978,7 @@ AND `group_id` = %d
 			if ( empty( $group_ids ) ) {
 				throw new InvalidArgumentException(
 					sprintf(
-						/* translators: %s: group name(s) */
+					/* translators: %s: group name(s) */
 						_n(
 							'The group "%s" does not exist.',
 							'The groups "%s" do not exist.',
@@ -993,36 +994,90 @@ AND `group_id` = %d
 			$where  .= " AND group_id {$group_operator} ( $id_list )";
 		}
 
-		/**
-		 * Sets the order-by clause used in the action claim query.
-		 *
-		 * @since 3.4.0
-		 * @since 3.8.3 Made $claim_id and $hooks available.
-		 *
-		 * @param string $order_by_sql
-		 * @param string $claim_id Claim Id.
-		 * @param array  $hooks Hooks to filter for.
-		 */
-		$order    = apply_filters( 'action_scheduler_claim_actions_order_by', 'ORDER BY priority ASC, attempts ASC, scheduled_date_gmt ASC, action_id ASC', $claim_id, $hooks );
-		$params[] = $limit;
+		$use_priorities = true;
+		$total_rows_affected = 0;
+		if ( $use_priorities ) {
+			$pending_priorities = $wpdb->get_col( $wpdb->prepare( "SELECT DISTINCT priority FROM {$wpdb->actionscheduler_actions} FORCE INDEX (claim_id_status_priority_scheduled_date_gmt) {$where} ORDER BY priority", $where_params ) );
+			if ( empty( $pending_priorities ) ) {
+				return 0;
+			}
 
-		$sql           = $wpdb->prepare( "{$update} {$where} {$order} LIMIT %d", $params ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders
-		$rows_affected = $wpdb->query( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-		if ( false === $rows_affected ) {
-			$error = empty( $wpdb->last_error )
-				? _x( 'unknown', 'database error', 'action-scheduler' )
-				: $wpdb->last_error;
-
-			throw new \RuntimeException(
-				sprintf(
+			foreach ( $pending_priorities as $pending_priority ) {
+				$sql           = $wpdb->prepare( "{$update} {$where} AND priority = %d LIMIT %d",
+					[
+						...$update_params,
+						...$where_params,
+						$pending_priority,
+						$limit
+					]
+				); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders
+				$rows_affected = $wpdb->query( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+				if ( false === $rows_affected ) {
+					$error = sprintf(
 					/* translators: %s database error. */
-					__( 'Unable to claim actions. Database error: %s.', 'action-scheduler' ),
-					$error
-				)
-			);
+						__( 'Unable to claim actions. Database error: %s.', 'action-scheduler' ),
+						empty( $wpdb->last_error ) ? _x( 'unknown', 'database error', 'action-scheduler' ) : $wpdb->last_error
+					);
+
+					if ( $total_rows_affected === 0 ) {
+						// Throw an exception if we weren't able to claim any actions at all to reflect previous behavior,
+						// otherwise, just trigger a WARNING so the claimed actions can still be processed.
+						throw new \RuntimeException(
+							$error
+						);
+					}
+					// Trigger an error notice and allow the claim to proceed.
+					wp_trigger_error( __METHOD__, $error );
+					break;
+				}
+				$limit               -= $rows_affected;
+				$total_rows_affected += $rows_affected;
+				if ( $limit < 1 ) {
+					break;
+				}
+
+			}
+		} else {
+			/**
+			 * Sets the order-by clause used in the action claim query.
+			 *
+			 * @param string $order_by_sql
+			 * @param string $claim_id Claim Id.
+			 * @param array $hooks Hooks to filter for.
+			 *
+			 * @since 3.8.3 Made $claim_id and $hooks available.
+			 *
+			 * @since 3.4.0
+			 */
+			//$order    = apply_filters( 'action_scheduler_claim_actions_order_by', 'ORDER BY priority ASC, attempts ASC, scheduled_date_gmt ASC, action_id ASC', $claim_id, $hooks );
+			// take out schedule_date and action_id to see if that improves it.  Next step is to potentially assign priority and not order by it or attempts.
+			$order = apply_filters( 'action_scheduler_claim_actions_order_by', 'ORDER BY priority ASC', $claim_id, $hooks );
+
+			$sql = $wpdb->prepare(
+				"{$update} {$where} {$order} LIMIT %d",
+				[
+					...$update_params,
+					...$where_params,
+					$limit
+				]
+			); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders
+
+			$total_rows_affected = $wpdb->query( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			if ( false === $total_rows_affected ) {
+				$error = empty( $wpdb->last_error )
+					? _x( 'unknown', 'database error', 'action-scheduler' )
+					: $wpdb->last_error;
+				throw new \RuntimeException(
+					sprintf(
+						/* translators: %s database error. */
+						__( 'Unable to claim actions. Database error: %s.', 'action-scheduler' ),
+						$error
+					)
+				);
+			}
 		}
 
-		return (int) $rows_affected;
+		return (int) $total_rows_affected;
 	}
 
 	/**
@@ -1094,7 +1149,7 @@ AND `group_id` = %d
 	}
 
 	/**
-	 * Release actions from a claim and delete the claim.
+	 * Release pending actions from a claim and delete the claim.
 	 *
 	 * @param ActionScheduler_ActionClaim $claim Claim object.
 	 * @throws \RuntimeException When unable to release actions from claim.
@@ -1107,6 +1162,12 @@ AND `group_id` = %d
 		 */
 		global $wpdb;
 
+		if ( 0 === intval( $claim->get_id() ) ) {
+			// Verify that the claim_id is valid before attempting to release the actions tied to it in case a failed query
+			// created the invalid claim.
+			return;
+		}
+
 		/**
 		 * Deadlock warning: This function modifies actions to release them from claims that have been processed. Earlier, we used to it in a atomic query, i.e. we would update all actions belonging to a particular claim_id with claim_id = 0.
 		 * While this was functionally correct, it would cause deadlock, since this update query will hold a lock on the claim_id_.. index on the action table.
@@ -1114,7 +1175,7 @@ AND `group_id` = %d
 		 *
 		 * We resolve this by getting all the actions_id that we want to release claim from in a separate query, and then releasing the claim on each of them. This way, our lock is acquired on the action_id index instead of the claim_id index. Note that the lock on claim_id will still be acquired, but it will only when we actually make the update, rather than when we select the actions.
 		 */
-		$action_ids = $wpdb->get_col( $wpdb->prepare( "SELECT action_id FROM {$wpdb->actionscheduler_actions} WHERE claim_id = %d", $claim->get_id() ) );
+		$action_ids = $wpdb->get_col( $wpdb->prepare( "SELECT action_id FROM {$wpdb->actionscheduler_actions} WHERE claim_id = %d AND status = %s", $claim->get_id(), self::STATUS_PENDING ) );
 
 		$row_updates = 0;
 		if ( count( $action_ids ) > 0 ) {

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -931,7 +931,6 @@ AND `group_id` = %d
 		 * @var \wpdb $wpdb
 		 */
 		global $wpdb;
-
 		$now  = as_get_datetime_object();
 		$date = is_null( $before_date ) ? $now : clone $before_date;
 		// can't use $wpdb->update() because of the <= condition.
@@ -994,9 +993,9 @@ AND `group_id` = %d
 			$where  .= " AND group_id {$group_operator} ( $id_list )";
 		}
 
-		$use_priorities = true;
 		$total_rows_affected = 0;
-		if ( $use_priorities ) {
+		$claim_staking_method = defined('CLAIM_STAKING_METHOD') ? \CLAIM_STAKING_METHOD : '';
+		if ( $claim_staking_method == 'priority_list' ) {
 			$pending_priorities = $wpdb->get_col( $wpdb->prepare( "SELECT DISTINCT priority FROM {$wpdb->actionscheduler_actions} FORCE INDEX (claim_id_status_priority_scheduled_date_gmt) {$where} ORDER BY priority", $where_params ) );
 			if ( empty( $pending_priorities ) ) {
 				return 0;
@@ -1037,6 +1036,61 @@ AND `group_id` = %d
 				}
 
 			}
+		} elseif( $claim_staking_method == 'prequery') {
+			/**
+			 * Sets the order-by clause used in the action claim query.
+			 *
+			 * @param string $order_by_sql
+			 * @param string $claim_id Claim Id.
+			 * @param array $hooks Hooks to filter for.
+			 *
+			 * @since 3.8.3 Made $claim_id and $hooks available.
+			 *
+			 * @since 3.4.0
+			 */
+			$order    = apply_filters( 'action_scheduler_claim_actions_order_by', 'ORDER BY priority ASC, attempts ASC, scheduled_date_gmt ASC, action_id ASC', $claim_id, $hooks );
+
+			$action_ids = $wpdb->get_col(
+				$wpdb->prepare(
+					"SELECT action_id from {$wpdb->actionscheduler_actions} {$where} {$order} LIMIT %d",
+					[
+						...$where_params,
+						$limit
+					]
+				)
+			);
+
+			if ( empty( $action_ids ) ) {
+				return 0;
+			}
+
+
+			$placeholders = array_fill( 0, count( $action_ids ), '%d' );
+			$where        .= ' AND action_id IN (' . join( ', ', $placeholders ) . ')';
+			$where_params = array_merge( $where_params, array_values( $action_ids ) );
+
+			$sql = $wpdb->prepare(
+				"{$update} {$where} LIMIT %d",
+				[
+					...$update_params,
+					...$where_params,
+					$limit
+				]
+			); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders
+
+			$total_rows_affected = $wpdb->query( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			if ( false === $total_rows_affected ) {
+				$error = empty( $wpdb->last_error )
+					? _x( 'unknown', 'database error', 'action-scheduler' )
+					: $wpdb->last_error;
+				throw new \RuntimeException(
+					sprintf(
+					/* translators: %s database error. */
+						__( 'Unable to claim actions. Database error: %s.', 'action-scheduler' ),
+						$error
+					)
+				);
+			}
 		} else {
 			/**
 			 * Sets the order-by clause used in the action claim query.
@@ -1049,9 +1103,7 @@ AND `group_id` = %d
 			 *
 			 * @since 3.4.0
 			 */
-			//$order    = apply_filters( 'action_scheduler_claim_actions_order_by', 'ORDER BY priority ASC, attempts ASC, scheduled_date_gmt ASC, action_id ASC', $claim_id, $hooks );
-			// take out schedule_date and action_id to see if that improves it.  Next step is to potentially assign priority and not order by it or attempts.
-			$order = apply_filters( 'action_scheduler_claim_actions_order_by', 'ORDER BY priority ASC', $claim_id, $hooks );
+			$order    = apply_filters( 'action_scheduler_claim_actions_order_by', 'ORDER BY priority ASC, attempts ASC, scheduled_date_gmt ASC, action_id ASC', $claim_id, $hooks );
 
 			$sql = $wpdb->prepare(
 				"{$update} {$where} {$order} LIMIT %d",

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -993,143 +993,87 @@ AND `group_id` = %d
 			$where  .= " AND group_id {$group_operator} ( $id_list )";
 		}
 
-		$total_rows_affected = 0;
-		$claim_staking_method = defined('CLAIM_STAKING_METHOD') ? \CLAIM_STAKING_METHOD : '';
-		if ( $claim_staking_method == 'priority_list' ) {
-			$pending_priorities = $wpdb->get_col( $wpdb->prepare( "SELECT DISTINCT priority FROM {$wpdb->actionscheduler_actions} FORCE INDEX (claim_id_status_priority_scheduled_date_gmt) {$where} ORDER BY priority", $where_params ) );
-			if ( empty( $pending_priorities ) ) {
-				return 0;
-			}
+		/**
+		 * Sets the order-by clause used in the action claim query.
+		 *
+		 * @param string $order_by_sql
+		 * @param string $claim_id Claim Id.
+		 * @param array $hooks Hooks to filter for.
+		 *
+		 * @since 3.8.3 Made $claim_id and $hooks available.
+		 *
+		 * @since 3.4.0
+		 */
+		$order           = apply_filters( 'action_scheduler_claim_actions_order_by', 'ORDER BY priority ASC, attempts ASC, scheduled_date_gmt ASC, action_id ASC', $claim_id, $hooks );
 
-			foreach ( $pending_priorities as $pending_priority ) {
-				$sql           = $wpdb->prepare( "{$update} {$where} AND priority = %d LIMIT %d",
-					[
-						...$update_params,
-						...$where_params,
-						$pending_priority,
-						$limit
-					]
-				); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders
-				$rows_affected = $wpdb->query( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-				if ( false === $rows_affected ) {
-					$error = sprintf(
-					/* translators: %s database error. */
-						__( 'Unable to claim actions. Database error: %s.', 'action-scheduler' ),
-						empty( $wpdb->last_error ) ? _x( 'unknown', 'database error', 'action-scheduler' ) : $wpdb->last_error
-					);
+		$skip_locked = $this->db_supports_skip_locked() ? ' SKIP LOCKED' : '';
 
-					if ( $total_rows_affected === 0 ) {
-						// Throw an exception if we weren't able to claim any actions at all to reflect previous behavior,
-						// otherwise, just trigger a WARNING so the claimed actions can still be processed.
-						throw new \RuntimeException(
-							$error
-						);
-					}
-					// Trigger an error notice and allow the claim to proceed.
-					wp_trigger_error( __METHOD__, $error );
-					break;
-				}
-				$limit               -= $rows_affected;
-				$total_rows_affected += $rows_affected;
-				if ( $limit < 1 ) {
-					break;
-				}
+		// Selecting the action_ids that we plan to claim, while skipping any locked rows to avoid deadlocking.
+		$select_sql = $wpdb->prepare( "SELECT action_id from {$wpdb->actionscheduler_actions} {$where} {$order} LIMIT %d FOR UPDATE{$skip_locked}", array_merge( $where_params, array( $limit ) ) );
 
-			}
-		} elseif( $claim_staking_method == 'prequery') {
-			/**
-			 * Sets the order-by clause used in the action claim query.
-			 *
-			 * @param string $order_by_sql
-			 * @param string $claim_id Claim Id.
-			 * @param array $hooks Hooks to filter for.
-			 *
-			 * @since 3.8.3 Made $claim_id and $hooks available.
-			 *
-			 * @since 3.4.0
-			 */
-			$order    = apply_filters( 'action_scheduler_claim_actions_order_by', 'ORDER BY priority ASC, attempts ASC, scheduled_date_gmt ASC, action_id ASC', $claim_id, $hooks );
-
-			$action_ids = $wpdb->get_col(
-				$wpdb->prepare(
-					"SELECT action_id from {$wpdb->actionscheduler_actions} {$where} {$order} LIMIT %d",
-					[
-						...$where_params,
-						$limit
-					]
+		// Now place it into an UPDATE statement by joining the result sets, allowing for the SKIP LOCKED behavior to take effect.
+		$update_sql    = "UPDATE {$wpdb->actionscheduler_actions} t1 JOIN ( $select_sql ) t2 ON t1.action_id = t2.action_id SET claim_id=%d, last_attempt_gmt=%s, last_attempt_local=%s";
+		$update_params = array(
+			$claim_id,
+			$now->format( 'Y-m-d H:i:s' ),
+			current_time( 'mysql' ),
+		);
+		$rows_affected =  $wpdb->query( $wpdb->prepare( $update_sql, $update_params ) );
+		if ( false === $rows_affected ) {
+			$error = empty( $wpdb->last_error )
+				? _x( 'unknown', 'database error', 'action-scheduler' )
+				: $wpdb->last_error;
+			throw new \RuntimeException(
+				sprintf(
+				/* translators: %s database error. */
+					__( 'Unable to claim actions. Database error: %s.', 'action-scheduler' ),
+					$error
 				)
 			);
-
-			if ( empty( $action_ids ) ) {
-				return 0;
-			}
-
-
-			$placeholders = array_fill( 0, count( $action_ids ), '%d' );
-			$where        .= ' AND action_id IN (' . join( ', ', $placeholders ) . ')';
-			$where_params = array_merge( $where_params, array_values( $action_ids ) );
-
-			$sql = $wpdb->prepare(
-				"{$update} {$where} LIMIT %d",
-				[
-					...$update_params,
-					...$where_params,
-					$limit
-				]
-			); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders
-
-			$total_rows_affected = $wpdb->query( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-			if ( false === $total_rows_affected ) {
-				$error = empty( $wpdb->last_error )
-					? _x( 'unknown', 'database error', 'action-scheduler' )
-					: $wpdb->last_error;
-				throw new \RuntimeException(
-					sprintf(
-					/* translators: %s database error. */
-						__( 'Unable to claim actions. Database error: %s.', 'action-scheduler' ),
-						$error
-					)
-				);
-			}
-		} else {
-			/**
-			 * Sets the order-by clause used in the action claim query.
-			 *
-			 * @param string $order_by_sql
-			 * @param string $claim_id Claim Id.
-			 * @param array $hooks Hooks to filter for.
-			 *
-			 * @since 3.8.3 Made $claim_id and $hooks available.
-			 *
-			 * @since 3.4.0
-			 */
-			$order    = apply_filters( 'action_scheduler_claim_actions_order_by', 'ORDER BY priority ASC, attempts ASC, scheduled_date_gmt ASC, action_id ASC', $claim_id, $hooks );
-
-			$sql = $wpdb->prepare(
-				"{$update} {$where} {$order} LIMIT %d",
-				[
-					...$update_params,
-					...$where_params,
-					$limit
-				]
-			); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders
-
-			$total_rows_affected = $wpdb->query( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-			if ( false === $total_rows_affected ) {
-				$error = empty( $wpdb->last_error )
-					? _x( 'unknown', 'database error', 'action-scheduler' )
-					: $wpdb->last_error;
-				throw new \RuntimeException(
-					sprintf(
-						/* translators: %s database error. */
-						__( 'Unable to claim actions. Database error: %s.', 'action-scheduler' ),
-						$error
-					)
-				);
-			}
 		}
 
-		return (int) $total_rows_affected;
+		return (int) $rows_affected;
+	}
+
+	/**
+	 * Determines whether the database supports using SKIP LOCKED.
+	 *
+	 * SKIP_LOCKED support was added to MariaDB in 10.6.0 and to MySQL in 8.0.1
+	 *
+	 * @return bool
+	 */
+	private function db_supports_skip_locked() {
+		global $wpdb;
+		$db_version     = $wpdb->db_version();
+		$db_server_info = $wpdb->db_server_info();
+		$is_mariadb     = ( false !== str_contains( $db_server_info, 'MariaDB' ) );
+
+		if ( $is_mariadb &&
+		     '5.5.5' === $db_version &&
+		     PHP_VERSION_ID < 80016 // PHP 8.0.15 or older.
+		) {
+			/*
+			 * Account for MariaDB version being prefixed with '5.5.5-' on older PHP versions.
+			 */
+			$db_server_info = preg_replace( '/^5\.5\.5-(.*)/', '$1', $db_server_info );
+			$db_version     = preg_replace( '/[^0-9.].*/', '', $db_server_info );
+		}
+
+		$is_supported = false;
+
+		/**
+		 * SKIP_LOCKED support was added to MariaDB in 10.6.0 and to MySQL in 8.0.1
+		 */
+		if ( $is_mariadb && version_compare( $db_version, '10.6.0', '>=' ) ) {
+			$is_supported = true;
+		} elseif ( version_compare( $db_version, '8.0.1', '>=' ) ) {
+			/**
+			 * SKIP_LOCKED support was added to MySQL in 8.0.1
+			 */
+			$is_supported = true;
+		}
+
+		return $is_supported;
 	}
 
 	/**

--- a/classes/schema/ActionScheduler_StoreSchema.php
+++ b/classes/schema/ActionScheduler_StoreSchema.php
@@ -100,8 +100,8 @@ class ActionScheduler_StoreSchema extends ActionScheduler_Abstract_Schema {
 				        KEY args (args($max_index_length)),
 				        KEY group_id (group_id),
 				        KEY last_attempt_gmt (last_attempt_gmt),
-				        KEY `claim_id_status_priority_scheduled_date_gmt` (`claim_id`,`status`,`priority`,`scheduled_date_gmt`)
-				        KEY `status_last_attempt_gmt` (`status`,`last_attempt_gmt`)
+				        KEY `claim_id_status_priority_scheduled_date_gmt` (`claim_id`,`status`,`priority`,`scheduled_date_gmt`),
+				        KEY `status_last_attempt_gmt` (`status`,`last_attempt_gmt`),
 				        KEY `status_claim_id` (`status`,`claim_id`)
 				        ) $charset_collate";
 

--- a/classes/schema/ActionScheduler_StoreSchema.php
+++ b/classes/schema/ActionScheduler_StoreSchema.php
@@ -20,7 +20,7 @@ class ActionScheduler_StoreSchema extends ActionScheduler_Abstract_Schema {
 	 *
 	 * @var int
 	 */
-	protected $schema_version = 7;
+	protected $schema_version = 8;
 
 	/**
 	 * Construct.
@@ -56,8 +56,28 @@ class ActionScheduler_StoreSchema extends ActionScheduler_Abstract_Schema {
 		$hook_status_scheduled_date_gmt_max_index_length = $max_index_length - 20 - 8; // - status, - scheduled_date_gmt
 
 		switch ( $table ) {
-
 			case self::ACTIONS_TABLE:
+				/*
+				 *
+				 * INDEX AUDIT - the following indexes need to be reviewed for usage/quality. Initial review doesn't show usage.
+				 * - args - not a great index, no reported usage in index usage summary during testing
+				 * - group_id - not a great index, no reported usage in index usage summary during testing
+				 * - last_attempt_gmt - no reported usage in index usage summary during testing
+				 *
+				 *
+				 * INDEXES KEPT:
+				 * - scheduled_date_gmt - used on action scheduler listing page for "All" actions.
+				 * - status_scheduled_date_gmt - used by status report: ActionScheduler_wcSystemStatus->get_oldest_and_newest()
+				 * - hook_status_scheduled_date_gmt - scheduling checks
+				 *
+				 * INDEXES REMOVED:
+				 * - claim_id_status_scheduled_date_gmt - other indexes are sufficient to replace this.
+				 *
+ 				 * INDEXES ADDED:
+				 * - claim_id_status_priority_scheduled_date_gmt - improved index for staking claims on actions.
+				 * - status_last_attempt_gmt - used for QueueCleaner::clean_actions()
+				 * - status_claim_id - used calculate distinct claim_ids to determine current claims being processed.
+				 */
 				return "CREATE TABLE {$table_name} (
 				        action_id bigint(20) unsigned NOT NULL auto_increment,
 				        hook varchar(191) NOT NULL,
@@ -80,7 +100,9 @@ class ActionScheduler_StoreSchema extends ActionScheduler_Abstract_Schema {
 				        KEY args (args($max_index_length)),
 				        KEY group_id (group_id),
 				        KEY last_attempt_gmt (last_attempt_gmt),
-				        KEY `claim_id_status_scheduled_date_gmt` (`claim_id`, `status`, `scheduled_date_gmt`)
+				        KEY `claim_id_status_priority_scheduled_date_gmt` (`claim_id`,`status`,`priority`,`scheduled_date_gmt`)
+				        KEY `status_last_attempt_gmt` (`status`,`last_attempt_gmt`)
+				        KEY `status_claim_id` (`status`,`claim_id`)
 				        ) $charset_collate";
 
 			case self::CLAIMS_TABLE:

--- a/tests/phpunit/procedural_api/procedural_api_Test.php
+++ b/tests/phpunit/procedural_api/procedural_api_Test.php
@@ -449,7 +449,7 @@ class Procedural_API_Test extends ActionScheduler_UnitTestCase {
 		$this->assertContains( 'Caught exception while enqueuing action "hook_18": Error saving action', $logged_errors );
 		$this->assertContains( 'Caught exception while enqueuing action "hook_19": Error saving action', $logged_errors );
 		$this->assertContains( 'Caught exception while enqueuing action "hook_20": Error saving action', $logged_errors );
-		$this->assertContains( "Unknown column 'priority' in 'field list'", $logged_errors );
+		$this->assertContains( "Unknown column 'priority' in ", $logged_errors );
 
 		// recreate the priority column.
 		$wpdb->query( "ALTER TABLE {$wpdb->actionscheduler_actions} ADD COLUMN priority tinyint(10) UNSIGNED NOT NULL DEFAULT 10" );


### PR DESCRIPTION
This PR is a combination of fixes that will be broken into smaller, more specific PRs.  I combined them into one for initial review/testing as all of the issues together contributed to deadlocking and performance problems that limit the ability to increase the rate which actions can be processed.  Testing while fixing only one of these issues at a time still caused the system to bog down enough to prevent a clear understanding of the improvements.

## Main issues being addressed:

### Reduce the the deadlock frequency caused by claiming pending actions.

Ref #1104

The atomic query used to claim actions frequently causes deadlocks on the actions table due to the amount of time it takes to apply the updates to the table.  The best way to reduce this is to get rid of any sorting needed as it limits the records that end up being locked during the update.

I'm proposing two different options for addressing this:

####  "priority list"
This proposes that we change the philosophy around claiming actions so that attempts, scheduled_date_gmt, or action_id are no longer relevant when claiming actions. Only priority is considered.  So actions with the same priority may execute in any order.  

Then, to fully remove the order by clause, we will query the unique priorities that are pending and loop through those in order to claim actions of each priority until our Queue is filled.

To further improve this update query, the KEY `claim_id_status_priority_scheduled_date_gmt` was added to the `wp_actionscheduler_actions` table.

Downsides:
* Removes the `action_scheduler_claim_actions_order_by`
* Changes the philosophy of prioritizing claims - may have some unexpected consequences if extensions assume schedule date dictates order.
* The query to retrieve active priorities can be slow.
* Potential for a loop of 255 queries.

#### "pre query actions"

This is the more backward compatible change.  It simply makes a select query to get a set of action_ids to work with prior to running the update to claim the actions.  The update query still applies the same where clauses, so it remains atomic and avoids more than one claim running actions, but limits the records that become locked by the action_ids returned from the prequery.

I decided to try this late, so I haven't tested it as much as the priority list option.  But after some initial tests, it seems more promising and has less downside.

Downsides:
* There isn't a great way to index to deal with the where and order by clauses in the pre-select query - but that is at least a select query and not the update.
* Race conditions of multiple instances attempting to claim the same actions can cause one end up without any. This can probably be addressed with re-attempts if a set of action_ids are pre-queried, but no updates occur.

[ ] - Need to keep the `claim_id_status_scheduled_date_gmt` index if this is the path chosen.

### Stop resetting the claim_id of completed actions.

Ref #1105

Many queries used by ActionScheduler apply `claim_id` filters.  However, the cardinality of this column is extremely low because all actions, outside of those with actively running claims, have a claim_id of `0`.  The current behavior resets even completed actions back to a claim_id of `0`.  As a result, the MySQL optimizer will often choose to use indexes that aren't as efficient because it's estimations don't show that the indexes with the claim_id column will be as efficient.

To fix this, only actions that are still `pending` will get set back to a claim_id of `0` after a claim queue has been processed.  This allows.

### Improve the query performance of QueueCleaner::reset_timeouts()

This adds a usable index (status_last_attempt_gmt) for the query used in QueueCleaner::reset_timeouts().  The `orderby` argument was also updated to `modified` to help force the use of the index.  During testing, the optimizer would often use status_claim_id based indexes which always performed much worse.  This also helps make sure the oldest claimed actions are reset first.

### Improve the query performance of calculating the current number of claims running.

Adds a key on `status_claim_id` for the query used to determine the number of claims already running when deciding whether to spawn more.

## Testing

I added the following to a file in `mu-plugins` to allow testing a heavier load on ActionScheduler:

```php

// Switch between these to toggle between implementations for load testing.  Comment out both to compare to the original implementation.
define('CLAIM_STAKING_METHOD', 'priority_list');
//define('CLAIM_STAKING_METHOD', 'prequery');

/**
 * Bump up the batch size to 50 actions at a time.
 */
add_filter( 'action_scheduler_queue_runner_batch_size', function ( $size ) {
	return 50;
} );
/**
 * Allow up to 5 concurrent queues/claims to run at a time.
 */
add_filter( 'action_scheduler_queue_runner_concurrent_batches', function ( $count ) {
	return 5;
} );


/**
 * Actions used for testing.
 */
function schedule_random_action() {

	$foo         = rand( 0, 10000 );
	$priority    = rand( 0, 255 );
	$time_offset = rand( 1, 24 ) * HOUR_IN_SECONDS;

	return as_schedule_single_action( time() + $time_offset, 'as_performance_testing_action', array( 'foo' => $foo ), '', false, $priority );
}

// The action callback hook will reschedule another action instance in the future to keep the load up.
add_action( 'as_performance_testing_action', function() {
	// comment this line out to have the action complete successfully but not fail.
	schedule_random_action();
});


if ( class_exists( 'WP_CLI' ) ) {
	/**
	 * Generate 50K actions for testing.  These are no-op callbacks so that we're testing the load of scheduling, not the actions themselves.
	 *
	 * Example:
	 *  wp generate_actions
	 */
	WP_CLI::add_command(
		'generate_actions',
		function () {
			if ( ! did_action( 'action_scheduler_init' ) ) {
				WP_CLI::error( 'ActionScheduler is not initialized!!!' );
			}

			global $wpdb;
			WP_CLI::line( ' current actions: ' . $wpdb->get_var( "SELECT COUNT(*) FROM wp_actionscheduler_actions" ) );

			$num_to_create = 50000;

			for ( $i = 0; $i < $num_to_create; $i ++ ) {
				if ( ! schedule_random_action() ) {
					WP_CLI::warning( 'action not created' );
				}
			}
			WP_CLI::success( "Created $num_to_create actions" );
		}
	);
}
```

* You can add actions to the queue using `wp generate_actions`. This will add 50K pending actions that are randomly spread out across the next 24 hours.  When each is run, it will reschedule itself again randomly within the next 24 hour period.
* Watch error logs for deadlocks and engine status with the database.

1. Use the `wp generate_actions` command to generate a lot of actions.  I was testing against continually processing ~1M in a 24 hour period.
2. Open multiple instances of the WP-Admin in the browser to increase the number of polling ajax requests that may trigger the scheduler queue.
3. Adjust the `action_scheduler_queue_runner_concurrent_batches` filter to set different levels of load and observe the point where deadlocks start to appear, if at all.
4. Modify the `CLAIM_STAKING_METHOD` constant to change the algorithm used for claiming.