### PR TITLE
Performance: address side-effects of processing corrupted entries (logs table bloat, hard-working queue processing)

### DIFF
--- a/classes/ActionScheduler_RecurringActionScheduler.php
+++ b/classes/ActionScheduler_RecurringActionScheduler.php
@@ -37,8 +37,9 @@ class ActionScheduler_RecurringActionScheduler {
 	public function schedule_recurring_scheduler_hook(): void {
 		if ( false === get_transient( 'as_is_ensure_recurring_actions_scheduled' ) ) {
 			if ( ! as_has_scheduled_action( self::RUN_SCHEDULED_RECURRING_ACTIONS_HOOK ) ) {
+				$date = ActionScheduler_TimezoneHelper::set_local_timezone( new DateTime() )->modify( 'tomorrow 3am' );
 				as_schedule_recurring_action(
-					time(),
+					$date->getTimestamp(),
 					DAY_IN_SECONDS,
 					self::RUN_SCHEDULED_RECURRING_ACTIONS_HOOK,
 					[],

--- a/classes/abstracts/ActionScheduler.php
+++ b/classes/abstracts/ActionScheduler.php
@@ -254,8 +254,11 @@ abstract class ActionScheduler {
 		/**
 		 * Handle WP comment cleanup after migration.
 		 */
-		if ( is_a( $logger, 'ActionScheduler_DBLogger' ) && ActionScheduler_DataController::is_migration_complete() && ActionScheduler_WPCommentCleaner::has_logs() ) {
-			ActionScheduler_WPCommentCleaner::init();
+		if ( is_a( $logger, 'ActionScheduler_DBLogger' ) && ActionScheduler_DataController::is_migration_complete() ) {
+			if ( ActionScheduler_WPCommentCleaner::has_logs() ) {
+				ActionScheduler_WPCommentCleaner::init();
+			}
+			add_action( 'action_scheduler_clear_deleted_action_logs_hook', array( $logger, 'clear_deleted_action_logs_single_batch' ), 10, 3 );
 		}
 
 		add_action( 'action_scheduler/migration_complete', 'ActionScheduler_WPCommentCleaner::maybe_schedule_cleanup' );

--- a/classes/abstracts/ActionScheduler.php
+++ b/classes/abstracts/ActionScheduler.php
@@ -254,11 +254,8 @@ abstract class ActionScheduler {
 		/**
 		 * Handle WP comment cleanup after migration.
 		 */
-		if ( is_a( $logger, 'ActionScheduler_DBLogger' ) && ActionScheduler_DataController::is_migration_complete() ) {
-			if ( ActionScheduler_WPCommentCleaner::has_logs() ) {
-				ActionScheduler_WPCommentCleaner::init();
-			}
-			add_action( 'action_scheduler_clear_deleted_action_logs_hook', array( $logger, 'clear_deleted_action_logs_single_batch' ), 10, 4 );
+		if ( is_a( $logger, 'ActionScheduler_DBLogger' ) && ActionScheduler_DataController::is_migration_complete() && ActionScheduler_WPCommentCleaner::has_logs() ) {
+			ActionScheduler_WPCommentCleaner::init();
 		}
 
 		add_action( 'action_scheduler/migration_complete', 'ActionScheduler_WPCommentCleaner::maybe_schedule_cleanup' );

--- a/classes/abstracts/ActionScheduler.php
+++ b/classes/abstracts/ActionScheduler.php
@@ -258,7 +258,7 @@ abstract class ActionScheduler {
 			if ( ActionScheduler_WPCommentCleaner::has_logs() ) {
 				ActionScheduler_WPCommentCleaner::init();
 			}
-			add_action( 'action_scheduler_clear_deleted_action_logs_hook', array( $logger, 'clear_deleted_action_logs_single_batch' ), 10, 3 );
+			add_action( 'action_scheduler_clear_deleted_action_logs_hook', array( $logger, 'clear_deleted_action_logs_single_batch' ), 10, 4 );
 		}
 
 		add_action( 'action_scheduler/migration_complete', 'ActionScheduler_WPCommentCleaner::maybe_schedule_cleanup' );

--- a/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php
+++ b/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php
@@ -84,10 +84,9 @@ abstract class ActionScheduler_Abstract_QueueRunner extends ActionScheduler_Abst
 		 * exceptions (and an exception thrown from a catch block cannot be caught by a later catch block in the *same*
 		 * structure).
 		 */
+		$valid_action = true;
 		try {
 			try {
-				$valid_action = true;
-
 				do_action( 'action_scheduler_before_execute', $action_id, $context );
 
 				if ( ActionScheduler_Store::STATUS_PENDING !== $this->store->get_status( $action_id ) ) {
@@ -98,10 +97,18 @@ abstract class ActionScheduler_Abstract_QueueRunner extends ActionScheduler_Abst
 
 				do_action( 'action_scheduler_begin_execute', $action_id, $context );
 
-				$action = $this->store->fetch_action( $action_id );
+				$action = $this->fetch_complete_action( $action_id );
+				if ( null === $action ) {
+					$valid_action = false;
+					$this->cancel_corrupted_action( $action_id );
+					return;
+				}
+
 				$this->store->log_execution( $action_id );
 				$action->execute();
+
 				do_action( 'action_scheduler_after_execute', $action_id, $action, $context );
+
 				$this->store->mark_complete( $action_id );
 			} catch ( Throwable $e ) {
 				// Throwable is defined when executing under PHP 7.0 and up. We convert it to an exception, for
@@ -118,6 +125,44 @@ abstract class ActionScheduler_Abstract_QueueRunner extends ActionScheduler_Abst
 		if ( isset( $action ) && is_a( $action, 'ActionScheduler_Action' ) && $action->get_schedule()->is_recurring() ) {
 			$this->schedule_next_instance( $action, $action_id );
 		}
+	}
+
+	/**
+	 * Fetches the action instance. On failure returns null instead of ActionScheduler_NullAction.
+	 *
+	 * @param int $action_id Action ID.
+	 * @return ActionScheduler_Action|null
+	 */
+	private function fetch_complete_action( int $action_id ) {
+		// Handle corrupted entries and potential DB read failures (corrupted arguments or schedule data; a known trigger is incomplete A-S migration).
+		$attempts_to_populate = 0;
+		do {
+			$action  = $this->store->fetch_action( $action_id );
+			$failure = $action instanceof ActionScheduler_NullAction;
+			// Sleep 0.01 second before retrying.
+			usleep( 10000 * (int) $failure );
+		} while ( $failure && ++$attempts_to_populate < 2 );
+
+		return $action instanceof ActionScheduler_NullAction ? null : $action;
+	}
+
+	/**
+	 * Cancels the corrupted actions and performs the necessary cleanup to address identified side effects.
+	 *
+	 * @param int $action_id Action ID.
+	 * @return void
+	 */
+	private function cancel_corrupted_action( int $action_id ) {
+		$this->store->cancel_action( $action_id );
+
+		// Corrupted entries typically contain an excessive number of logs, which we intend to remove immediately.
+		do_action( 'action_scheduler_cancelled_corrupted_action', $action_id );
+
+		// Add a comment to clarify the missing logs and explain the reason for the cancellation.
+		ActionScheduler_Logger::instance()->log(
+			$action_id,
+			__( 'This action data appears to be corrupt. We are cancelling it to allow recurring actions to be re-created by extensions.', 'action-scheduler' )
+		);
 	}
 
 	/**

--- a/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php
+++ b/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php
@@ -156,7 +156,7 @@ abstract class ActionScheduler_Abstract_QueueRunner extends ActionScheduler_Abst
 		$this->store->cancel_action( $action_id );
 
 		// Corrupted entries typically contain an excessive number of logs, which we intend to remove immediately.
-		do_action( 'action_scheduler_cancelled_corrupted_action', $action_id );
+		do_action( 'action_scheduler_canceled_corrupted_action', $action_id );
 
 		// Add a comment to clarify the missing logs and explain the reason for the cancellation.
 		ActionScheduler_Logger::instance()->log(

--- a/classes/data-stores/ActionScheduler_DBLogger.php
+++ b/classes/data-stores/ActionScheduler_DBLogger.php
@@ -121,7 +121,7 @@ class ActionScheduler_DBLogger extends ActionScheduler_Logger {
 	 * @param int $action_id Action ID.
 	 */
 	public function clear_deleted_action_logs( $action_id ) {
-		$this->clear_deleted_action_logs_single_batch( $action_id, -1, 1, 100 );
+		$this->clear_deleted_action_logs_single_batch( $action_id, -1, 1, 4000 );
 	}
 
 	/**

--- a/classes/data-stores/ActionScheduler_DBLogger.php
+++ b/classes/data-stores/ActionScheduler_DBLogger.php
@@ -110,7 +110,7 @@ class ActionScheduler_DBLogger extends ActionScheduler_Logger {
 		parent::init();
 
 		add_action( 'action_scheduler_deleted_action', array( $this, 'clear_deleted_action_logs' ), 10, 1 );
-		add_action( 'action_scheduler_cancelled_corrupted_action', array( $this, 'clear_deleted_action_logs' ), 10, 1 );
+		add_action( 'action_scheduler_canceled_corrupted_action', array( $this, 'clear_deleted_action_logs' ), 10, 1 );
 		add_action( 'action_scheduler_clear_deleted_action_logs_hook', array( $this, 'clear_deleted_action_logs_single_batch' ), 10, 4 );
 	}
 

--- a/classes/data-stores/ActionScheduler_DBLogger.php
+++ b/classes/data-stores/ActionScheduler_DBLogger.php
@@ -111,6 +111,7 @@ class ActionScheduler_DBLogger extends ActionScheduler_Logger {
 
 		add_action( 'action_scheduler_deleted_action', array( $this, 'clear_deleted_action_logs' ), 10, 1 );
 		add_action( 'action_scheduler_cancelled_corrupted_action', array( $this, 'clear_deleted_action_logs' ), 10, 1 );
+		add_action( 'action_scheduler_clear_deleted_action_logs_hook', array( $this, 'clear_deleted_action_logs_single_batch' ), 10, 4 );
 	}
 
 	/**

--- a/classes/data-stores/ActionScheduler_DBLogger.php
+++ b/classes/data-stores/ActionScheduler_DBLogger.php
@@ -120,20 +120,27 @@ class ActionScheduler_DBLogger extends ActionScheduler_Logger {
 	 * @param int $action_id Action ID.
 	 */
 	public function clear_deleted_action_logs( $action_id ) {
+		$this->clear_deleted_action_logs_single_batch( $action_id, 1, 100 );
+	}
+
+	/**
+	 * Delete the action logs batch for an action.
+	 *
+	 * @param int  $action_id  Action id.
+	 * @param int  $batch      The batch index is used solely for troubleshooting. Reviewing action arguments provides a clear understanding of progressive deletion.
+	 * @param int  $batch_size Batch size.
+	 *
+	 * @return void
+	 */
+	public function clear_deleted_action_logs_single_batch( $action_id, $batch, $batch_size ) {
 		global $wpdb;
 
-		$batch_size = 100;
-		do {
-			$deleted_entries_count = (int) $wpdb->query(
-				$wpdb->prepare(
-					"DELETE FROM {$wpdb->actionscheduler_logs} WHERE action_id = %d LIMIT %d",
-					$action_id,
-					$batch_size
-				)
-			);
-			// Sleep 0.01 second (max) before the next batch deletion.
-			usleep( ( 10000 / $batch_size ) * $deleted_entries_count );
-		} while ( $deleted_entries_count === $batch_size );
+		$deleted  = (int) $wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->actionscheduler_logs} WHERE action_id = %d LIMIT %d", $action_id, $batch_size ) );
+		$continue = $deleted === $batch_size;
+		if ( $continue ) {
+			// Schedule immediately, as this action will not be selected during the current run and will have lower than normal priority.
+			as_schedule_single_action( time(), 'action_scheduler_clear_deleted_action_logs_hook', array( $action_id, ++$batch, $batch_size ), '', false, 9 );
+		}
 	}
 
 	/**

--- a/classes/data-stores/ActionScheduler_DBLogger.php
+++ b/classes/data-stores/ActionScheduler_DBLogger.php
@@ -145,7 +145,7 @@ class ActionScheduler_DBLogger extends ActionScheduler_Logger {
 		$continue = $deleted === $batch_size;
 		if ( $continue ) {
 			// Schedule immediately, as this action will not be selected during the current run and will have lower than normal priority.
-			as_schedule_single_action( time(), 'action_scheduler_clear_deleted_action_logs_hook', array( $action_id, $cutoff_log_id, ++$batch, $batch_size ), '', false, 9 );
+			as_schedule_single_action( time(), 'action_scheduler_clear_deleted_action_logs_hook', array( $action_id, $cutoff_log_id, ++$batch, $batch_size ), '', false, 20 );
 		}
 	}
 

--- a/classes/data-stores/ActionScheduler_DBLogger.php
+++ b/classes/data-stores/ActionScheduler_DBLogger.php
@@ -120,26 +120,31 @@ class ActionScheduler_DBLogger extends ActionScheduler_Logger {
 	 * @param int $action_id Action ID.
 	 */
 	public function clear_deleted_action_logs( $action_id ) {
-		$this->clear_deleted_action_logs_single_batch( $action_id, 1, 100 );
+		$this->clear_deleted_action_logs_single_batch( $action_id, -1, 1, 100 );
 	}
 
 	/**
 	 * Delete the action logs batch for an action.
 	 *
-	 * @param int  $action_id  Action id.
-	 * @param int  $batch      The batch index is used solely for troubleshooting. Reviewing action arguments provides a clear understanding of progressive deletion.
-	 * @param int  $batch_size Batch size.
+	 * @param int  $action_id      Action id.
+	 * @param int  $cutoff_log_id  Cutoff log ID. Retain logs generated after the cleanup begins. A value of -1 indicates the start of the cleanup.
+	 * @param int  $batch          The batch index is used solely for troubleshooting. Reviewing action arguments provides a clear understanding of progressive deletion.
+	 * @param int  $batch_size     Batch size.
 	 *
 	 * @return void
 	 */
-	public function clear_deleted_action_logs_single_batch( $action_id, $batch, $batch_size ) {
+	public function clear_deleted_action_logs_single_batch( $action_id, $cutoff_log_id, $batch, $batch_size ) {
 		global $wpdb;
 
-		$deleted  = (int) $wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->actionscheduler_logs} WHERE action_id = %d LIMIT %d", $action_id, $batch_size ) );
+		if ( -1 === $cutoff_log_id ) {
+			$cutoff_log_id = 1 + (int) $wpdb->get_var( $wpdb->prepare( "SELECT MAX(log_id) FROM {$wpdb->actionscheduler_logs} WHERE action_id = %d", $action_id ) );
+		}
+
+		$deleted  = (int) $wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->actionscheduler_logs} WHERE action_id = %d AND log_id < %d LIMIT %d", $action_id, $cutoff_log_id, $batch_size ) );
 		$continue = $deleted === $batch_size;
 		if ( $continue ) {
 			// Schedule immediately, as this action will not be selected during the current run and will have lower than normal priority.
-			as_schedule_single_action( time(), 'action_scheduler_clear_deleted_action_logs_hook', array( $action_id, ++$batch, $batch_size ), '', false, 9 );
+			as_schedule_single_action( time(), 'action_scheduler_clear_deleted_action_logs_hook', array( $action_id, $cutoff_log_id, ++$batch, $batch_size ), '', false, 9 );
 		}
 	}
 

--- a/classes/data-stores/ActionScheduler_DBLogger.php
+++ b/classes/data-stores/ActionScheduler_DBLogger.php
@@ -110,17 +110,30 @@ class ActionScheduler_DBLogger extends ActionScheduler_Logger {
 		parent::init();
 
 		add_action( 'action_scheduler_deleted_action', array( $this, 'clear_deleted_action_logs' ), 10, 1 );
+		add_action( 'action_scheduler_cancelled_corrupted_action', array( $this, 'clear_deleted_action_logs' ), 10, 1 );
 	}
 
 	/**
 	 * Delete the action logs for an action.
 	 *
+	 * @since 3.9.3 the logs will be deleted in batches of 100.
 	 * @param int $action_id Action ID.
 	 */
 	public function clear_deleted_action_logs( $action_id ) {
-		/** @var \wpdb $wpdb */ //phpcs:ignore Generic.Commenting.DocComment.MissingShort
 		global $wpdb;
-		$wpdb->delete( $wpdb->actionscheduler_logs, array( 'action_id' => $action_id ), array( '%d' ) );
+
+		$batch_size = 100;
+		do {
+			$deleted_entries_count = (int) $wpdb->query(
+				$wpdb->prepare(
+					"DELETE FROM {$wpdb->actionscheduler_logs} WHERE action_id = %d LIMIT %d",
+					$action_id,
+					$batch_size
+				)
+			);
+			// Sleep 0.01 second (max) before the next batch deletion.
+			usleep( ( 10000 / $batch_size ) * $deleted_entries_count );
+		} while ( $deleted_entries_count === $batch_size );
 	}
 
 	/**

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -391,17 +391,22 @@ AND `group_id` = %d
 	 * @return ActionScheduler_Action|ActionScheduler_CanceledAction|ActionScheduler_FinishedAction
 	 */
 	protected function make_action_from_db_record( $data ) {
-
-		$hook     = $data->hook;
-		$args     = json_decode( $data->args, true );
-		$schedule = unserialize( $data->schedule ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_unserialize
-
-		$this->validate_args( $args, $data->action_id );
-		$this->validate_schedule( $schedule, $data->action_id );
-
-		if ( empty( $schedule ) ) {
-			$schedule = new ActionScheduler_NullSchedule();
+		$args = json_decode( $data->args, true );
+		if ( ! is_array( $args ) && $data->status === self::STATUS_CANCELED ) {
+			// The handled corrupted action should appear in UI.
+			$args = array();
+		} else {
+			$this->validate_args( $args, $data->action_id );
 		}
+
+		$schedule = @unserialize( $data->schedule ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_unserialize WordPress.PHP.NoSilencingOperator
+		if ( false === $schedule && $data->status === self::STATUS_CANCELED ) {
+			// The handled corrupted action should appear in UI.
+			$schedule = new ActionScheduler_NullSchedule();
+		} else {
+			$this->validate_schedule( $schedule, $data->action_id );
+		}
+
 		$group = $data->group ? $data->group : '';
 
 		return ActionScheduler::factory()->get_stored_action( $data->status, $data->hook, $args, $schedule, $group, $data->priority );

--- a/classes/data-stores/ActionScheduler_HybridStore.php
+++ b/classes/data-stores/ActionScheduler_HybridStore.php
@@ -405,9 +405,8 @@ class ActionScheduler_HybridStore extends Store {
 				if ( null !== $store->get_status( $action_id ) ) {
 					return $store;
 				}
-			} catch ( \InvalidArgumentException $e ) {
+			} catch ( \InvalidArgumentException $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
 				// Do nothing. In this context, not finding status for the given ID is not an error.
-				unset( $e ); // Make the code sniffer happy.
 			}
 		}
 		return null;

--- a/classes/data-stores/ActionScheduler_HybridStore.php
+++ b/classes/data-stores/ActionScheduler_HybridStore.php
@@ -400,9 +400,14 @@ class ActionScheduler_HybridStore extends Store {
 		}
 
 		foreach ( $stores as $store ) {
-			$action = $store->fetch_action( $action_id );
-			if ( ! is_a( $action, 'ActionScheduler_NullAction' ) ) {
-				return $store;
+			try {
+				// Probe by fetching the action status: if entry is corrupted, the object construction is not feasible.
+				if ( null !== $store->get_status( $action_id ) ) {
+					return $store;
+				}
+			} catch ( \InvalidArgumentException $e ) {
+				// Do nothing. In this context, not finding status for the given ID is not an error.
+				unset( $e ); // Make the code sniffer happy.
 			}
 		}
 		return null;

--- a/tests/phpunit/runner/ActionScheduler_QueueRunner_Test.php
+++ b/tests/phpunit/runner/ActionScheduler_QueueRunner_Test.php
@@ -305,6 +305,40 @@ class ActionScheduler_QueueRunner_Test extends ActionScheduler_UnitTestCase {
 	}
 
 	/**
+	 * If a corrupted action entry is being processed, it'll be canceled and its logs truncated leaving only a single log
+	 * explaining the corrupted state. Cancelling should enable the recurring actions being re-created.
+	 *
+	 * @return void
+	 */
+	public function test_corrupted_actions_are_unscheduled() {
+		global $wpdb;
+
+		$store  = ActionScheduler_Store::instance();
+		$logger = ActionScheduler_Logger::instance();
+		$runner = ActionScheduler_Mocker::get_queue_runner( $store );
+
+		$action_id = as_schedule_recurring_action( time(), HOUR_IN_SECONDS, 'corrupted-action' );
+		$this->assertSame( ActionScheduler_Store::STATUS_PENDING, $store->get_status( $action_id ) );
+
+		// Mimic the corrupted state: truncate the schedule field to break unserialization and action object population.
+		$wpdb->query(
+			$wpdb->prepare(
+				"UPDATE {$wpdb->actionscheduler_actions} SET schedule = SUBSTRING(schedule, 1, 30) WHERE action_id = %d",
+				$action_id
+			)
+		);
+
+		$runner->process_action( $action_id );
+		$logs = $logger->get_logs( $action_id );
+
+		$this->assertSame( ActionScheduler_Store::STATUS_CANCELED, $store->get_status( $action_id ) );
+		$this->assertCount( 1, $logs );
+		$this->assertStringContainsString( 'This action data appears to be corrupt.', $logs[0]->get_message() );
+
+		$store->delete_action( $action_id );
+	}
+
+	/**
 	 * If a recurring action continually fails, it will not be re-scheduled. However, a hook makes it possible to
 	 * exempt specific actions from this behavior (without impacting other unrelated recurring actions).
 	 *

--- a/tests/phpunit/runner/ActionScheduler_QueueRunner_Test.php
+++ b/tests/phpunit/runner/ActionScheduler_QueueRunner_Test.php
@@ -335,6 +335,11 @@ class ActionScheduler_QueueRunner_Test extends ActionScheduler_UnitTestCase {
 		$this->assertCount( 1, $logs );
 		$this->assertStringContainsString( 'This action data appears to be corrupt.', $logs[0]->get_message() );
 
+		// Verify that a canceled corrupted action is visible in the user interface.
+		$action = $store->fetch_action( $action_id );
+		$this->assertInstanceOf( ActionScheduler_FinishedAction::class, $action );
+		$this->assertInstanceOf( ActionScheduler_NullSchedule::class, $action->get_schedule() );
+
 		$store->delete_action( $action_id );
 	}
 


### PR DESCRIPTION
Fixes #1311 ACTSCH-92

This update follows up on p1772090743156589-slack-C08SVLULL3B and addresses the handling of actions with corrupted data:
- Identifies actions with corrupted data and cancels their execution to allow for rescheduling.
- Removes excessive logs generated during attempts to process corrupted actions (gradually if it's the target bloat case).
- Makes the cancelled action available in the UI for investigation.

In this PR, we identify actions that fail to construct an action object after two attempts and cancel them, including purging their associated logs (gradually if needed).

From an architectural perspective, we are aligning replication-friendly cleanup methods with the WooCommerce core work I [completed](https://github.com/woocommerce/woocommerce/pull/60711) earlier to meet the performance requirements of HVM stores and addressing a known reliability issue.

Testing Instructions:

- Build the plugin from this branch and install it on your test site.
- Modify any pending `action_scheduler_run_recurring_actions_schedule_hook` by truncating part of the `schedule` field and updating its scheduled date to a past date.
- Navigate to the admin area under `Tools -> Action Scheduler`.
- Verify that the action status has changed and that there is a single log entry mentioning data corruption, which must appear in the UI.
- Delete the `as_is_ensure_recurring_actions_scheduled` transient and refresh the page.
- Verify that `action_scheduler_run_recurring_actions_schedule_hook` is rescheduled for 3 a.m. the next day.