### PR TITLE
[dev] details on BC break in 3.9.4

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,7 +2,7 @@
 
 = 3.9.4 =
 * Breaking change: Failed actions are now automatically purged after three months by default. Use the `action_scheduler_retention_period_for_failed` filter to adjust or pass `__return_zero` to disable. (#1310)
-* Breaking change: Action cleanup is now a separate daily scheduled task running at 3 am site time instead of inline on every queue run. Custom `ActionScheduler_QueueCleaner` subclasses and custom queue runner classes preserve the previous inline behavior. (#1312)
+* Performance: Action cleanup now runs as a dedicated daily task at 3 am site time with higher throughput, keeping tables lean without competing with normal queue processing. Custom cleaner subclasses preserve existing behavior. (#1312)
 * Performance: Actions with corrupted data are automatically cancelled on detection and their excess logs cleaned up in batches, preventing queue stalls and log table bloat. (#1309)
 
 = 3.9.3 - 2025-07-15 =

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,10 @@
 *** Changelog ***
 
+= 3.9.4 =
+* Breaking change: Failed actions are now automatically purged after three months by default. Use the `action_scheduler_retention_period_for_failed` filter to adjust or pass `__return_zero` to disable. (#1310)
+* Breaking change: Action cleanup is now a separate daily scheduled task running at 3 am site time instead of inline on every queue run. Custom `ActionScheduler_QueueCleaner` subclasses and custom queue runner classes preserve the previous inline behavior. (#1312)
+* Performance: Actions with corrupted data are automatically cancelled on detection and their excess logs cleaned up in batches, preventing queue stalls and log table bloat. (#1309)
+
 = 3.9.3 - 2025-07-15 =
 * Add hook 'action_scheduler_ensure_recurring_actions' specifically for scheduling recurring actions.
 * Assume an action is valid until proven otherwise.


### PR DESCRIPTION
For the following 3 PRs:
- https://github.com/woocommerce/action-scheduler/pull/1310
- https://github.com/woocommerce/action-scheduler/pull/1309
- https://github.com/woocommerce/action-scheduler/pull/1312

Single BC break for an edge case:

```
  Failed actions now auto-expire (breaking)
                                                                                                                                                                    
  Failed actions are deleted after 90 days by default. Previously, they were never auto-deleted. Sites that rely on long-term retention of failed actions for auditing or retry logic need to opt out:        

  // Keep indefinitely (previous behavior)
  add_filter( 'action_scheduler_retention_period_for_failed', '__return_zero' );                                                                                                                               
   
  // Or set a custom period                                                                                                                                                                                    
  add_filter( 'action_scheduler_retention_period_for_failed', fn() => 12 * MONTH_IN_SECONDS );                                                                                                               
```

And it's also in docs: https://github.com/woocommerce/action-scheduler/blob/trunk/docs/perf.md?plain=1#L132