### PR TITLE
Add claim order index for queue actions

### DIFF
--- a/classes/schema/ActionScheduler_StoreSchema.php
+++ b/classes/schema/ActionScheduler_StoreSchema.php
@@ -20,7 +20,7 @@ class ActionScheduler_StoreSchema extends ActionScheduler_Abstract_Schema {
 	 *
 	 * @var int
 	 */
-	protected $schema_version = 8;
+	protected $schema_version = 9;
 
 	/**
 	 * Construct.
@@ -81,6 +81,7 @@ class ActionScheduler_StoreSchema extends ActionScheduler_Abstract_Schema {
 				        KEY group_id (group_id),
 				        KEY last_attempt_gmt (last_attempt_gmt),
 				        KEY `claim_id_status_priority_scheduled_date_gmt` (`claim_id`,`status`,`priority`,`scheduled_date_gmt`),
+				        KEY `claim_id_status_priority_attempts_scheduled_date_gmt_action_id` (`claim_id`,`status`,`priority`,`attempts`,`scheduled_date_gmt`,`action_id`),
 				        KEY `status_last_attempt_gmt` (`status`,`last_attempt_gmt`),
 				        KEY `status_claim_id` (`status`,`claim_id`)
 				        ) $charset_collate";


### PR DESCRIPTION
## Summary

- bumps the custom table store schema version to add a claim-order index
- adds `claim_id_status_priority_attempts_scheduled_date_gmt_action_id` on `(claim_id,status,priority,attempts,scheduled_date_gmt,action_id)`
- targets the default queue runner claim query order: `priority ASC, attempts ASC, scheduled_date_gmt ASC, action_id ASC`

## Benchmark evidence

This came from the WooCommerce performance audit fixture published at:

https://adamziel.github.io/woocommerce/reports/woocommerce-deep-performance-audit-2026-07-02/

Relevant artifacts:

- `subscriptions-action-scheduler-scale-probe.json`
- `subscriptions-action-scheduler-claim-index-probe.json`

Most relevant validation was a 100k-row mixed Action Scheduler copied-table fixture:

- 100,000 pending actions
- 50,413 due actions
- 20% subscription-like target hook/group, 80% noise across 8 other hooks and 20 groups
- claim batch size 25
- MySQL 8.0.46, PHP 8.3, WooCommerce benchmark stack

Default unfiltered queue claim shape:

- existing indexes: SELECT median `36.959ms`, UPDATE-claim median `97.222ms`
- with this generic claim-order index: SELECT median `0.215ms`, UPDATE-claim median `5.449ms`

Filtered hook/group claim shape also improved with the same generic index:

- existing indexes: SELECT median `12.085ms`, UPDATE-claim median `23.444ms`
- with this generic claim-order index: SELECT median `0.358ms`, UPDATE-claim median `6.068ms`

The optimizer used the new index for the default claim query and avoided the prior filesort caused by the existing `claim_id_status_priority_scheduled_date_gmt` index missing the `attempts` ordering column.

## Notes

This is related to the older closed #1250, but trunk now has the later claim/deadlock changes including SKIP LOCKED. This PR is narrower: keep the existing index and add the attempts-aware claim-order index that matches the current queue runner ordering.

## Testing

- `php -l classes/schema/ActionScheduler_StoreSchema.php`
- `composer install --no-interaction --no-progress`
- `composer run-script lint`
- Reflection sanity check confirmed `schema_version=9`

`composer run-script test` could not run in this fresh clone because `/tmp/wordpress-tests-lib/includes/functions.php` is not installed.
