### PR TITLE
fix: clarify timed-out action log message wording

### DIFF
--- a/classes/abstracts/ActionScheduler_Logger.php
+++ b/classes/abstracts/ActionScheduler_Logger.php
@@ -168,7 +168,7 @@ abstract class ActionScheduler_Logger {
 	 */
 	public function log_timed_out_action( $action_id, $timeout ) {
 		/* translators: %s: amount of time */
-		$this->log( $action_id, sprintf( __( 'action marked as failed after %s seconds. Unknown error occurred. Check server, PHP and database error logs to diagnose cause.', 'action-scheduler' ), $timeout ) );
+		$this->log( $action_id, sprintf( __( 'action was in-progress for at least %s seconds without completing and has been marked as failed. Check server, PHP and database error logs to diagnose cause.', 'action-scheduler' ), $timeout ) );
 	}
 
 	/**


### PR DESCRIPTION
## What

The log message for a timed-out action read:

> action marked as failed after 300 seconds

The value `300` comes from `10 × get_time_limit()` — it's the cleanup window, not the time the action actually ran. With a 30-second PHP time limit, the log implies the action ran for five minutes when in reality it ran for at most 30 seconds. This regularly trips up developers reading logs when diagnosing slow or hung actions.

**Before:**
```
action marked as failed after %s seconds. Unknown error occurred.
```

**After:**
```
action was in-progress for at least %s seconds without completing and has been marked as failed.
```

The new wording makes it clear that `%s` is the minimum elapsed time at which the cleaner *checked*, not a measurement of how long the action actually ran.

## Why not change the value passed?

Changing the multiplier or the method signature would affect the cleanup window logic, which is a separate concern. The wording fix is the minimal, safe change — it corrects the misleading implication without touching any behavior.

Related to #980

---
*Development and testing assisted by AI. All code reviewed and verified manually.*