### PR TITLE
Fix custom error handler not restored if fatal

### DIFF
--- a/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php
+++ b/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php
@@ -78,6 +78,7 @@ abstract class ActionScheduler_Abstract_QueueRunner extends ActionScheduler_Abst
 			},
 			E_USER_ERROR | E_RECOVERABLE_ERROR
 		);
+		add_action( 'shutdown', 'restore_error_handler', -10 );
 
 		/*
 		 * The nested try/catch structure is required because we potentially need to convert thrown errors into
@@ -112,6 +113,7 @@ abstract class ActionScheduler_Abstract_QueueRunner extends ActionScheduler_Abst
 			$this->handle_action_error( $action_id, $e, $context, $valid_action );
 		} finally {
 			restore_error_handler();
+			remove_action( 'shutdown', 'restore_error_handler', -10 );
 		}
 
 		if ( isset( $action ) && is_a( $action, 'ActionScheduler_Action' ) && $action->get_schedule()->is_recurring() ) {

--- a/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php
+++ b/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php
@@ -78,7 +78,7 @@ abstract class ActionScheduler_Abstract_QueueRunner extends ActionScheduler_Abst
 			},
 			E_USER_ERROR | E_RECOVERABLE_ERROR
 		);
-		add_action( 'shutdown', 'restore_error_handler', -10 );
+		add_action( 'shutdown', 'restore_error_handler', -10, 0 );
 
 		/*
 		 * The nested try/catch structure is required because we potentially need to convert thrown errors into


### PR DESCRIPTION
Fix https://github.com/woocommerce/action-scheduler/issues/1253
