### PR TITLE
Fix: include args in unique action WHERE clause to prevent cross-args blocking

### DIFF
--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -202,12 +202,14 @@ SELECT action_id FROM $table_name
 WHERE status IN ( $pending_status_placeholders )
 AND hook = %s
 AND `group_id` = %d
+AND args = %s
 ",
 			array_merge(
 				$pending_statuses,
 				array(
 					$data['hook'],
 					$data['group_id'],
+					$data['args'],
 				)
 			)
 		);

--- a/tests/phpunit/jobstore/ActionScheduler_DBStore_Test.php
+++ b/tests/phpunit/jobstore/ActionScheduler_DBStore_Test.php
@@ -629,7 +629,8 @@ class ActionScheduler_DBStore_Test extends AbstractStoreTest {
 	}
 
 	/**
-	 * Test asserting that action when an action is created with empty args, it matches with actions created with args for uniqueness.
+	 * Test that a unique action with non-empty args does not block a unique action with empty args on the same hook/group,
+	 * since they have different args and are legitimately distinct actions.
 	 */
 	public function test_create_action_unique_with_empty_array() {
 		$time     = as_get_datetime_object();
@@ -644,14 +645,15 @@ class ActionScheduler_DBStore_Test extends AbstractStoreTest {
 		$this->assertTrue( is_a( $action_from_db, ActionScheduler_Action::class ) );
 
 		$action_with_empty_args = new ActionScheduler_Action( $hook, array(), $schedule );
-		$action_id_duplicate    = $store->save_unique_action( $action_with_empty_args );
-		$this->assertEquals( 0, $action_id_duplicate );
+		$action_id_empty_args   = $store->save_unique_action( $action_with_empty_args );
+		$this->assertNotEquals( 0, $action_id_empty_args );
 	}
 
 	/**
-	 * Uniqueness does not check for args, so actions with different args can't be scheduled when unique is true.
+	 * Test that unique actions with different args on the same hook/group are both schedulable.
+	 * Uniqueness checks hook + group + args, so different args should not block each other.
 	 */
-	public function test_create_action_unique_with_different_args_still_fail() {
+	public function test_create_action_unique_with_different_args() {
 		$time     = as_get_datetime_object();
 		$hook     = md5( wp_rand() );
 		$schedule = new ActionScheduler_SimpleSchedule( $time );
@@ -664,8 +666,8 @@ class ActionScheduler_DBStore_Test extends AbstractStoreTest {
 		$this->assertTrue( is_a( $action_from_db, ActionScheduler_Action::class ) );
 
 		$action_with_diff_args = new ActionScheduler_Action( $hook, array( 'foo' => 'bazz' ), $schedule );
-		$action_id_duplicate   = $store->save_unique_action( $action_with_diff_args );
-		$this->assertEquals( 0, $action_id_duplicate );
+		$action_id_diff_args   = $store->save_unique_action( $action_with_diff_args );
+		$this->assertNotEquals( 0, $action_id_diff_args );
 	}
 
 	/**


### PR DESCRIPTION
## Description

`ActionScheduler_DBStore::build_where_clause_for_insert()` checks for an existing pending/running action when `$unique = true`, but the WHERE clause only matched on `hook + group_id` — `args` was omitted. This caused two actions with the **same hook and group but different args** to incorrectly block each other.

**Before (buggy query):**
```sql
SELECT action_id FROM wp_actionscheduler_actions
WHERE status IN ('pending', 'in-progress')
AND hook = %s
AND `group_id` = %d
-- args missing — a pending action with args ['shop_order'] blocks ['shop_subscription'] on the same hook+group
LIMIT 1
```

**After (fixed query):**
```sql
SELECT action_id FROM wp_actionscheduler_actions
WHERE status IN ('pending', 'in-progress')
AND hook = %s
AND `group_id` = %d
AND args = %s
LIMIT 1
```

**Why `$data['args']` is always correct:** when args exceed the max index length, AS stores a hash in `args` and the full JSON in `extended_args`. The `args` field is therefore always the consistent lookup field for uniqueness checks.

**Discovered via:** duplicate recurring AS chains in production caused by `woocommerce_refresh_order_count_cache` with args `['shop_order']` incorrectly blocking the same hook with args `['shop_subscription']`.

**Note on testing with `ActionScheduler_HybridStore`:** environments still using `HybridStore` won't reproduce this bug via `as_schedule_single_action` — `HybridStore` has no `save_unique_action`, so the factory falls back to a `find_action`-based check that already includes args. Test by calling `ActionScheduler_DBStore::save_unique_action` directly (see instructions below).

## Changes

- `classes/data-stores/ActionScheduler_DBStore.php`: add `AND args = %s` and `$data['args']` to the WHERE clause in `build_where_clause_for_insert()`
- `tests/phpunit/jobstore/ActionScheduler_DBStore_Test.php`: update two tests that were asserting the buggy behavior; rename `test_create_action_unique_with_different_args_still_fail` → `test_create_action_unique_with_different_args`

## Test instructions

**Run existing unit tests:**
```bash
./vendor/bin/phpunit tests/phpunit/jobstore/ActionScheduler_DBStore_Test.php \
  -c tests/phpunit.xml.dist \
  --filter "test_create_action_unique"
```

All uniqueness tests should pass, including the updated `test_create_action_unique_with_different_args` and `test_create_action_unique_with_empty_array`.

**Manual verification on a local WordPress + WooCommerce site** (call `ActionScheduler_DBStore` directly to bypass `HybridStore`):

```php
global $wpdb;
$t     = $wpdb->prefix . 'actionscheduler_actions';
$store = new ActionScheduler_DBStore();
$sched = new ActionScheduler_SimpleSchedule( as_get_datetime_object( time() + 3600 ) );

// Test 1: Different args — both should schedule (fix stops them blocking each other)
$hook  = 'as_fix_test_diff_' . uniqid();
$group = 'as_fix_test_grp_' . uniqid();
$id1 = $store->save_unique_action( new ActionScheduler_Action( $hook, ['k' => 'X'], $sched, $group ) );
$id2 = $store->save_unique_action( new ActionScheduler_Action( $hook, ['k' => 'Y'], $sched, $group ) );
$cnt = $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM $t WHERE hook=%s AND status='pending'", $hook ) );
echo "Diff args: id1=$id1 id2=$id2 pending_in_db=$cnt\n";
echo ( $id2 !== 0 && $cnt == 2 ) ? "PASS\n" : "FAIL (id2 should be non-zero, pending should be 2)\n";
$wpdb->query( $wpdb->prepare( "DELETE FROM $t WHERE hook=%s", $hook ) );

// Test 2: Same args — second must still be blocked (deduplication must not regress)
$hook2 = 'as_fix_test_same_' . uniqid();
$a1 = $store->save_unique_action( new ActionScheduler_Action( $hook2, ['k' => 'v'], $sched, $group ) );
$a2 = $store->save_unique_action( new ActionScheduler_Action( $hook2, ['k' => 'v'], $sched, $group ) );
$cnt2 = $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM $t WHERE hook=%s AND status='pending'", $hook2 ) );
echo "Same args: a1=$a1 a2=$a2 pending_in_db=$cnt2\n";
echo ( $a2 === 0 && $cnt2 == 1 ) ? "PASS\n" : "FAIL (a2 should be 0, pending should be 1)\n";
$wpdb->query( $wpdb->prepare( "DELETE FROM $t WHERE hook=%s", $hook2 ) );
```

Save the above as a PHP file and run it via `wp eval-file yourfile.php`, or paste into WP shell (`wp shell`).

**On trunk (before fix):**
```
Diff args: id1=<id> id2=0 pending_in_db=1
FAIL
Same args: a1=<id> a2=0 pending_in_db=1
PASS
```

**On this branch (after fix):**
```
Diff args: id1=<id> id2=<id> pending_in_db=2
PASS
Same args: a1=<id> a2=0 pending_in_db=1
PASS
```
