### PR TITLE
Performance: cap failed actions retention period to three months by default

### DIFF
--- a/classes/ActionScheduler_QueueCleaner.php
+++ b/classes/ActionScheduler_QueueCleaner.php
@@ -107,7 +107,7 @@ class ActionScheduler_QueueCleaner {
 		$deleted_failed_entries = array();
 		// Backward compatibility note: if store already purging the failed statuses, don't change the behaviour.
 		if ( $lifespan_failed > 0 && ! in_array( ActionScheduler_Store::STATUS_FAILED, $statuses_to_purge, true ) ) {
-			// use a fixed default batch size to ensure that the cleanup of failed actions does not interfere with the regular cleanup.
+			// Use a fixed default batch size to ensure that the cleanup of failed actions does not interfere with the regular cleanup.
 			$deleted_failed_entries = $this->clean_actions( array( ActionScheduler_Store::STATUS_FAILED ), $cutoff_failed, 20 );
 		}
 

--- a/classes/ActionScheduler_QueueCleaner.php
+++ b/classes/ActionScheduler_QueueCleaner.php
@@ -107,7 +107,7 @@ class ActionScheduler_QueueCleaner {
 		$deleted_failed_entries = array();
 		// Backward compatibility note: if store already purging the failed statuses, don't change the behaviour.
 		if ( $lifespan_failed > 0 && ! in_array( ActionScheduler_Store::STATUS_FAILED, $statuses_to_purge, true ) ) {
-			// We will use a hard-coded default batch size, as recommended in the code review.
+			// use a fixed default batch size to ensure that the cleanup of failed actions does not interfere with the regular cleanup.
 			$deleted_failed_entries = $this->clean_actions( array( ActionScheduler_Store::STATUS_FAILED ), $cutoff_failed, 20 );
 		}
 

--- a/classes/ActionScheduler_QueueCleaner.php
+++ b/classes/ActionScheduler_QueueCleaner.php
@@ -50,6 +50,7 @@ class ActionScheduler_QueueCleaner {
 	/**
 	 * Default queue cleaner process used by queue runner.
 	 *
+	 * @since 3.9.4 by default, failed actions are removed after three months.
 	 * @return array
 	 */
 	public function delete_old_actions() {
@@ -60,8 +61,28 @@ class ActionScheduler_QueueCleaner {
 		 */
 		$lifespan = apply_filters( 'action_scheduler_retention_period', $this->month_in_seconds );
 
+		/**
+		 * Set the retention period, in seconds, for actions with a status returned by the action_scheduler_default_cleaner_statuses filter.
+		 *
+		 * @param int $retention_period Retention period in seconds.
+		 */
+		$lifespan_default = max( 0, (int) apply_filters( 'action_scheduler_retention_period_by_default', $lifespan ) );
+		$lifespan_default = $lifespan_default > 0 ? $lifespan_default : $this->month_in_seconds;
+
+		/**
+		 * Set the retention period in seconds for actions with a failed status. If the action_scheduler_default_cleaner_statuses filter includes
+		 * a failed status, this filter result will be ignored, and the retention period for failed actions will match that of other statuses.
+		 *
+		 * @param int $retention_period Retention period in seconds.
+		 */
+		$lifespan_failed = max( 0, (int) apply_filters( 'action_scheduler_retention_period_for_failed', 3 * $this->month_in_seconds ) );
+		// We considered 12-month, 3-month, and 1-month options for failed action retention and selected a 3-month period
+		// to align with the quarterly accounting cycle. Store owners may adjust the retention period to achieve PCI DSS
+		// compliance or to align with a different accounting cycle, as needed.
+
 		try {
-			$cutoff = as_get_datetime_object( $lifespan . ' seconds ago' );
+			$cutoff_failed  = as_get_datetime_object( $lifespan_failed . ' seconds ago' );
+			$cutoff_default = as_get_datetime_object( $lifespan_default . ' seconds ago' );
 		} catch ( Exception $e ) {
 			_doing_it_wrong(
 				__METHOD__,
@@ -83,7 +104,16 @@ class ActionScheduler_QueueCleaner {
 		 */
 		$statuses_to_purge = (array) apply_filters( 'action_scheduler_default_cleaner_statuses', $this->default_statuses_to_purge );
 
-		return $this->clean_actions( $statuses_to_purge, $cutoff, $this->get_batch_size() );
+		$deleted_failed_entries = array();
+		// Backward compatibility note: if store already purging the failed statuses, don't change the behaviour.
+		if ( $lifespan_failed > 0 && ! in_array( ActionScheduler_Store::STATUS_FAILED, $statuses_to_purge, true ) ) {
+			// We will use a hard-coded default batch size, as recommended in the code review.
+			$deleted_failed_entries = $this->clean_actions( array( ActionScheduler_Store::STATUS_FAILED ), $cutoff_failed, 20 );
+		}
+
+		$deleted_entries = $this->clean_actions( $statuses_to_purge, $cutoff_default, $this->get_batch_size() );
+
+		return array_merge( $deleted_failed_entries, $deleted_entries );
 	}
 
 	/**
@@ -105,7 +135,6 @@ class ActionScheduler_QueueCleaner {
 		}
 
 		$deleted_actions = array();
-
 		foreach ( $statuses_to_purge as $status ) {
 			$actions_to_delete = $this->store->query_actions(
 				array(
@@ -116,11 +145,10 @@ class ActionScheduler_QueueCleaner {
 					'orderby'          => 'none',
 				)
 			);
-
-			$deleted_actions = array_merge( $deleted_actions, $this->delete_actions( $actions_to_delete, $lifespan, $context ) );
+			$deleted_actions[] = $this->delete_actions( $actions_to_delete, $lifespan, $context );
 		}
 
-		return $deleted_actions;
+		return array_merge( array(), ...$deleted_actions );
 	}
 
 	/**

--- a/classes/ActionScheduler_QueueRunner.php
+++ b/classes/ActionScheduler_QueueRunner.php
@@ -153,8 +153,10 @@ class ActionScheduler_QueueRunner extends ActionScheduler_Abstract_QueueRunner {
 
 		$this->processed_actions_count = 0;
 		if ( false === $this->has_maximum_concurrent_batches() ) {
+			$batch_size = apply_filters( 'action_scheduler_queue_runner_batch_size', 25 );
+			// Note: gc_collect_cycles() was considered here and in do_batch/clear_caches, but rejected:
+			// upside is speculative, GC sweep cost scales with object count and can cause pauses.
 			do {
-				$batch_size                     = apply_filters( 'action_scheduler_queue_runner_batch_size', 25 );
 				$processed_actions_in_batch     = $this->do_batch( $batch_size, $context );
 				$this->processed_actions_count += $processed_actions_in_batch;
 			} while ( $processed_actions_in_batch > 0 && ! $this->batch_limits_exceeded( $this->processed_actions_count ) ); // keep going until we run out of actions, time, or memory.
@@ -180,11 +182,13 @@ class ActionScheduler_QueueRunner extends ActionScheduler_Abstract_QueueRunner {
 		$this->monitor->attach( $claim );
 		$processed_actions = 0;
 
+		$claim_id = $claim->get_id();
 		foreach ( $claim->get_actions() as $action_id ) {
 			// bail if we lost the claim.
-			if ( ! in_array( $action_id, $this->store->find_actions_by_claim_id( $claim->get_id() ), true ) ) {
+			if ( $claim_id !== $this->store->get_claim_id( $action_id ) ) {
 				break;
 			}
+
 			$this->process_action( $action_id, $context );
 			$processed_actions++;
 

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -1231,9 +1231,13 @@ AND `group_id` = %d
 
 		$updated = $wpdb->update(
 			$wpdb->actionscheduler_actions,
-			array( 'status' => self::STATUS_FAILED ),
+			array(
+				'status'             => self::STATUS_FAILED,
+				'last_attempt_gmt'   => current_time( 'mysql', true ),
+				'last_attempt_local' => current_time( 'mysql' ),
+			),
 			array( 'action_id' => $action_id ),
-			array( '%s' ),
+			array( '%s', '%s', '%s' ),
 			array( '%d' )
 		);
 		if ( empty( $updated ) ) {
@@ -1301,7 +1305,7 @@ AND `group_id` = %d
 				'last_attempt_local' => current_time( 'mysql' ),
 			),
 			array( 'action_id' => $action_id ),
-			array( '%s' ),
+			array( '%s', '%s', '%s' ),
 			array( '%d' )
 		);
 		if ( empty( $updated ) ) {

--- a/docs/perf.md
+++ b/docs/perf.md
@@ -140,8 +140,6 @@ add_filter( 'action_scheduler_retention_period_for_failed', function( $retention
 add_filter( 'action_scheduler_retention_period_for_failed', '__return_zero' );
 ```
 
-> Note: returning `0` from `action_scheduler_retention_period_by_default` or `action_scheduler_retention_period` does not preserve actions — on the next cleanup execution, all complete and canceled actions will be eligible for deletion.
-
 Prior to version 3.9.4, by default Action Scheduler does not automatically delete old failed actions. There are two optional methods of removing these actions:
 
 - Include the failed status in the list of statuses to purge:

--- a/docs/perf.md
+++ b/docs/perf.md
@@ -140,7 +140,7 @@ add_filter( 'action_scheduler_retention_period_for_failed', function( $retention
 add_filter( 'action_scheduler_retention_period_for_failed', '__return_zero' );
 ```
 
-Prior to version 3.9.4, by default Action Scheduler does not automatically delete old failed actions. There are two optional methods of removing these actions:
+Prior to version 3.9.4, by default Action Scheduler did not automatically delete old failed actions. There are two optional methods of removing these actions:
 
 - Include the failed status in the list of statuses to purge:
 ```php

--- a/docs/perf.md
+++ b/docs/perf.md
@@ -129,7 +129,20 @@ add_action( 'wp_ajax_nopriv_eg_create_additional_runners', 'eg_create_additional
 
 ## Cleaning Failed Actions
 
-By default, Action Scheduler does not automatically delete old failed actions. There are two optional methods of removing these actions:
+As of version 3.9.4, Action Scheduler retains failed actions for three months by default. If 'failed' is included in the purge statuses, the original behavior remains.
+The retention period for failed actions can be customized:
+
+```php
+add_filter( 'action_scheduler_retention_period_for_failed', function( $retention_period ) {
+    return 12 * MONTH_IN_SECONDS;
+} );
+// or if you prefer to retain failed actions indefinitely
+add_filter( 'action_scheduler_retention_period_for_failed', '__return_zero' );
+```
+
+> Note: returning `0` from `action_scheduler_retention_period_by_default` or `action_scheduler_retention_period` does not preserve actions — on the next cleanup execution, all complete and canceled actions will be eligible for deletion.
+
+Prior to version 3.9.4, by default Action Scheduler does not automatically delete old failed actions. There are two optional methods of removing these actions:
 
 - Include the failed status in the list of statuses to purge:
 ```php

--- a/tests/phpunit/runner/ActionScheduler_QueueCleaner_Test.php
+++ b/tests/phpunit/runner/ActionScheduler_QueueCleaner_Test.php
@@ -18,11 +18,13 @@ class ActionScheduler_QueueCleaner_Test extends ActionScheduler_UnitTestCase {
 		}
 
 		$runner->run();
+		sleep( 1 );
 
-		add_filter( 'action_scheduler_retention_period', '__return_zero' ); // delete any finished job.
+		$callback = static function () { return 1; };
+		add_filter( 'action_scheduler_retention_period', $callback ); // delete any finished job.
 		$cleaner = new ActionScheduler_QueueCleaner( $store );
 		$cleaned = $cleaner->delete_old_actions();
-		remove_filter( 'action_scheduler_retention_period', '__return_zero' );
+		remove_filter( 'action_scheduler_retention_period', $callback );
 
 		$this->assertIsArray( $cleaned, 'ActionScheduler_QueueCleaner::delete_old_actions() returns an array.' );
 		$this->assertCount( 5, $cleaned, 'ActionScheduler_QueueCleaner::delete_old_actions() deleted the expected number of actions.' );
@@ -34,13 +36,11 @@ class ActionScheduler_QueueCleaner_Test extends ActionScheduler_UnitTestCase {
 	}
 
 	public function test_invalid_retention_period_filter_hook() {
-		// Supplying a non-integer such as null would break under 3.5.4 and earlier.
+		// Non-integer inputs are managed through type casting and range checking.
 		add_filter( 'action_scheduler_retention_period', '__return_null' );
 		$cleaner = new ActionScheduler_QueueCleaner( ActionScheduler::store() );
-
-		$this->setExpectedIncorrectUsage( 'ActionScheduler_QueueCleaner::delete_old_actions' );
 		$result = $cleaner->delete_old_actions();
-		remove_filter( 'action_scheduler_retention_period', '__return_zero' );
+		remove_filter( 'action_scheduler_retention_period', '__return_null' );
 
 		$this->assertIsArray(
 			$result,
@@ -169,5 +169,56 @@ class ActionScheduler_QueueCleaner_Test extends ActionScheduler_UnitTestCase {
 		$failed = $store->query_actions( array( 'status' => ActionScheduler_Store::STATUS_FAILED ) );
 		$this->assertEquals( $created_actions[0], $failed[0] );
 		$this->assertCount( 1, $failed );
+	}
+
+	/**
+	 * Ensures deleting old actions in stock state handles failed actions as well.
+	 *
+	 * @return void
+	 */
+	public function test_delete_old_failed_actions_separately_by_default() {
+		$cleaner = $this->getMockBuilder( ActionScheduler_QueueCleaner::class )
+			->setConstructorArgs( array() )
+			->setMethodsExcept( array( 'delete_old_actions', 'get_batch_size' ) )
+			->getMock();
+		$cleaner->expects( $this->exactly( 2 ) )
+			->method( 'clean_actions' )
+			->withConsecutive(
+				array( array( ActionScheduler_Store::STATUS_FAILED ), $this->anything(), 20 ),
+				array( array( ActionScheduler_Store::STATUS_COMPLETE, ActionScheduler_Store::STATUS_CANCELED ), $this->anything(), 20 )
+			)
+			->willReturnOnConsecutiveCalls( array( '...', '...', '...', '...', '...', '...' ), array( '-' ) );
+
+		$deleted = $cleaner->delete_old_actions();
+
+		$this->assertSame( array( '...', '...', '...', '...', '...', '...', '-' ), $deleted );
+	}
+
+	/**
+	 * Ensures deleting old actions handles failed actions in backward compatible way when the failed status is
+	 * injected 'via action_scheduler_default_cleaner_statuses' and not processed separately compared to the stock state.
+	 *
+	 * @return void
+	 */
+	public function test_delete_old_failed_actions_with_other_statuses() {
+		$filter = function () {
+			return array( ActionScheduler_Store::STATUS_COMPLETE, ActionScheduler_Store::STATUS_FAILED );
+		};
+		add_filter( 'action_scheduler_default_cleaner_statuses', $filter );
+
+		$cleaner = $this->getMockBuilder( ActionScheduler_QueueCleaner::class )
+			->setConstructorArgs( array() )
+			->setMethodsExcept( array( 'delete_old_actions', 'get_batch_size' ) )
+			->getMock();
+		$cleaner->expects( $this->once() )
+			->method( 'clean_actions' )
+			->with( array( ActionScheduler_Store::STATUS_COMPLETE, ActionScheduler_Store::STATUS_FAILED ), $this->anything(), 20 )
+			->willReturn( array( '...', '...' ) );
+
+		$deleted = $cleaner->delete_old_actions();
+
+		$this->assertSame( array( '...', '...' ), $deleted );
+
+		remove_filter( 'action_scheduler_default_cleaner_statuses', $filter );
 	}
 }


### PR DESCRIPTION
Partially addresses ACTSCH-15 #912.

The issue resurfaces in stats shared under p1772090743156589-slack-C08SVLULL3B. This PR limits the retention period for failed actions to three months to prevent failed actions from continuously increasing the A-S table size.

We are addressing A-S scalability issues in HVM caused by the accumulation of failed actions, which increases database table size and slows A-S performance. As the database is often the main bottleneck, slower A-S queries further impact performance, especially during BFCM.

> Note: The actions scheduler allows you to customize retention periods for action statuses, but these settings apply to all statuses collectively. However, failed statuses require a longer retention period than others to support troubleshooting while maintaining a manageable actions table size. This PR addresses this need.

> BC break note: By default, failed actions are purged after three months. Values returned by `action_scheduler_retention_period` are enforced more strictly. If the value cannot be resolved as a positive integer, a one-month retention period will be applied as a fallback.

Testing Instructions:

- Build the plugin from this branch and install it on your test system.
- Modify a completed action by setting its status to failed and updating all date fields to twelve months in the past.
- Navigate to the admin area.
- Confirm that the action record has been deleted.