### PR TITLE
Add filter to disable failed action cleanup and simplify retention filters

### DIFF
--- a/classes/ActionScheduler_QueueCleaner.php
+++ b/classes/ActionScheduler_QueueCleaner.php
@@ -146,7 +146,11 @@ class ActionScheduler_QueueCleaner {
 		 *
 		 * @param string[] $default_statuses_to_purge Action statuses to clean.
 		 */
-		$statuses_to_purge = (array) apply_filters( 'action_scheduler_default_cleaner_statuses', $this->default_statuses_to_purge );
+		$statuses_to_purge = apply_filters( 'action_scheduler_default_cleaner_statuses', $this->default_statuses_to_purge );
+		// Only an explicit empty array disables the purge; a non-array (e.g. a filter that forgot to return) falls back to the defaults.
+		if ( ! is_array( $statuses_to_purge ) ) {
+			$statuses_to_purge = $this->default_statuses_to_purge;
+		}
 
 		/**
 		 * Filter whether failed actions are purged. Return false to disable failed action cleanup.

--- a/classes/ActionScheduler_QueueCleaner.php
+++ b/classes/ActionScheduler_QueueCleaner.php
@@ -110,15 +110,7 @@ class ActionScheduler_QueueCleaner {
 		 * @param int $retention_period Minimum scheduled age in seconds of the actions to be deleted.
 		 */
 		$lifespan = apply_filters( 'action_scheduler_retention_period', $this->month_in_seconds );
-
-		/**
-		 * Set the retention period, in seconds, for actions with a status returned by the action_scheduler_default_cleaner_statuses filter.
-		 * Zero means purge immediately. Negative or non-numeric values default to one month.
-		 *
-		 * @param int $retention_period Retention period in seconds.
-		 */
-		$lifespan_default = apply_filters( 'action_scheduler_retention_period_by_default', $lifespan );
-		$lifespan_default = ( is_numeric( $lifespan_default ) && $lifespan_default >= 0 ) ? (int) $lifespan_default : $this->month_in_seconds;
+		$lifespan = is_numeric( $lifespan ) ? max( 0, (int) $lifespan ) : $this->month_in_seconds;
 
 		/**
 		 * Set the retention period in seconds for actions with a failed status. If the action_scheduler_default_cleaner_statuses filter includes
@@ -126,14 +118,15 @@ class ActionScheduler_QueueCleaner {
 		 *
 		 * @param int $retention_period Retention period in seconds.
 		 */
-		$lifespan_failed = max( 0, (int) apply_filters( 'action_scheduler_retention_period_for_failed', 3 * $this->month_in_seconds ) );
+		$lifespan_failed = apply_filters( 'action_scheduler_retention_period_for_failed', 3 * $this->month_in_seconds );
+		$lifespan_failed = is_numeric( $lifespan_failed ) ? max( 0, (int) $lifespan_failed ) : 3 * $this->month_in_seconds;
 		// We considered 12-month, 3-month, and 1-month options for failed action retention and selected a 3-month period
 		// to align with the quarterly accounting cycle. Store owners may adjust the retention period to achieve PCI DSS
 		// compliance or to align with a different accounting cycle, as needed.
 
 		try {
-			$cutoff_failed  = as_get_datetime_object( $lifespan_failed . ' seconds ago' );
-			$cutoff_default = as_get_datetime_object( $lifespan_default . ' seconds ago' );
+			$cutoff_failed = as_get_datetime_object( $lifespan_failed . ' seconds ago' );
+			$cutoff        = as_get_datetime_object( $lifespan . ' seconds ago' );
 		} catch ( Exception $e ) {
 			_doing_it_wrong(
 				__METHOD__,
@@ -155,14 +148,26 @@ class ActionScheduler_QueueCleaner {
 		 */
 		$statuses_to_purge = (array) apply_filters( 'action_scheduler_default_cleaner_statuses', $this->default_statuses_to_purge );
 
+		/**
+		 * Filter whether failed actions are purged. Return false to disable failed action cleanup.
+		 *
+		 * @since 4.0.0
+		 *
+		 * @param bool $enabled Whether failed actions should be purged. Default true.
+		 */
+		$clean_failed = (bool) apply_filters( 'action_scheduler_enable_failed_action_cleanup', true );
+
 		$deleted_failed_entries = array();
 		// Backward compatibility note: if store already purging the failed statuses, don't change the behaviour.
-		if ( $lifespan_failed > 0 && ! in_array( ActionScheduler_Store::STATUS_FAILED, $statuses_to_purge, true ) ) {
+		if ( $clean_failed && ! in_array( ActionScheduler_Store::STATUS_FAILED, $statuses_to_purge, true ) ) {
 			// Use a fixed default batch size to ensure that the cleanup of failed actions does not interfere with the regular cleanup.
 			$deleted_failed_entries = $this->clean_actions( array( ActionScheduler_Store::STATUS_FAILED ), $cutoff_failed, 20 );
 		}
 
-		$deleted_entries = $this->clean_actions( $statuses_to_purge, $cutoff_default, $this->get_batch_size() );
+		$deleted_entries = array();
+		if ( ! empty( $statuses_to_purge ) ) {
+			$deleted_entries = $this->clean_actions( $statuses_to_purge, $cutoff, $this->get_batch_size() );
+		}
 
 		return array_merge( $deleted_failed_entries, $deleted_entries );
 	}

--- a/docs/perf.md
+++ b/docs/perf.md
@@ -129,15 +129,20 @@ add_action( 'wp_ajax_nopriv_eg_create_additional_runners', 'eg_create_additional
 
 ## Cleaning Failed Actions
 
-As of version 4.0.0, Action Scheduler retains failed actions for three months by default. If 'failed' is included in the purge statuses, the original behavior remains.
-The retention period for failed actions can be customized:
+As of version 4.0.0, Action Scheduler retains failed actions for three months by default. This retention period is independent of `action_scheduler_retention_period`. If 'failed' is included in the purge statuses, it is cleaned alongside the other statuses using their retention period instead.
+
+The retention period for failed actions can be customized. Zero purges them on the next cleanup pass; negative values are treated as zero:
 
 ```php
 add_filter( 'action_scheduler_retention_period_for_failed', function( $retention_period ) {
     return 12 * MONTH_IN_SECONDS;
 } );
-// or if you prefer to retain failed actions indefinitely
-add_filter( 'action_scheduler_retention_period_for_failed', '__return_zero' );
+```
+
+To retain failed actions indefinitely (the pre-4.0.0 behavior), disable failed cleanup entirely:
+
+```php
+add_filter( 'action_scheduler_enable_failed_action_cleanup', '__return_false' );
 ```
 
 Prior to version 4.0.0, by default Action Scheduler did not automatically delete old failed actions. There are two optional methods of removing these actions:

--- a/readme.txt
+++ b/readme.txt
@@ -49,7 +49,8 @@ Collaboration is cool. We'd love to work with you to improve Action Scheduler. [
 
 = 4.0.0 - 2026-06-16 =
 * Breaking change: action args are taken into account when scheduling unique actions.
-* Breaking change: failed actions are now automatically purged after 3 months by default.
+* Breaking change: failed actions are now automatically purged after 3 months by default, controlled by the `action_scheduler_retention_period_for_failed` filter.
+* Add `action_scheduler_enable_failed_action_cleanup` filter to disable automatic cleanup of failed actions.
 * Performance - Actions with corrupted data are automatically cancelled on detection and their excess logs cleaned up in batches, preventing queue stalls and log table bloat.
 * Performance - Action cleanup now runs as a dedicated daily task at 3 am site time with higher throughput.
 * Update favicon images.

--- a/tests/phpunit/runner/ActionScheduler_QueueCleaner_Test.php
+++ b/tests/phpunit/runner/ActionScheduler_QueueCleaner_Test.php
@@ -272,6 +272,37 @@ class ActionScheduler_QueueCleaner_Test extends ActionScheduler_UnitTestCase {
 	}
 
 	/**
+	 * Ensures a non-array return (e.g. a filter that forgot to return) falls back to the default statuses
+	 * rather than disabling the purge the way an explicit empty array does.
+	 *
+	 * @return void
+	 */
+	public function test_null_cleaner_statuses_falls_back_to_defaults() {
+		$filter = function () {
+			return null;
+		};
+		add_filter( 'action_scheduler_default_cleaner_statuses', $filter );
+
+		$cleaner = $this->getMockBuilder( ActionScheduler_QueueCleaner::class )
+			->setConstructorArgs( array() )
+			->setMethodsExcept( array( 'delete_old_actions', 'get_batch_size' ) )
+			->getMock();
+		$cleaner->expects( $this->exactly( 2 ) )
+			->method( 'clean_actions' )
+			->withConsecutive(
+				array( array( ActionScheduler_Store::STATUS_FAILED ), $this->anything(), 20 ),
+				array( array( ActionScheduler_Store::STATUS_COMPLETE, ActionScheduler_Store::STATUS_CANCELED ), $this->anything(), 20 )
+			)
+			->willReturnOnConsecutiveCalls( array( 'f' ), array( 'd' ) );
+
+		$deleted = $cleaner->delete_old_actions();
+
+		remove_filter( 'action_scheduler_default_cleaner_statuses', $filter );
+
+		$this->assertSame( array( 'f', 'd' ), $deleted );
+	}
+
+	/**
 	 * Ensures a zero failed retention period purges immediately rather than disabling the cleanup.
 	 *
 	 * @return void

--- a/tests/phpunit/runner/ActionScheduler_QueueCleaner_Test.php
+++ b/tests/phpunit/runner/ActionScheduler_QueueCleaner_Test.php
@@ -221,6 +221,126 @@ class ActionScheduler_QueueCleaner_Test extends ActionScheduler_UnitTestCase {
 	}
 
 	/**
+	 * Ensures failed action cleanup can be turned off entirely via the dedicated filter.
+	 *
+	 * @return void
+	 */
+	public function test_failed_cleanup_can_be_disabled() {
+		add_filter( 'action_scheduler_enable_failed_action_cleanup', '__return_false' );
+
+		$cleaner = $this->getMockBuilder( ActionScheduler_QueueCleaner::class )
+			->setConstructorArgs( array() )
+			->setMethodsExcept( array( 'delete_old_actions', 'get_batch_size' ) )
+			->getMock();
+		$cleaner->expects( $this->once() )
+			->method( 'clean_actions' )
+			->with( array( ActionScheduler_Store::STATUS_COMPLETE, ActionScheduler_Store::STATUS_CANCELED ), $this->anything(), 20 )
+			->willReturn( array( 'x' ) );
+
+		$deleted = $cleaner->delete_old_actions();
+
+		remove_filter( 'action_scheduler_enable_failed_action_cleanup', '__return_false' );
+
+		$this->assertSame( array( 'x' ), $deleted );
+	}
+
+	/**
+	 * Ensures an empty default cleaner status list stops completed/canceled actions from being purged.
+	 *
+	 * @return void
+	 */
+	public function test_empty_cleaner_statuses_skips_default_purge() {
+		$filter = function () {
+			return array();
+		};
+		add_filter( 'action_scheduler_default_cleaner_statuses', $filter );
+
+		$cleaner = $this->getMockBuilder( ActionScheduler_QueueCleaner::class )
+			->setConstructorArgs( array() )
+			->setMethodsExcept( array( 'delete_old_actions', 'get_batch_size' ) )
+			->getMock();
+		$cleaner->expects( $this->once() )
+			->method( 'clean_actions' )
+			->with( array( ActionScheduler_Store::STATUS_FAILED ), $this->anything(), 20 )
+			->willReturn( array( 'f' ) );
+
+		$deleted = $cleaner->delete_old_actions();
+
+		remove_filter( 'action_scheduler_default_cleaner_statuses', $filter );
+
+		$this->assertSame( array( 'f' ), $deleted );
+	}
+
+	/**
+	 * Ensures a zero failed retention period purges immediately rather than disabling the cleanup.
+	 *
+	 * @return void
+	 */
+	public function test_failed_retention_zero_purges_immediately() {
+		add_filter( 'action_scheduler_retention_period_for_failed', '__return_zero' );
+
+		$cutoff  = $this->capture_failed_cutoff();
+		$cleaner = $cutoff['cleaner'];
+		$cleaner->delete_old_actions();
+
+		remove_filter( 'action_scheduler_retention_period_for_failed', '__return_zero' );
+
+		$this->assertInstanceOf( DateTime::class, $cutoff['captured'](), 'Failed actions are still purged when the retention period is zero.' );
+		$this->assertLessThanOrEqual( 5, abs( time() - $cutoff['captured']()->getTimestamp() ), 'A zero retention period purges failed actions as of now.' );
+	}
+
+	/**
+	 * Ensures a negative failed retention period is clamped to zero (immediate) rather than a future cutoff.
+	 *
+	 * @return void
+	 */
+	public function test_negative_failed_retention_clamps_to_immediate() {
+		$negative = function () {
+			return -DAY_IN_SECONDS;
+		};
+		add_filter( 'action_scheduler_retention_period_for_failed', $negative );
+
+		$cutoff  = $this->capture_failed_cutoff();
+		$cleaner = $cutoff['cleaner'];
+		$cleaner->delete_old_actions();
+
+		remove_filter( 'action_scheduler_retention_period_for_failed', $negative );
+
+		$this->assertInstanceOf( DateTime::class, $cutoff['captured'](), 'A negative retention period still purges failed actions.' );
+		$this->assertLessThanOrEqual( 5, abs( time() - $cutoff['captured']()->getTimestamp() ), 'A negative retention period is clamped to now, not a future cutoff.' );
+	}
+
+	/**
+	 * Build a cleaner whose clean_actions() records the cutoff used for the failed status.
+	 *
+	 * @return array{cleaner: ActionScheduler_QueueCleaner, captured: callable}
+	 */
+	private function capture_failed_cutoff() {
+		$captured = null;
+
+		$cleaner = $this->getMockBuilder( ActionScheduler_QueueCleaner::class )
+			->setConstructorArgs( array() )
+			->setMethodsExcept( array( 'delete_old_actions', 'get_batch_size' ) )
+			->getMock();
+		$cleaner->method( 'clean_actions' )
+			->willReturnCallback(
+				function ( $statuses, $cutoff ) use ( &$captured ) {
+					if ( array( ActionScheduler_Store::STATUS_FAILED ) === $statuses ) {
+						$captured = $cutoff;
+					}
+					return array();
+				}
+			);
+
+		return array(
+			'cleaner'  => $cleaner,
+			'captured' => function () use ( &$captured ) {
+				return $captured;
+			},
+		);
+	}
+
+	/**
 	 * Verify that custom cleaners perform direct cleanup rather than task-based cleanup.
 	 */
 	public function test_custom_cleaner_performs_cleanup_in_queue_run_only() {


### PR DESCRIPTION
4.0.0 added automatic purging of failed actions (after 3 months). This PR makes that controllable and tidies up the retention filters before release.

### Behavior

| Want | Completed/canceled | Failed |
|---|---|---|
| Default | 31 days | 3 months |
| Custom window | `action_scheduler_retention_period` | `action_scheduler_retention_period_for_failed` |
| Immediately | return `0` | return `0` |
| Never | remove from `action_scheduler_default_cleaner_statuses` | `action_scheduler_enable_failed_action_cleanup` => false |