### PR TITLE
Include database error in the exception message.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 4.1.0 - xxxx-xx-xx =
 * Use `wp_admin_notice()` to render admin notices, instead of custom HTML.
+* Dev - Updates the `wpPostStore` to capture any database errors that might occur while claiming actions.
 
 = 4.0.0 - 2026-06-16 =
 * Breaking change: action args are taken into account when scheduling unique actions.

--- a/classes/data-stores/ActionScheduler_wpPostStore.php
+++ b/classes/data-stores/ActionScheduler_wpPostStore.php
@@ -697,10 +697,12 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 				? _x( 'unknown', 'database error', 'action-scheduler' )
 				: $wpdb->last_error;
 			throw new RuntimeException(
-				sprintf(
-					/* translators: %s database error. */
-					esc_html__( 'Unable to claim actions. Database error: %s.', 'action-scheduler' ),
-					$error
+				esc_html(
+					sprintf(
+						/* translators: %s database error. */
+						__( 'Unable to claim actions. Database error: %s.', 'action-scheduler' ),
+						$error
+					)
 				)
 			);
 		}

--- a/classes/data-stores/ActionScheduler_wpPostStore.php
+++ b/classes/data-stores/ActionScheduler_wpPostStore.php
@@ -696,7 +696,7 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 			$error = empty( $wpdb->last_error )
 				? _x( 'unknown', 'database error', 'action-scheduler' )
 				: $wpdb->last_error;
-			throw new \RuntimeException(
+			throw new RuntimeException(
 				sprintf(
 					/* translators: %s database error. */
 					__( 'Unable to claim actions. Database error: %s.', 'action-scheduler' ),

--- a/classes/data-stores/ActionScheduler_wpPostStore.php
+++ b/classes/data-stores/ActionScheduler_wpPostStore.php
@@ -693,7 +693,16 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 		$rows_affected = $wpdb->query( $wpdb->prepare( "{$update} {$where} {$order}", $params ) ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
 
 		if ( false === $rows_affected ) {
-			throw new RuntimeException( __( 'Unable to claim actions. Database error.', 'action-scheduler' ) );
+			$error = empty( $wpdb->last_error )
+				? _x( 'unknown', 'database error', 'action-scheduler' )
+				: $wpdb->last_error;
+			throw new \RuntimeException(
+				sprintf(
+					/* translators: %s database error. */
+					__( 'Unable to claim actions. Database error: %s.', 'action-scheduler' ),
+					$error
+				)
+			);
 		}
 
 		return (int) $rows_affected;

--- a/classes/data-stores/ActionScheduler_wpPostStore.php
+++ b/classes/data-stores/ActionScheduler_wpPostStore.php
@@ -699,7 +699,7 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 			throw new RuntimeException(
 				sprintf(
 					/* translators: %s database error. */
-					__( 'Unable to claim actions. Database error: %s.', 'action-scheduler' ),
+					esc_html__( 'Unable to claim actions. Database error: %s.', 'action-scheduler' ),
 					$error
 				)
 			);


### PR DESCRIPTION
In #966 the "Database error." exception was improved to include the actual DB error, however, it only updated one location where this exception is used.

This sync's the code to the other location.

100% untested.