### PR TITLE
Option lock stuck locked with ''

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 4.1.0 - xxxx-xx-xx =
 * Use `wp_admin_notice()` to render admin notices, instead of custom HTML.
+* Fix an oversight in the lock implementation (used to rate-limit async request runners) that could result in a database error in unusual cases.
 * Dev - Updates the `wpPostStore` to capture any database errors that might occur while claiming actions.
 
 = 4.0.0 - 2026-06-16 =

--- a/classes/ActionScheduler_OptionLock.php
+++ b/classes/ActionScheduler_OptionLock.php
@@ -112,12 +112,18 @@ class ActionScheduler_OptionLock extends ActionScheduler_Lock {
 		global $wpdb;
 
 		// Now grab the existing lock value, if there is one.
-		return $wpdb->get_var(
+		// get_val() returns null for the empty string ('') so we must use get_row().
+		$row = $wpdb->get_row( // phpcs:ignore WordPress.DB.DirectDatabaseQuery
 			$wpdb->prepare(
 				"SELECT option_value FROM $wpdb->options WHERE option_name = %s",
-				$this->get_key( $lock_type )
+				$this->get_key($lock_type)
 			)
 		);
+
+		if ($row) {
+			return $row->option_value;
+		}
+		return null;
 	}
 
 	/**

--- a/classes/ActionScheduler_OptionLock.php
+++ b/classes/ActionScheduler_OptionLock.php
@@ -112,11 +112,11 @@ class ActionScheduler_OptionLock extends ActionScheduler_Lock {
 		global $wpdb;
 
 		// Now grab the existing lock value, if there is one.
-		// get_val() returns null for the empty string ('') so we must use get_row().
+		// get_var() returns null for the empty string ('') so we must use get_row().
 		$row = $wpdb->get_row( // phpcs:ignore WordPress.DB.DirectDatabaseQuery
 			$wpdb->prepare(
 				"SELECT option_value FROM $wpdb->options WHERE option_name = %s",
-				$this->get_key($lock_type)
+				$this->get_key( $lock_type )
 			)
 		);
 

--- a/classes/ActionScheduler_OptionLock.php
+++ b/classes/ActionScheduler_OptionLock.php
@@ -43,7 +43,7 @@ class ActionScheduler_OptionLock extends ActionScheduler_Lock {
 			);
 		}
 
-		if ( $this->get_expiration_from( $existing_lock_value ) >= time() ) {
+		if ( $this->get_expiration_from( (string) $existing_lock_value ) >= time() ) {
 			return false;
 		}
 

--- a/classes/ActionScheduler_OptionLock.php
+++ b/classes/ActionScheduler_OptionLock.php
@@ -43,7 +43,7 @@ class ActionScheduler_OptionLock extends ActionScheduler_Lock {
 			);
 		}
 
-		if ( $this->get_expiration_from($existing_lock_value ) >= time() ) {
+		if ( $this->get_expiration_from( $existing_lock_value ) >= time() ) {
 			return false;
 		}
 

--- a/classes/ActionScheduler_OptionLock.php
+++ b/classes/ActionScheduler_OptionLock.php
@@ -120,7 +120,7 @@ class ActionScheduler_OptionLock extends ActionScheduler_Lock {
 			)
 		);
 
-		if ($row) {
+		if ( $row ) {
 			return $row->option_value;
 		}
 		return null;

--- a/classes/ActionScheduler_OptionLock.php
+++ b/classes/ActionScheduler_OptionLock.php
@@ -102,7 +102,7 @@ class ActionScheduler_OptionLock extends ActionScheduler_Lock {
 	}
 
 	/**
-	 * Supplies the existing lock value, or an empty string if not set.
+	 * Supplies the existing lock value, or null if not set.
 	 *
 	 * @param string $lock_type A string to identify different lock types.
 	 *
@@ -113,7 +113,7 @@ class ActionScheduler_OptionLock extends ActionScheduler_Lock {
 
 		// Now grab the existing lock value, if there is one.
 		// get_var() returns null for the empty string ('') so we must use get_row().
-		$row = $wpdb->get_row( // phpcs:ignore WordPress.DB.DirectDatabaseQuery
+		$row = $wpdb->get_row(
 			$wpdb->prepare(
 				"SELECT option_value FROM $wpdb->options WHERE option_name = %s",
 				$this->get_key( $lock_type )

--- a/classes/ActionScheduler_OptionLock.php
+++ b/classes/ActionScheduler_OptionLock.php
@@ -32,7 +32,7 @@ class ActionScheduler_OptionLock extends ActionScheduler_Lock {
 		$new_lock_value      = $this->new_lock_value( $lock_type );
 
 		// The lock may not exist yet, or may have been deleted.
-		if ( empty( $existing_lock_value ) ) {
+		if ( null === $existing_lock_value ) {
 			return (bool) $wpdb->insert(
 				$wpdb->options,
 				array(
@@ -65,7 +65,7 @@ class ActionScheduler_OptionLock extends ActionScheduler_Lock {
 	 * @return bool|int False if no lock is set, otherwise the timestamp for when the lock is set to expire.
 	 */
 	public function get_expiration( $lock_type ) {
-		return $this->get_expiration_from( $this->get_existing_lock( $lock_type ) );
+		return $this->get_expiration_from( (string) $this->get_existing_lock( $lock_type ) );
 	}
 
 	/**
@@ -106,13 +106,13 @@ class ActionScheduler_OptionLock extends ActionScheduler_Lock {
 	 *
 	 * @param string $lock_type A string to identify different lock types.
 	 *
-	 * @return string
+	 * @return string|null
 	 */
 	private function get_existing_lock( $lock_type ) {
 		global $wpdb;
 
 		// Now grab the existing lock value, if there is one.
-		return (string) $wpdb->get_var(
+		return $wpdb->get_var(
 			$wpdb->prepare(
 				"SELECT option_value FROM $wpdb->options WHERE option_name = %s",
 				$this->get_key( $lock_type )

--- a/classes/ActionScheduler_OptionLock.php
+++ b/classes/ActionScheduler_OptionLock.php
@@ -43,7 +43,7 @@ class ActionScheduler_OptionLock extends ActionScheduler_Lock {
 			);
 		}
 
-		if ( $this->get_expiration_from( (string) $existing_lock_value ) >= time() ) {
+		if ( $this->get_expiration_from($existing_lock_value ) >= time() ) {
 			return false;
 		}
 

--- a/tests/phpunit/lock/ActionScheduler_OptionLock_Test.php
+++ b/tests/phpunit/lock/ActionScheduler_OptionLock_Test.php
@@ -74,4 +74,42 @@ class ActionScheduler_OptionLock_Test extends ActionScheduler_UnitTestCase {
 		$wpdb->suppress_errors( false );
 		remove_filter( 'query', $simulate_concurrent_claim );
 	}
+
+	/**
+	 * If the lock option already exists but holds an empty string, `set()` should still be able to
+	 * obtain the lock.
+	 *
+	 * This corrupted state (an existing row with an empty `option_value`) can be left behind by older
+	 * versions of Action Scheduler. It must be recovered by updating the existing row, rather than by
+	 * attempting to insert a duplicate row (which would fail, leaving the lock permanently stuck).
+	 *
+	 * @return void
+	 */
+	public function test_set_recovers_from_empty_lock_value() {
+		global $wpdb;
+
+		$lock     = ActionScheduler::lock();
+		$type     = md5( wp_rand() );
+		$lock_key = 'action_scheduler_lock_' . $type;
+
+		// Simulate the corrupted state: an existing lock option whose value is an empty string.
+		$wpdb->insert(
+			$wpdb->options,
+			array(
+				'option_name'  => $lock_key,
+				'option_value' => '',
+				'autoload'     => 'no',
+			)
+		);
+
+		// An empty lock value does not represent a held lock.
+		$this->assertFalse( $lock->is_locked( $type ), 'An empty lock value is not treated as a held lock.' );
+
+		// Setting the lock should succeed by updating (healing) the empty row, not by inserting a duplicate.
+		$this->assertTrue( $lock->set( $type ), 'The lock is obtained despite a pre-existing empty lock value.' );
+		$this->assertTrue( $lock->is_locked( $type ), 'The lock is held after recovering from the empty value.' );
+
+		// The stored value should now be a valid lock value with a future expiration timestamp.
+		$this->assertGreaterThan( time(), $lock->get_expiration( $type ), 'The recovered lock has a future expiration.' );
+	}
 }


### PR DESCRIPTION
Somehow (maybe old AS version?) the option value can get set to `''`. In this case the code will attempt to insert the option but it will give a duplicate key error. So the lock can never be set until someone manually deletes this option. 

With this cade change the option will be updated if it's `''` an update will be used instead of an insert.
