### PR TITLE
Ensure cleanup action is enqueued via queue runner

### DIFF
--- a/classes/ActionScheduler_QueueCleaner.php
+++ b/classes/ActionScheduler_QueueCleaner.php
@@ -238,12 +238,32 @@ class ActionScheduler_QueueCleaner {
 			$continue_scheduled_cleanup = $continue_scheduled_cleanup || ( $iteration_execution_budget === $fetched_actions_count );
 		}
 
-		if ( $is_scheduled_cleanup && $continue_scheduled_cleanup ) {
-			// Use a separate hook with unique=true so at most one follow-up cleanup is ever pending.
-			as_schedule_single_action( time(), self::CONTINUE_SCHEDULED_CLEANER_HOOK, array(), 'ActionScheduler', true, 0 );
+		// When called from the scheduled cleanup hook, unique=true prevents duplicates at the SQL level. When called
+		// from a continuation, that same flag would match the running entry, so check for a pending continuation first.
+		$called_from_run = doing_action( self::RUN_SCHEDULED_CLEANER_HOOK );
+		if ( $is_scheduled_cleanup && $continue_scheduled_cleanup && ( $called_from_run || ! $this->has_pending_continuation() ) ) {
+			as_schedule_single_action( time(), self::CONTINUE_SCHEDULED_CLEANER_HOOK, array(), 'ActionScheduler', $called_from_run, 0 );
 		}
 
 		return array_merge( array(), ...$deleted_actions );
+	}
+
+	/**
+	 * Whether a continuation of the cleanup is already queued.
+	 *
+	 * @return bool
+	 */
+	private function has_pending_continuation() {
+		$pending = as_get_scheduled_actions(
+			array(
+				'hook'     => self::CONTINUE_SCHEDULED_CLEANER_HOOK,
+				'status'   => ActionScheduler_Store::STATUS_PENDING,
+				'per_page' => 1,
+			),
+			'ids'
+		);
+
+		return ! empty( $pending );
 	}
 
 	/**

--- a/classes/ActionScheduler_QueueCleaner.php
+++ b/classes/ActionScheduler_QueueCleaner.php
@@ -12,7 +12,7 @@ class ActionScheduler_QueueCleaner {
 	private const RUN_SCHEDULED_CLEANER_HOOK = 'action_scheduler_run_actions_cleanup_hook';
 
 	/**
-	 * Hook used to keep deleting old actions in batches; unique=true ensures only one is pending at a time.
+	 * Hook used to keep deleting old actions in batches, with at most one continuation pending at a time.
 	 *
 	 * @var string
 	 */

--- a/classes/ActionScheduler_RecurringActionScheduler.php
+++ b/classes/ActionScheduler_RecurringActionScheduler.php
@@ -24,6 +24,8 @@ class ActionScheduler_RecurringActionScheduler {
 	 */
 	public function init(): void {
 		add_action( self::RUN_SCHEDULED_RECURRING_ACTIONS_HOOK, array( $this, 'run_recurring_scheduler_hook' ) );
+		// Also run the check during queue processing, so installs without admin traffic still schedule the recurring action.
+		add_action( 'action_scheduler_before_process_queue', array( $this, 'schedule_recurring_scheduler_hook' ) );
 		if ( is_admin() && ! wp_doing_ajax() && ! wp_is_serving_rest_request() ) {
 			add_action( 'action_scheduler_init', array( $this, 'schedule_recurring_scheduler_hook' ) );
 		}

--- a/tests/phpunit/ActionScheduler_Mocker.php
+++ b/tests/phpunit/ActionScheduler_Mocker.php
@@ -18,6 +18,9 @@ class ActionScheduler_Mocker {
 			$store = ActionScheduler_Store::instance();
 		}
 
+		// Mark the recurring-actions check as already done so it doesn't queue a recurring action during unrelated tests.
+		set_transient( 'as_is_ensure_recurring_actions_scheduled', true, HOUR_IN_SECONDS );
+
 		return new ActionScheduler_QueueRunner( $store, null, null, self::get_async_request_queue_runner( $store ) );
 	}
 


### PR DESCRIPTION
The cleanup routine introduced in #1312 depends on `action_scheduler_ensure_recurring_actions`, which in turn, [is scheduled behind an `is_admin()` check](https://github.com/woocommerce/action-scheduler/blob/a5fdd7febce33871ced133fcc2a265b090904d21/classes/ActionScheduler_RecurringActionScheduler.php#L27-L29).

For sites with no admin page views, we still want the cleanup to be scheduled. This PR ensures that this happens during any queue run and also changes the job from a recurring one to a regular scheduled one. Given each run schedules its own tail cleanup job (and that one in turn does the same), there's no need for a recurring one.

## Testing Instructions

0. Reset actions from a previous test run (if any):
   ```
   wp db query 'DELETE FROM wp_actionscheduler_actions WHERE hook IN ("test_cleanup_old_action", "dummy_test_hook", "action_scheduler_run_actions_cleanup_hook", "action_scheduler_continue_actions_cleanup_hook", "action_scheduler_run_recurring_actions_schedule_hook")'

   wp transient delete as_is_ensure_recurring_actions_scheduled
   ```
1. Confirm there's no meta-recurring action pending:
   ```
   wp action-scheduler action list --hook=action_scheduler_run_recurring_actions_schedule_hook --status=pending
   ```
1. Schedule a dummy action so that we have something to execute during a first run and run:
   ```
   wp eval 'as_schedule_single_action( time(), "dummy_test_hook" );'
   wp action-scheduler run
   ```
1. Confirm the meta-recurring action has been scheduled:
   ```
   wp action-scheduler action list --hook=action_scheduler_run_recurring_actions_schedule_hook --status=pending
   ```

   The action should be scheduled for tomorrow 3 AM.
1. Confirm there's no cleanup scheduled at this point:

   ```
   wp action-scheduler action list --hook=action_scheduler_run_actions_cleanup_hook --status=pending
   ```
1. Run the meta-recurring action and confirm that schedules the recurring cleanup as well:
   ```
   META_ID=$(wp action-scheduler action list --hook=action_scheduler_run_recurring_actions_schedule_hook --status=pending --format=ids)
   wp action-scheduler action run $META_ID

   wp action-scheduler action list --hook=action_scheduler_run_actions_cleanup_hook --status=pending --fields=hook,recurring,scheduled_date
   ```
1. Insert ~10k old actions into the database to simulate a backlog. Use the helper script below (`insert-test-data.php`):
   ```
   wp eval-file insert-test-data.php

   # Should return ~10,000.
   wp db query 'SELECT COUNT(*) FROM wp_actionscheduler_actions WHERE hook = "test_cleanup_old_action"'
   ```

   <details><summary>insert-test-data.php</summary>
   <p>

   ```php
   <?php
   global $wpdb;
   
   $past     = as_get_datetime_object( '-12 months' );
   $past_gmt = $past->format( 'Y-m-d H:i:s' );
   $schedule = serialize( new ActionScheduler_SimpleSchedule( $past ) );
   
   foreach ( array( 'failed', 'complete', 'canceled' ) as $status ) {
	   for ( $i = 0; $i < 3334; $i++ ) {
		   $wpdb->insert( $wpdb->actionscheduler_actions, array(
			   'hook'                 => 'test_cleanup_old_action',
			   'status'               => $status,
			   'scheduled_date_gmt'   => $past_gmt,
			   'scheduled_date_local' => $past_gmt,
			   'args'                 => '[]',
			   'schedule'             => $schedule,
			   'group_id'             => 0,
			   'priority'             => 10,
			   'last_attempt_gmt'     => $past_gmt,
			   'last_attempt_local'   => $past_gmt,
		   ) );
	   }
   }

   ```
   </p>
   </details> 
1. Force-run the pending cleanup:

   ```
   CLEANUP_ID=$(wp action-scheduler action list --hook=action_scheduler_run_actions_cleanup_hook --status=pending --format=ids)
   wp action-scheduler action run $CLEANUP_ID
   ```
1. Continue draining the continuation queue one batch at a time, and confirm that there's always at most 1 continuation more scheduled and the old actions are indeed being deleted:

   ```
   wp action-scheduler run --hooks=action_scheduler_continue_actions_cleanup_hook --batch-size=25 --batches=1

   wp action-scheduler action list --hook=action_scheduler_continue_actions_cleanup_hook --status=pending

   wp db query 'SELECT COUNT(*) FROM wp_actionscheduler_actions WHERE hook = "test_cleanup_old_action"'
   ```
1. Run until no continuation remains:
   ```
   wp action-scheduler run
   ```
1. Confirm the backlog is fully gone:
   ```
   wp db query 'SELECT COUNT(*) FROM wp_actionscheduler_actions WHERE hook = "test_cleanup_old_action"'
   ```
