### PR TITLE
Update require_once path for Cancel_CommandFix absolute import

### DIFF
--- a/classes/WP_CLI/Action_Command.php
+++ b/classes/WP_CLI/Action_Command.php
@@ -34,7 +34,7 @@ class Action_Command extends \WP_CLI_Command {
 	 * @return void
 	 */
 	public function cancel( array $args, array $assoc_args ) {
-		require_once 'Action/Cancel_Command.php';
+		require_once __DIR__ . 'Action/Cancel_Command.php';
 		$command = new Action\Cancel_Command( $args, $assoc_args );
 		$command->execute();
 	}

--- a/classes/WP_CLI/Action_Command.php
+++ b/classes/WP_CLI/Action_Command.php
@@ -34,7 +34,7 @@ class Action_Command extends \WP_CLI_Command {
 	 * @return void
 	 */
 	public function cancel( array $args, array $assoc_args ) {
-		require_once __DIR__ . 'Action/Cancel_Command.php';
+		require_once __DIR__ . '/Action/Cancel_Command.php';
 		$command = new Action\Cancel_Command( $args, $assoc_args );
 		$command->execute();
 	}
@@ -86,7 +86,7 @@ class Action_Command extends \WP_CLI_Command {
 	 * @return void
 	 */
 	public function create( array $args, array $assoc_args ) {
-		require_once 'Action/Create_Command.php';
+		require_once __DIR__ . '/Action/Create_Command.php';
 		$command = new Action\Create_Command( $args, $assoc_args );
 		$command->execute();
 	}
@@ -118,7 +118,7 @@ class Action_Command extends \WP_CLI_Command {
 	 * @return void
 	 */
 	public function delete( array $args, array $assoc_args ) {
-		require_once 'Action/Delete_Command.php';
+		require_once __DIR__ . '/Action/Delete_Command.php';
 		$command = new Action\Delete_Command( $args, $assoc_args );
 		$command->execute();
 	}
@@ -167,7 +167,7 @@ class Action_Command extends \WP_CLI_Command {
 	 * @return void
 	 */
 	public function generate( array $args, array $assoc_args ) {
-		require_once 'Action/Generate_Command.php';
+		require_once __DIR__ . '/Action/Generate_Command.php';
 		$command = new Action\Generate_Command( $args, $assoc_args );
 		$command->execute();
 	}
@@ -205,7 +205,7 @@ class Action_Command extends \WP_CLI_Command {
 	 * @return void
 	 */
 	public function get( array $args, array $assoc_args ) {
-		require_once 'Action/Get_Command.php';
+		require_once __DIR__ . '/Action/Get_Command.php';
 		$command = new Action\Get_Command( $args, $assoc_args );
 		$command->execute();
 	}
@@ -263,7 +263,7 @@ class Action_Command extends \WP_CLI_Command {
 	 * @subcommand list
 	 */
 	public function subcommand_list( array $args, array $assoc_args ) {
-		require_once 'Action/List_Command.php';
+		require_once __DIR__ . '/Action/List_Command.php';
 		$command = new Action\List_Command( $args, $assoc_args );
 		$command->execute();
 	}
@@ -315,7 +315,7 @@ class Action_Command extends \WP_CLI_Command {
 	 * @return void
 	 */
 	public function next( array $args, array $assoc_args ) {
-		require_once 'Action/Next_Command.php';
+		require_once __DIR__ . '/Action/Next_Command.php';
 		$command = new Action\Next_Command( $args, $assoc_args );
 		$command->execute();
 	}
@@ -347,7 +347,7 @@ class Action_Command extends \WP_CLI_Command {
 	 * @return void
 	 */
 	public function run( array $args, array $assoc_args ) {
-		require_once 'Action/Run_Command.php';
+		require_once __DIR__ . '/Action/Run_Command.php';
 		$command = new Action\Run_Command( $args, $assoc_args );
 		$command->execute();
 	}


### PR DESCRIPTION
This PR removes absolute imports to future-proof importing Action Scheduler on WPCOM.

Fixes #1319 

Part of future-proofing upgrading Woo on WPCOM (see [SHILL-1863: Upgrade Woo on Simple](https://linear.app/a8c/issue/SHILL-1863/upgrade-woo-on-simple))