### PR TITLE
fix: auto-detect migration complete when old store is empty

### DIFF
--- a/classes/ActionScheduler_DataController.php
+++ b/classes/ActionScheduler_DataController.php
@@ -63,10 +63,40 @@ class ActionScheduler_DataController {
 	/**
 	 * Get a flag indicating whether the migration is complete.
 	 *
-	 * @return bool Whether the flag has been set marking the migration as complete
+	 * Checks the status flag first for performance. If not set, auto-detects
+	 * completion by checking if the old post-based store is empty.
+	 *
+	 * @return bool Whether the migration is complete
 	 */
 	public static function is_migration_complete() {
-		return get_option( self::STATUS_FLAG ) === self::STATUS_COMPLETE;
+		// Fast path: check the option first.
+		if ( get_option( self::STATUS_FLAG ) === self::STATUS_COMPLETE ) {
+			return true;
+		}
+
+		// Auto-detect: if no actions exist in the old post-based store, migration is complete.
+		if ( self::is_old_store_empty() ) {
+			self::mark_migration_complete();
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Check if the old post-based action store is empty.
+	 *
+	 * @return bool True if no scheduled-action posts exist.
+	 */
+	private static function is_old_store_empty() {
+		global $wpdb;
+
+		// Use a direct query for performance - avoid loading post objects.
+		$count = $wpdb->get_var(
+			"SELECT COUNT(*) FROM {$wpdb->posts} WHERE post_type = 'scheduled-action' LIMIT 1"
+		);
+
+		return 0 === (int) $count;
 	}
 
 	/**


### PR DESCRIPTION
## Problem

The migration status option (`action_scheduler_migration_status`) may never get set in some scenarios:
- Sites that upgraded through multiple Action Scheduler versions
- Cases where the migration runner completed but the option wasn't persisted
- Fresh installs that never had actions in the old store

When this happens, `is_migration_complete()` returns `false` indefinitely, causing the `HybridStore` wrapper to be used even when there are **zero actions** in the old post-based store.

The HybridStore adds overhead by querying multiple stores to determine which one contains an action:

```php
// HybridStore::fetch_action() calls get_store_from_action_id() which:
foreach ($stores as $store) {
    $action = $store->fetch_action($action_id); // Query #1 to FIND the store
    if (!is_a($action, 'ActionScheduler_NullAction')) {
        return $store;
    }
}
return $store->fetch_action($action_id); // Query #2 to GET the action
```

This results in **duplicate database queries on every action fetch** - a performance hit on every page load.

## Solution

Auto-detect migration completion when the old store is empty:

1. **Fast path preserved**: Check the option first (no behavior change for sites with flag set)
2. **Auto-detection**: If flag not set, check if old post-based store is empty
3. **Auto-mark**: If empty, set the flag and return `true`
4. **Performance**: Uses direct SQL with LIMIT 1 (no post object loading)

## Testing

- Verified on site with 0 `scheduled-action` posts and missing status flag
- Before: HybridStore used, duplicate queries on every fetch
- After: DBStore used directly, single query per fetch

## Changelog

```
* Fix - Auto-detect migration complete when old post-based store is empty, avoiding unnecessary HybridStore overhead.
```