### PR TITLE
Add release instructions and restrict releases to trunk or newer

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,3 +12,4 @@ package.json export-ignore
 package-lock.json export-ignore
 phpcs.xml export-ignore
 phpunit.* export-ignore
+RELEASING.md export-ignore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,16 @@ jobs:
           token: ${{ github.token }}
           path: plugin
 
+      - name: Ensure version is not older than trunk
+        working-directory: plugin
+        run: |
+          set -euo pipefail
+          trunk_version=$(grep -m1 -oP 'Version:\s*\K[\d.]+' action-scheduler.php)
+          if ! php -r 'exit(version_compare($argv[1], $argv[2], ">=") ? 0 : 1);' "$VERSION" "$trunk_version"; then
+            echo "::error::${VERSION} is older than trunk (${trunk_version})."
+            exit 1
+          fi
+
       # Collect the titles of the PRs merged since the last release, one "* <title>" per line, and
       # write them to a file for the bash step below to fold into readme.txt.
       - name: Generate changelog entries

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,24 @@
+# Releasing Action Scheduler
+
+Releases run through the **Release Action Scheduler** workflow (`.github/workflows/release.yml`), triggered manually from the Actions tab.
+
+## Part 1: Release prep
+
+1. Open the [**Release Action Scheduler** workflow](https://github.com/woocommerce/action-scheduler/actions/workflows/release.yml).
+2. Click **Run workflow**, set **Version** to the release number (`x.y.z`), set **Which step** to `release prep`, leave **Dry run** checked, and click **Run workflow**.
+3. Open the run and read the diff in the job log. It also shows the changelog and the version bump.
+4. If the preview looks right, run the workflow again the same way but with **Dry run** unchecked.
+   Note that the changelog doesn't have to be perfect here, as it can be edited later.
+5. Confirm that branch `release/x.y.z` was created and a PR `Release prep: x.y.z` PR opened.
+6. On that PR, curate the changelog in `readme.txt` and confirm `Requires at least`, `Requires PHP`, and `Tested up to` are all correct.
+7. Merge the prep PR into `release/x.y.z`.
+
+## Part 2: Release
+
+1. Open the [**Release Action Scheduler** workflow](https://github.com/woocommerce/action-scheduler/actions/workflows/release.yml) again.
+2. Click **Run workflow**, use the same **Version** from Part 1, set **Which step** to `release`, leave **Dry run** checked, and click **Run workflow**.
+3. The dry run syncs `changelog.txt`, builds the package, and stages the WordPress.org upload without committing. Take a look at the SVN diff in the workflow logs and download the `action-scheduler-x.y.z-dryrun` artifact to check the generated plugin file.
+4. If everything looks good, run the workflow again with **Dry run** unchecked.
+6. Confirm that SVN's trunk on wporg was updated and that tag `x.y.z` was created both on [WordPress.org SVN](https://plugins.svn.wordpress.org/action-scheduler/) and in this repo.
+7. Fetch WordPress.org credentials for one of our accounts from the secret store and [confirm the release](https://wordpress.org/plugins/developers/releases/).
+8. Merge the `Merge release/x.y.z into trunk` PR that was opened to bring the version bump and changelog back into `trunk`.


### PR DESCRIPTION
Follow-up to the release workflow added recently.

- Add `RELEASING.md` at the repo root documenting the two-step release process (prep, then release). It's excluded from built ZIPs via a new `export-ignore` entry in `.gitattributes`.
- The release workflow now only handles versions at or ahead of trunk. The prep job validates the requested version against trunk's plugin header version (using PHP's `version_compare`) and fails fast otherwise.

### Testing
Both workflow steps default to a dry run, so they can be executed safely (no branches, commits, or uploads).

- Dry-run the prep step against this branch and confirm the job log shows the generated changelog and version bump, with nothing pushed:
  ```
  gh workflow run release.yml --ref version-based-release-branch \
    -f version=4.1.0 -f step="release prep" -f simulate=true
  ```
- Verify the new guard rejects an older-than-trunk version: run the same command with `-f version=3.9.0` and confirm the run fails at the "Ensure version is not older than trunk" step.
- Confirm `RELEASING.md` is absent from the build: `git archive HEAD | tar -t | grep RELEASING` returns nothing.
