### PR TITLE
Correctly implement wp_cache_set in ActionScheduler_RecurringActionScheduler

### DIFF
--- a/classes/ActionScheduler_RecurringActionScheduler.php
+++ b/classes/ActionScheduler_RecurringActionScheduler.php
@@ -35,7 +35,7 @@ class ActionScheduler_RecurringActionScheduler {
 	 * @return void
 	 */
 	public function schedule_recurring_scheduler_hook(): void {
-		if ( false === wp_cache_get( 'as_is_ensure_recurring_actions_scheduled' ) ) {
+		if ( false === wp_cache_get( 'as_is_ensure_recurring_actions_scheduled', 'ActionScheduler' ) ) {
 			if ( ! as_has_scheduled_action( self::RUN_SCHEDULED_RECURRING_ACTIONS_HOOK ) ) {
 				as_schedule_recurring_action(
 					time(),

--- a/classes/ActionScheduler_RecurringActionScheduler.php
+++ b/classes/ActionScheduler_RecurringActionScheduler.php
@@ -47,7 +47,7 @@ class ActionScheduler_RecurringActionScheduler {
 					20
 				);
 			}
-			wp_cache_set( 'as_is_ensure_recurring_actions_scheduled', true, HOUR_IN_SECONDS );
+			wp_cache_set( 'as_is_ensure_recurring_actions_scheduled', true, 'ActionScheduler', HOUR_IN_SECONDS );
 		}
 	}
 


### PR DESCRIPTION
Use the correct unique cache group `'ActionScheduler'` in the single `wp_cache_set()` function call.

Fix #1296

