### PR TITLE
[dev] Pin Github actions to full-commit SHA

### DIFF
--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@0f7f1d08e3e32076e51cae65eb0b0c871405b16e # v2.34.1
         with:
           php-version: ${{ matrix.php }}
           tools: composer


### PR DESCRIPTION
Contributes to [QAO-23](https://linear.app/a8c/issue/QAO-23/pin-version-of-shivammathursetup-php-to-a-commit-sha)

Pins Github actions to full commit SHAs as immutable references (only shivammathur/setup-php)
Skipped all official GitHub actions and only pinned other 3rd party ones.
No version updates - used the latest commit in the tag that was already used.

