### PR TITLE
Import missing WP_CLI class to prevent fatal error

### DIFF
--- a/classes/WP_CLI/Action_Command.php
+++ b/classes/WP_CLI/Action_Command.php
@@ -2,6 +2,8 @@
 
 namespace Action_Scheduler\WP_CLI;
 
+use WP_CLI;
+
 /**
  * Action command for Action Scheduler.
  */


### PR DESCRIPTION
### How to test the changes in this Pull Request:

1. Run `wp action-scheduler action list` and take note of the `id` of any action.
2. Run `wp action-scheduler action logs <id>`. No fatal error should occur and the logs for the action should appear.
3. (Optional) On `trunk`, run `wp action-scheduler action logs <id>` and you get a fatal error.

https://github.com/woocommerce/action-scheduler/blob/628fd3ccf87649ba470240afa9abc4adb8bce7e0/classes/WP_CLI/Action_Command.php#L284-L285