### PR TITLE
[Performance] Cache resolved group IDs to reduce the number of SQL queries

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@
 * Fix an oversight in the lock implementation (used to rate-limit async request runners) that could result in a database error in unusual cases.
 * Dev - Updates the `wpPostStore` to capture any database errors that might occur while claiming actions.
 * Performance - Reduce the number of SQL queries on Action Scheduler admin page.
+* Performance - Cache resolved group IDs to reduce the number of SQL queries.
 
 = 4.0.0 - 2026-06-16 =
 * Breaking change: action args are taken into account when scheduling unique actions.

--- a/classes/abstracts/ActionScheduler_Store.php
+++ b/classes/abstracts/ActionScheduler_Store.php
@@ -492,6 +492,12 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 	public function mark_migrated( $action_id ) {}
 
 	/**
+	 * Flush all store caches.
+	 */
+	public function flush_caches() {
+	}
+
+	/**
 	 * Get instance.
 	 *
 	 * @return ActionScheduler_Store

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -10,6 +10,16 @@
 class ActionScheduler_DBStore extends ActionScheduler_Store {
 
 	/**
+	 * WordPress object cache group for resolved group IDs.
+	 */
+	const GROUP_IDS_CACHE_GROUP = 'action_scheduler_groups';
+
+	/**
+	 * Cache key used for the default (empty-slug) group, since wp_cache_* rejects empty string keys.
+	 */
+	const GROUP_IDS_DEFAULT_CACHE_KEY = 'group:default';
+
+	/**
 	 * Used to share information about the before_date property of claims internally.
 	 *
 	 * This is used in preference to passing the same information as a method param
@@ -53,6 +63,23 @@ class ActionScheduler_DBStore extends ActionScheduler_Store {
 		$table_maker = new ActionScheduler_StoreSchema();
 		$table_maker->init();
 		$table_maker->register_tables();
+	}
+
+	/**
+	 * Flush all store caches.
+	 */
+	public function flush_caches() {
+		wp_cache_flush_group( self::GROUP_IDS_CACHE_GROUP );
+	}
+
+	/**
+	 * Translate a group slug into a valid (non-empty) object cache key.
+	 *
+	 * @param string $slug Group slug.
+	 * @return string
+	 */
+	private function get_group_cache_key( string $slug ): string {
+		return '' !== $slug ? $slug : self::GROUP_IDS_DEFAULT_CACHE_KEY;
 	}
 
 	/**
@@ -264,17 +291,17 @@ AND args = %s
 		}
 		return $this->hash_args( $encoded );
 	}
+
 	/**
 	 * Get a group's ID based on its name/slug.
 	 *
 	 * @param string|array $slugs                The string name of a group, or names for several groups.
 	 * @param bool         $create_if_not_exists Whether to create the group if it does not already exist. Default, true - create the group.
 	 *
-	 * @return array The group IDs, if they exist or were successfully created. May be empty.
+	 * @return int[] The group IDs, if they exist or were successfully created. May be empty.
 	 */
 	protected function get_group_ids( $slugs, $create_if_not_exists = true ) {
-		$slugs     = (array) $slugs;
-		$group_ids = array();
+		$slugs = (array) $slugs;
 
 		if ( empty( $slugs ) ) {
 			return array();
@@ -287,16 +314,54 @@ AND args = %s
 		 */
 		global $wpdb;
 
+		// For the primary path, resolve slugs using the WordPress cache first, then identify which slugs require a database lookup.
+		$group_ids  = array();
+		$unresolved = array();
 		foreach ( $slugs as $slug ) {
-			$group_id = (int) $wpdb->get_var( $wpdb->prepare( "SELECT group_id FROM {$wpdb->actionscheduler_groups} WHERE slug=%s", $slug ) );
+			$cached_group_id = wp_cache_get( $this->get_group_cache_key( (string) $slug ), self::GROUP_IDS_CACHE_GROUP );
+			if ( false !== $cached_group_id ) {
+				$group_ids[] = (int) $cached_group_id;
+			} else {
+				$unresolved[] = $slug;
+			}
+		}
 
-			if ( empty( $group_id ) && $create_if_not_exists ) {
-				$group_id = $this->create_group( $slug );
+		// For the secondary or initialization path, bulk-resolve any remaining slugs from the database.
+		if ( ! empty( $unresolved ) ) {
+			$resolved = array();
+
+			// Bulk-fetch unresolved slugs from the database. It is acceptable not to use wp_cache_set_multiple to maintain code simplicity.
+			$placeholders = implode( ', ', array_fill( 0, count( $unresolved ), '%s' ) );
+			$rows         = $wpdb->get_results(
+				$wpdb->prepare(
+					// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+					"SELECT group_id, slug FROM {$wpdb->actionscheduler_groups} WHERE slug IN ( $placeholders )",
+					...$unresolved
+				)
+			);
+			foreach ( $rows as $row ) {
+				$resolved[] = $row->slug;
+				wp_cache_set( $this->get_group_cache_key( $row->slug ), $row->group_id, self::GROUP_IDS_CACHE_GROUP, 10 * MINUTE_IN_SECONDS );
 			}
 
-			if ( $group_id ) {
-				$group_ids[] = $group_id;
+			// Automatically create unresolved slugs if requested.
+			if ( $create_if_not_exists ) {
+				foreach ( array_diff( $unresolved, $resolved ) as $slug ) {
+					$this->create_group( $slug );
+				}
 			}
+
+			// Ensure stable sorting by aligning the IDs, which are currently sourced from various locations, to match the order of the provided slugs.
+			$group_ids = array_values(
+				array_filter(
+					array_map(
+						function ( $slug ) {
+							return (int) wp_cache_get( $this->get_group_cache_key( (string) $slug ), self::GROUP_IDS_CACHE_GROUP );
+						},
+						$slugs
+					)
+				)
+			);
 		}
 
 		return $group_ids;
@@ -319,7 +384,12 @@ AND args = %s
 
 		$wpdb->insert( $wpdb->actionscheduler_groups, array( 'slug' => $slug ) );
 
-		return (int) $wpdb->insert_id;
+		$group_id = (int) $wpdb->insert_id;
+		if ( $group_id ) {
+			wp_cache_set( $this->get_group_cache_key( $slug ), $group_id, self::GROUP_IDS_CACHE_GROUP, 10 * MINUTE_IN_SECONDS );
+		}
+
+		return $group_id;
 	}
 
 	/**

--- a/classes/data-stores/ActionScheduler_HybridStore.php
+++ b/classes/data-stores/ActionScheduler_HybridStore.php
@@ -79,6 +79,14 @@ class ActionScheduler_HybridStore extends Store {
 	}
 
 	/**
+	 * Flush all store caches.
+	 */
+	public function flush_caches() {
+		$this->primary_store->flush_caches();
+		$this->secondary_store->flush_caches();
+	}
+
+	/**
 	 * When the actions table is created, set its autoincrement
 	 * value to be one higher than the posts table to ensure that
 	 * there are no ID collisions.

--- a/tests/ActionScheduler_UnitTestCase.php
+++ b/tests/ActionScheduler_UnitTestCase.php
@@ -26,6 +26,7 @@ class ActionScheduler_UnitTestCase extends WP_UnitTestCase {
 	 */
 	public function tear_down() {
 		ActionScheduler_Callbacks::remove_callbacks();
+		ActionScheduler::store()->flush_caches();
 		parent::tear_down();
 	}
 

--- a/tests/phpunit/jobstore/ActionScheduler_DBStore_Test.php
+++ b/tests/phpunit/jobstore/ActionScheduler_DBStore_Test.php
@@ -927,4 +927,29 @@ class ActionScheduler_DBStore_Test extends AbstractStoreTest {
 		$store = new ActionScheduler_DBStore();
 		$this->assertIsInt( $store->get_claim_count() );
 	}
+
+	/**
+	 * @testdox get_group_ids() resolves a pre-cached slug, a cold slug, and an empty slug; populates the object cache for all three groups.
+	 */
+	public function test_get_group_ids_resolves_mixed_cached_and_uncached_slugs() {
+		$store    = new class() extends ActionScheduler_DBStore {
+			// phpcs:ignore Generic.CodeAnalysis.UselessOverridingMethod.Found
+			public function get_group_ids( $slugs, $create_if_not_exists = true ) {
+				return parent::get_group_ids( $slugs, $create_if_not_exists );
+			}
+		};
+		$schedule = new ActionScheduler_SimpleSchedule( as_get_datetime_object() );
+
+		// Saving an action warms the object cache for 'cached_group'.
+		$store->save_action( new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, array(), $schedule, 'cached_group' ) );
+		$ids = $store->get_group_ids( array( 'cached_group', 'uncached_group', '' ) );
+
+		$this->assertCount( 3, $ids );
+		$this->assertGreaterThan( 0, $ids[0] );
+		$this->assertGreaterThan( 0, $ids[1] );
+		$this->assertGreaterThan( 0, $ids[2] );
+		$this->assertSame( (int) wp_cache_get( 'cached_group', ActionScheduler_DBStore::GROUP_IDS_CACHE_GROUP ), $ids[0] );
+		$this->assertSame( (int) wp_cache_get( 'uncached_group', ActionScheduler_DBStore::GROUP_IDS_CACHE_GROUP ), $ids[1] );
+		$this->assertSame( (int) wp_cache_get( ActionScheduler_DBStore::GROUP_IDS_DEFAULT_CACHE_KEY, ActionScheduler_DBStore::GROUP_IDS_CACHE_GROUP ), $ids[2] );
+	}
 }


### PR DESCRIPTION
Lowers the number of SQL queries and increases throughput during bulk tasks processing and scheduling.

Testing:
- Automated: CI-checks shall pass
- Smoke test: build fresh zip and install it on the test site, perform products import and verify related actions scheduler jobs has been added to the queue.