### PR TITLE
Harden schedule deserialization against PHP object injection

### DIFF
--- a/classes/ActionScheduler_ScheduleDeserializer.php
+++ b/classes/ActionScheduler_ScheduleDeserializer.php
@@ -214,6 +214,10 @@ class ActionScheduler_ScheduleDeserializer {
 	 * @return object|false
 	 */
 	protected static function handle_rejection( $data, $offending_class, $top_class, array $nested_classes ) {
+		// Resolve enforcement once so the reported value and the branch taken cannot disagree, and the
+		// action_scheduler_enforce_schedule_allowed_classes filter runs a single time.
+		$enforced = self::is_enforced();
+
 		/**
 		 * Fires when a stored schedule blob references a class Action Scheduler did not expect.
 		 *
@@ -225,9 +229,9 @@ class ActionScheduler_ScheduleDeserializer {
 		 * @param bool     $enforced        Whether the blob was rejected (true) or allowed through
 		 *                                  in shadow mode (false).
 		 */
-		do_action( 'action_scheduler_unexpected_schedule_class', $offending_class, $top_class, $nested_classes, self::is_enforced() );
+		do_action( 'action_scheduler_unexpected_schedule_class', $offending_class, $top_class, $nested_classes, $enforced );
 
-		if ( self::is_enforced() ) {
+		if ( $enforced ) {
 			return false;
 		}
 

--- a/classes/ActionScheduler_ScheduleDeserializer.php
+++ b/classes/ActionScheduler_ScheduleDeserializer.php
@@ -76,9 +76,11 @@ class ActionScheduler_ScheduleDeserializer {
 			return self::handle_rejection( $data, $top_class, $top_class, $nested_classes );
 		}
 
-		// Phase 2b: every nested object must be on the vetted allow-list.
+		// Phase 2b: every nested object must be on the vetted allow-list. Resolve the list (and run its
+		// filter) once here rather than per nested class, since it does not vary across the loop.
+		$allowed_nested = self::get_allowed_nested_classes();
 		foreach ( $nested_classes as $nested_class ) {
-			if ( ! self::is_allowed_nested_class( $nested_class ) ) {
+			if ( ! self::is_allowed_nested_class( $nested_class, $allowed_nested ) ) {
 				return self::handle_rejection( $data, $nested_class, $top_class, $nested_classes );
 			}
 		}
@@ -118,15 +120,21 @@ class ActionScheduler_ScheduleDeserializer {
 	 * CronExpression family. Composite schedules that nest another schedule are also fine. The
 	 * default list is filterable so extenders can vet their own supporting classes.
 	 *
-	 * @param string $class_name Class name discovered nested in the blob.
+	 * @param string        $class_name     Class name discovered nested in the blob.
+	 * @param string[]|null $allowed_nested Pre-resolved allow-list to reuse across a batch. When null,
+	 *                                      it is resolved (and its filter run) on this call.
 	 * @return bool
 	 */
-	protected static function is_allowed_nested_class( $class_name ) {
+	protected static function is_allowed_nested_class( $class_name, ?array $allowed_nested = null ) {
 		if ( ! is_string( $class_name ) || '' === $class_name ) {
 			return false;
 		}
 
-		if ( in_array( $class_name, self::get_allowed_nested_classes(), true ) ) {
+		if ( null === $allowed_nested ) {
+			$allowed_nested = self::get_allowed_nested_classes();
+		}
+
+		if ( in_array( $class_name, $allowed_nested, true ) ) {
 			return true;
 		}
 

--- a/classes/ActionScheduler_ScheduleDeserializer.php
+++ b/classes/ActionScheduler_ScheduleDeserializer.php
@@ -28,6 +28,16 @@
 class ActionScheduler_ScheduleDeserializer {
 
 	/**
+	 * Maximum object-graph depth we will walk while vetting a blob.
+	 *
+	 * Real schedules nest only a handful of levels deep (a cron schedule's CronExpression graph is
+	 * the deepest at ~6). Anything beyond this bound is treated as untrustworthy rather than walked.
+	 *
+	 * @var int
+	 */
+	const MAX_GRAPH_DEPTH = 100;
+
+	/**
 	 * Deserialize a stored schedule blob without instantiating unexpected classes.
 	 *
 	 * @param string $data The raw serialized schedule blob as stored in the database.
@@ -51,7 +61,13 @@ class ActionScheduler_ScheduleDeserializer {
 
 		$top_class      = self::class_name_of( $inert );
 		$nested_classes = array();
-		self::collect_class_names( $inert, $nested_classes, true );
+		$seen           = array();
+
+		// A tampered blob can encode a self-referential or pathologically deep object graph. If we
+		// cannot fully walk it within a sane bound, we refuse to vouch for it and reject.
+		if ( ! self::collect_class_names( $inert, $nested_classes, true, $seen, 0 ) ) {
+			return self::handle_rejection( $data, $top_class, $top_class, $nested_classes );
+		}
 
 		// Phase 2a: the outermost object must be a real, loaded schedule class. This is the same
 		// contract ActionScheduler_Store::validate_schedule() already enforces, only applied before
@@ -70,7 +86,9 @@ class ActionScheduler_ScheduleDeserializer {
 		// All classes vetted: re-hydrate for real, restricting instantiation to exactly that set.
 		$allowed = array_values( array_unique( array_merge( array( $top_class ), $nested_classes ) ) );
 
-		return unserialize( $data, array( 'allowed_classes' => $allowed ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_unserialize
+		// Silenced to match the stores' historical @unserialize() behaviour: a blob that parsed inert
+		// in phase 1 will parse here too, but we keep the same log-quiet contract regardless.
+		return @unserialize( $data, array( 'allowed_classes' => $allowed ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_unserialize, WordPress.PHP.NoSilencedErrors.Discouraged
 	}
 
 	/**
@@ -239,33 +257,53 @@ class ActionScheduler_ScheduleDeserializer {
 	/**
 	 * Recursively collect the class names of every object nested inside a value.
 	 *
-	 * @param mixed    $value  The value to walk (object, array, or scalar).
-	 * @param string[] $found  Accumulator of discovered nested class names (by reference).
+	 * A tampered blob can decode (via `r:`/`R:` references) into a self-referential or extremely deep
+	 * object graph. Walking that naively would recurse until the stack overflows, so we track objects
+	 * already visited (to short-circuit cycles and shared references) and cap the recursion depth.
+	 *
+	 * @param mixed    $value   The value to walk (object, array, or scalar).
+	 * @param string[] $found   Accumulator of discovered nested class names (by reference).
 	 * @param bool     $is_root Whether $value is the outermost object (excluded from $found).
-	 * @return void
+	 * @param array    $seen    Object ids already visited, keyed by spl_object_id (by reference).
+	 * @param int      $depth   Current recursion depth.
+	 * @return bool True if the value was fully walked; false if it was too deep to vet safely.
 	 */
-	protected static function collect_class_names( $value, array &$found, $is_root = false ) {
+	protected static function collect_class_names( $value, array &$found, $is_root, array &$seen, $depth ) {
+		if ( $depth > self::MAX_GRAPH_DEPTH ) {
+			return false;
+		}
+
 		if ( is_object( $value ) ) {
-			$vars = (array) $value;
+			$object_id = spl_object_id( $value );
+			if ( isset( $seen[ $object_id ] ) ) {
+				return true; // Already walked (cycle or shared reference); nothing new to collect.
+			}
+			$seen[ $object_id ] = true;
 
 			if ( ! $is_root ) {
 				$found[] = self::class_name_of( $value );
 			}
 
-			foreach ( $vars as $key => $child ) {
+			foreach ( (array) $value as $key => $child ) {
 				if ( '__PHP_Incomplete_Class_Name' === $key ) {
 					continue;
 				}
-				self::collect_class_names( $child, $found, false );
+				if ( ! self::collect_class_names( $child, $found, false, $seen, $depth + 1 ) ) {
+					return false;
+				}
 			}
 
-			return;
+			return true;
 		}
 
 		if ( is_array( $value ) ) {
 			foreach ( $value as $child ) {
-				self::collect_class_names( $child, $found, false );
+				if ( ! self::collect_class_names( $child, $found, false, $seen, $depth + 1 ) ) {
+					return false;
+				}
 			}
 		}
+
+		return true;
 	}
 }

--- a/classes/ActionScheduler_ScheduleDeserializer.php
+++ b/classes/ActionScheduler_ScheduleDeserializer.php
@@ -1,0 +1,271 @@
+<?php
+
+/**
+ * Safely turns a stored, serialized schedule blob back into a schedule object.
+ *
+ * Scheduled actions persist their schedule as a native PHP-serialized blob. Reading that blob
+ * back with a bare unserialize() lets an attacker who can influence the stored bytes have PHP
+ * instantiate arbitrary classes, running their __wakeup()/__destruct() magic methods (PHP object
+ * injection). @see https://github.com/woocommerce/action-scheduler/issues/1318
+ *
+ * This class moves Action Scheduler's existing "is this really an ActionScheduler_Schedule?" check
+ * to *before* any class is instantiated, using a two-phase deserialization:
+ *
+ *   1. Parse the blob with `allowed_classes => false`, which instantiates nothing — every object
+ *      in the payload becomes a harmless __PHP_Incomplete_Class placeholder. No constructor,
+ *      __wakeup(), __destruct() or autoloading runs.
+ *   2. Inspect the class names actually present. Only if the outermost class implements
+ *      ActionScheduler_Schedule, and every nested class is on a small vetted allow-list, do we
+ *      re-run unserialize() a second time restricted to exactly that verified set of classes.
+ *
+ * The allow-list is derived, not hard-coded: any loaded schedule class (including third-party
+ * ones) is trusted automatically because it implements ActionScheduler_Schedule, so extenders need
+ * to do nothing. A blob referencing anything else is rejected the same way a corrupt blob already
+ * is today, or — in shadow mode — allowed through untouched while a warning is surfaced.
+ *
+ * @since 3.10.0
+ */
+class ActionScheduler_ScheduleDeserializer {
+
+	/**
+	 * Deserialize a stored schedule blob without instantiating unexpected classes.
+	 *
+	 * @param string $data The raw serialized schedule blob as stored in the database.
+	 * @return ActionScheduler_Schedule|object|false The schedule object, or false if the blob is
+	 *                                                unusable (corrupt, or rejected while enforcing).
+	 *                                                Callers already treat false like a corrupt blob.
+	 */
+	public static function unserialize( $data ) {
+		if ( ! is_string( $data ) || '' === $data ) {
+			return false;
+		}
+
+		// Phase 1: parse the blob without instantiating any class from it. This is inert: objects
+		// become __PHP_Incomplete_Class placeholders, so no __wakeup()/__destruct()/autoload runs.
+		$inert = @unserialize( $data, array( 'allowed_classes' => false ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_unserialize, WordPress.PHP.NoSilencedErrors.Discouraged
+
+		// A schedule is always an object graph. Anything else is corrupt/unexpected data.
+		if ( ! is_object( $inert ) ) {
+			return false;
+		}
+
+		$top_class      = self::class_name_of( $inert );
+		$nested_classes = array();
+		self::collect_class_names( $inert, $nested_classes, true );
+
+		// Phase 2a: the outermost object must be a real, loaded schedule class. This is the same
+		// contract ActionScheduler_Store::validate_schedule() already enforces, only applied before
+		// instantiation instead of after.
+		if ( ! self::is_allowed_top_level_class( $top_class ) ) {
+			return self::handle_rejection( $data, $top_class, $top_class, $nested_classes );
+		}
+
+		// Phase 2b: every nested object must be on the vetted allow-list.
+		foreach ( $nested_classes as $nested_class ) {
+			if ( ! self::is_allowed_nested_class( $nested_class ) ) {
+				return self::handle_rejection( $data, $nested_class, $top_class, $nested_classes );
+			}
+		}
+
+		// All classes vetted: re-hydrate for real, restricting instantiation to exactly that set.
+		$allowed = array_values( array_unique( array_merge( array( $top_class ), $nested_classes ) ) );
+
+		return unserialize( $data, array( 'allowed_classes' => $allowed ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_unserialize
+	}
+
+	/**
+	 * Decide whether the outermost class in a schedule blob may be instantiated.
+	 *
+	 * Allowed iff the class is loaded and implements ActionScheduler_Schedule. A class that is not
+	 * loaded cannot be validated (and, prior to this change, already produced a broken action), so
+	 * rejecting it here does not regress any case that previously worked.
+	 *
+	 * @param string $class_name Class name discovered in the blob.
+	 * @return bool
+	 */
+	protected static function is_allowed_top_level_class( $class_name ) {
+		if ( ! is_string( $class_name ) || '' === $class_name || ! class_exists( $class_name ) ) {
+			return false;
+		}
+
+		$implements = class_implements( $class_name );
+
+		return is_array( $implements ) && isset( $implements['ActionScheduler_Schedule'] );
+	}
+
+	/**
+	 * Decide whether a nested class (a property of the schedule) may be instantiated.
+	 *
+	 * The only classes Action Scheduler itself ever nests inside a schedule are the bundled
+	 * CronExpression family. Composite schedules that nest another schedule are also fine. The
+	 * default list is filterable so extenders can vet their own supporting classes.
+	 *
+	 * @param string $class_name Class name discovered nested in the blob.
+	 * @return bool
+	 */
+	protected static function is_allowed_nested_class( $class_name ) {
+		if ( ! is_string( $class_name ) || '' === $class_name ) {
+			return false;
+		}
+
+		if ( in_array( $class_name, self::get_allowed_nested_classes(), true ) ) {
+			return true;
+		}
+
+		// A schedule nested inside another schedule (composite schedules) is safe by the same rule
+		// as the top-level check.
+		if ( class_exists( $class_name ) ) {
+			$implements = class_implements( $class_name );
+			if ( is_array( $implements ) && isset( $implements['ActionScheduler_Schedule'] ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * The supporting classes Action Scheduler is willing to instantiate when nested in a schedule.
+	 *
+	 * @return string[]
+	 */
+	public static function get_allowed_nested_classes() {
+		$default = array(
+			'CronExpression',
+			'CronExpression_FieldFactory',
+			'CronExpression_AbstractField',
+			'CronExpression_MinutesField',
+			'CronExpression_HoursField',
+			'CronExpression_DayOfMonthField',
+			'CronExpression_MonthField',
+			'CronExpression_DayOfWeekField',
+			'CronExpression_YearField',
+		);
+
+		/**
+		 * Filters the list of non-schedule classes that may be instantiated when nested inside a
+		 * stored schedule blob during deserialization.
+		 *
+		 * Add the fully-qualified names of any supporting classes your custom schedule stores as
+		 * properties. Schedule classes themselves (implementing ActionScheduler_Schedule) are
+		 * always allowed and do not need to be listed here.
+		 *
+		 * @since 3.10.0
+		 *
+		 * @param string[] $default List of allowed nested class names.
+		 */
+		return (array) apply_filters( 'action_scheduler_allowed_nested_schedule_classes', $default );
+	}
+
+	/**
+	 * Whether an unexpected class causes the blob to be rejected (true) or merely reported while the
+	 * legacy, unrestricted deserialization proceeds (false, "shadow mode").
+	 *
+	 * Enforcement is on by default. Site owners can opt into shadow mode for a release to gather
+	 * data before enforcing, without changing any stored data.
+	 *
+	 * @return bool
+	 */
+	public static function is_enforced() {
+		/**
+		 * Filters whether Action Scheduler rejects schedule blobs referencing unexpected classes.
+		 *
+		 * Return false to run in "shadow mode": unexpected classes are reported via the
+		 * `action_scheduler_unexpected_schedule_class` action but the blob is still deserialized
+		 * exactly as it was before this hardening. Useful to confirm the allow-list is complete for
+		 * your site before switching enforcement on.
+		 *
+		 * @since 3.10.0
+		 *
+		 * @param bool $enforced Whether to reject blobs with unexpected classes. Default true.
+		 */
+		return (bool) apply_filters( 'action_scheduler_enforce_schedule_allowed_classes', true );
+	}
+
+	/**
+	 * Handle a blob that references a class outside the vetted set.
+	 *
+	 * Always surfaces the event for observability. Under enforcement (the default) the blob is
+	 * rejected by returning false, which callers already handle like a corrupt schedule. In shadow
+	 * mode the pre-hardening behaviour is preserved so a mis-tuned allow-list cannot disrupt a site.
+	 *
+	 * @param string   $data            The raw serialized blob.
+	 * @param string   $offending_class The first class that failed validation.
+	 * @param string   $top_class       The outermost class in the blob.
+	 * @param string[] $nested_classes  All nested class names discovered in the blob.
+	 * @return object|false
+	 */
+	protected static function handle_rejection( $data, $offending_class, $top_class, array $nested_classes ) {
+		/**
+		 * Fires when a stored schedule blob references a class Action Scheduler did not expect.
+		 *
+		 * @since 3.10.0
+		 *
+		 * @param string   $offending_class The first disallowed class encountered.
+		 * @param string   $top_class       The outermost class in the blob.
+		 * @param string[] $nested_classes  All nested class names discovered in the blob.
+		 * @param bool     $enforced        Whether the blob was rejected (true) or allowed through
+		 *                                  in shadow mode (false).
+		 */
+		do_action( 'action_scheduler_unexpected_schedule_class', $offending_class, $top_class, $nested_classes, self::is_enforced() );
+
+		if ( self::is_enforced() ) {
+			return false;
+		}
+
+		// Shadow mode: behave exactly as Action Scheduler did before this change.
+		return @unserialize( $data ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_unserialize, WordPress.PHP.NoSilencedErrors.Discouraged
+	}
+
+	/**
+	 * Get the class name of an object parsed in "inert" mode.
+	 *
+	 * Objects whose class was disallowed become __PHP_Incomplete_Class, which hides the original
+	 * name behind get_class(); it lives in the __PHP_Incomplete_Class_Name pseudo-property instead.
+	 * stdClass is never converted by PHP, so its real name is returned directly.
+	 *
+	 * @param object $maybe_incomplete Object parsed with allowed_classes => false.
+	 * @return string The original class name, or '' if it cannot be determined.
+	 */
+	protected static function class_name_of( $maybe_incomplete ) {
+		if ( $maybe_incomplete instanceof __PHP_Incomplete_Class ) {
+			$vars = (array) $maybe_incomplete;
+			return isset( $vars['__PHP_Incomplete_Class_Name'] ) ? (string) $vars['__PHP_Incomplete_Class_Name'] : '';
+		}
+
+		return get_class( $maybe_incomplete );
+	}
+
+	/**
+	 * Recursively collect the class names of every object nested inside a value.
+	 *
+	 * @param mixed    $value  The value to walk (object, array, or scalar).
+	 * @param string[] $found  Accumulator of discovered nested class names (by reference).
+	 * @param bool     $is_root Whether $value is the outermost object (excluded from $found).
+	 * @return void
+	 */
+	protected static function collect_class_names( $value, array &$found, $is_root = false ) {
+		if ( is_object( $value ) ) {
+			$vars = (array) $value;
+
+			if ( ! $is_root ) {
+				$found[] = self::class_name_of( $value );
+			}
+
+			foreach ( $vars as $key => $child ) {
+				if ( '__PHP_Incomplete_Class_Name' === $key ) {
+					continue;
+				}
+				self::collect_class_names( $child, $found, false );
+			}
+
+			return;
+		}
+
+		if ( is_array( $value ) ) {
+			foreach ( $value as $child ) {
+				self::collect_class_names( $child, $found, false );
+			}
+		}
+	}
+}

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -401,7 +401,7 @@ AND args = %s
 			$this->validate_args( $args, $data->action_id );
 		}
 
-		$schedule = @unserialize( $data->schedule ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_unserialize WordPress.PHP.NoSilencingOperator
+		$schedule = ActionScheduler_ScheduleDeserializer::unserialize( $data->schedule );
 		if ( false === $schedule && $data->status === self::STATUS_CANCELED ) {
 			// The handled corrupted action should appear in UI.
 			$schedule = new ActionScheduler_NullSchedule();

--- a/classes/data-stores/ActionScheduler_wpPostStore.php
+++ b/classes/data-stores/ActionScheduler_wpPostStore.php
@@ -256,11 +256,15 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 	 * vetted supporting classes). @see https://github.com/woocommerce/action-scheduler/issues/1318
 	 *
 	 * @param int $post_id Post ID of the scheduled action.
-	 * @return ActionScheduler_Schedule|object|false The schedule, or false if unusable.
+	 * @return mixed The schedule object, false if unusable, or the raw meta value when it is not a
+	 *               serialized object (left for validate_schedule() to reject, as before).
 	 */
 	protected function get_schedule_from_post_meta( $post_id ) {
 		global $wpdb;
 
+		// Direct, uncached query is intentional: we need the raw serialized value before the meta API
+		// runs it through maybe_unserialize(), so we bypass get_post_meta() and its cache here.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 		$raw = $wpdb->get_var(
 			$wpdb->prepare(
 				"SELECT meta_value FROM {$wpdb->postmeta} WHERE post_id = %d AND meta_key = %s ORDER BY meta_id ASC LIMIT 1",

--- a/classes/data-stores/ActionScheduler_wpPostStore.php
+++ b/classes/data-stores/ActionScheduler_wpPostStore.php
@@ -238,13 +238,48 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 		$args = json_decode( $post->post_content, true );
 		$this->validate_args( $args, $post->ID );
 
-		$schedule = get_post_meta( $post->ID, self::SCHEDULE_META_KEY, true );
+		$schedule = $this->get_schedule_from_post_meta( $post->ID );
 		$this->validate_schedule( $schedule, $post->ID );
 
 		$group = wp_get_object_terms( $post->ID, self::GROUP_TAXONOMY, array( 'fields' => 'names' ) );
 		$group = empty( $group ) ? '' : reset( $group );
 
 		return ActionScheduler::factory()->get_stored_action( $this->get_action_status_by_post_status( $post->post_status ), $hook, $args, $schedule, $group );
+	}
+
+	/**
+	 * Read a scheduled action's schedule from post meta without instantiating unexpected classes.
+	 *
+	 * Using get_post_meta() would run the stored blob through maybe_unserialize(), instantiating
+	 * whatever classes it names before we can vet them. Instead we read the raw serialized value and
+	 * hand it to ActionScheduler_ScheduleDeserializer, which only instantiates a valid schedule (and its
+	 * vetted supporting classes). @see https://github.com/woocommerce/action-scheduler/issues/1318
+	 *
+	 * @param int $post_id Post ID of the scheduled action.
+	 * @return ActionScheduler_Schedule|object|false The schedule, or false if unusable.
+	 */
+	protected function get_schedule_from_post_meta( $post_id ) {
+		global $wpdb;
+
+		$raw = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT meta_value FROM {$wpdb->postmeta} WHERE post_id = %d AND meta_key = %s ORDER BY meta_id ASC LIMIT 1",
+				$post_id,
+				self::SCHEDULE_META_KEY
+			)
+		);
+
+		if ( null === $raw ) {
+			return false;
+		}
+
+		// Schedule objects are stored serialized by the meta API. A non-serialized value cannot be a
+		// schedule object, so there is nothing to protect against — return it as-is for validation.
+		if ( ! is_serialized( $raw ) ) {
+			return $raw;
+		}
+
+		return ActionScheduler_ScheduleDeserializer::unserialize( $raw );
 	}
 
 	/**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -32,6 +32,8 @@ if ( class_exists( 'PHPUnit\Framework\TestResult' ) ) { // PHPUnit 6.0 or newer.
 }
 
 include_once 'phpunit/helpers/ActionScheduler_Callbacks.php';
+include_once 'phpunit/helpers/ActionScheduler_Test_Evil_Gadget.php';
+include_once 'phpunit/helpers/ActionScheduler_Test_Custom_Schedule.php';
 include_once 'phpunit/ActionScheduler_Mocker.php';
 include_once 'phpunit/ActionScheduler_Mock_Async_Request_QueueRunner.php';
 include_once 'phpunit/jobstore/AbstractStoreTest.php';

--- a/tests/phpunit.xml.dist
+++ b/tests/phpunit.xml.dist
@@ -17,6 +17,7 @@
 		<testsuite name="Tables">
 			<file phpVersion="5.6">./phpunit/jobstore/ActionScheduler_DBStoreMigrator_Test.php</file>
 			<file phpVersion="5.6">./phpunit/jobstore/ActionScheduler_DBStore_Test.php</file>
+			<file phpVersion="5.6">./phpunit/jobstore/ActionScheduler_ScheduleUnserialize_Test.php</file>
 			<file phpVersion="5.6">./phpunit/jobstore/ActionScheduler_HybridStore_Test.php</file>
 			<file phpVersion="5.6">./phpunit/logging/ActionScheduler_DBLogger_Test.php</file>
 		</testsuite>

--- a/tests/phpunit/helpers/ActionScheduler_Test_Custom_Schedule.php
+++ b/tests/phpunit/helpers/ActionScheduler_Test_Custom_Schedule.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * A well-behaved third party schedule class. It implements ActionScheduler_Schedule
+ * but is defined outside of Action Scheduler, exactly like a schedule shipped by a
+ * plugin extending Action Scheduler. Hardening must NOT break these.
+ */
+class ActionScheduler_Test_Custom_Schedule implements ActionScheduler_Schedule {
+
+	/**
+	 * Scheduled run timestamp.
+	 *
+	 * @var int
+	 */
+	protected $timestamp = 0;
+
+	/**
+	 * Construct.
+	 *
+	 * @param int $timestamp Scheduled run timestamp.
+	 */
+	public function __construct( $timestamp ) {
+		$this->timestamp = $timestamp;
+	}
+
+	/**
+	 * Get the next run date.
+	 *
+	 * @param null|DateTime $after Timestamp.
+	 * @return DateTime|null
+	 */
+	public function next( ?DateTime $after = null ) {
+		return as_get_datetime_object( $this->timestamp );
+	}
+
+	/**
+	 * Not recurring.
+	 *
+	 * @return bool
+	 */
+	public function is_recurring() {
+		return false;
+	}
+}

--- a/tests/phpunit/helpers/ActionScheduler_Test_Evil_Gadget.php
+++ b/tests/phpunit/helpers/ActionScheduler_Test_Evil_Gadget.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * A "gadget" class used to prove that deserializing a scheduled action's
+ * schedule blob does not instantiate arbitrary classes.
+ *
+ * If PHP's unserialize() is allowed to instantiate this class, its __wakeup()
+ * magic method runs and flips the static flag. A hardened deserialization path
+ * must never let that happen.
+ */
+class ActionScheduler_Test_Evil_Gadget {
+
+	/**
+	 * Set to true the moment an instance is woken up by unserialize().
+	 *
+	 * @var bool
+	 */
+	public static $fired = false;
+
+	/**
+	 * The side effect an attacker's gadget chain would exploit.
+	 */
+	public function __wakeup() {
+		self::$fired = true;
+	}
+}

--- a/tests/phpunit/jobstore/ActionScheduler_ScheduleUnserialize_Test.php
+++ b/tests/phpunit/jobstore/ActionScheduler_ScheduleUnserialize_Test.php
@@ -119,6 +119,33 @@ class ActionScheduler_ScheduleUnserialize_Test extends ActionScheduler_UnitTestC
 	}
 
 	/**
+	 * A self-referential blob must not send the class-name walk into infinite recursion.
+	 *
+	 * PHP's `r:` references let a tampered blob decode into a cyclic object graph. Before the cycle
+	 * guard, walking it recursed until the stack overflowed (a DoS). The store must instead return.
+	 */
+	public function test_self_referential_blob_is_handled_without_infinite_recursion() {
+		$nul       = chr( 0 );
+		$prop_rec  = $nul . '*' . $nul . 'recurrence'; // Protected property marker.
+		$container = 'ActionScheduler_IntervalSchedule';
+		// The single property `recurrence` references value #1 — the object itself — forming a cycle.
+		$blob      = 'O:' . strlen( $container ) . ':"' . $container . '":1:{'
+			. 's:' . strlen( $prop_rec ) . ':"' . $prop_rec . '";r:1;}';
+		$action_id = $this->store_action_with_raw_schedule( $blob );
+
+		$store   = new ActionScheduler_DBStore();
+		$fetched = null;
+		try {
+			$fetched = $store->fetch_action( $action_id );
+		} catch ( Exception $e ) {
+			unset( $e ); // Acceptable; the point is that we return rather than exhaust the stack.
+		}
+
+		// Reaching this line at all proves the walk terminated. fetch_action always yields an object.
+		$this->assertNotNull( $fetched, 'A self-referential schedule blob did not resolve to an action.' );
+	}
+
+	/**
 	 * The happy path must keep working: a simple schedule round-trips through the store unchanged.
 	 */
 	public function test_simple_schedule_round_trips() {

--- a/tests/phpunit/jobstore/ActionScheduler_ScheduleUnserialize_Test.php
+++ b/tests/phpunit/jobstore/ActionScheduler_ScheduleUnserialize_Test.php
@@ -1,0 +1,243 @@
+<?php
+
+/**
+ * Battle tests for the hardening of schedule deserialization.
+ *
+ * The supporting fixtures (ActionScheduler_Test_Evil_Gadget and
+ * ActionScheduler_Test_Custom_Schedule) live in tests/phpunit/helpers and are loaded by the
+ * test bootstrap.
+ *
+ * @see https://github.com/woocommerce/action-scheduler/issues/1318
+ *
+ * @group tables
+ */
+class ActionScheduler_ScheduleUnserialize_Test extends ActionScheduler_UnitTestCase {
+
+	/**
+	 * Legacy CronSchedule blob produced by Action Scheduler < this change, containing the full
+	 * CronExpression object graph (CronExpression, CronExpression_FieldFactory and the field
+	 * objects). Old rows in the wild look exactly like this and must keep working.
+	 *
+	 * Captured from trunk for "0 0 * * *" scheduled at 2026-01-01 00:00:00 UTC (ts 1767225600).
+	 * Base64-encoded because the serialized form contains NUL bytes (protected/private property
+	 * name markers) that cannot be represented safely as a literal PHP string.
+	 *
+	 * @var string
+	 */
+	const LEGACY_CRON_BLOB_B64 = 'TzoyODoiQWN0aW9uU2NoZWR1bGVyX0Nyb25TY2hlZHVsZSI6NTp7czoyMjoiACoAc2NoZWR1bGVkX3RpbWVzdGFtcCI7aToxNzY3MjI1NjAwO3M6MTg6IgAqAGZpcnN0X3RpbWVzdGFtcCI7aToxNzY3MjI1NjAwO3M6MTM6IgAqAHJlY3VycmVuY2UiO086MTQ6IkNyb25FeHByZXNzaW9uIjoyOntzOjI1OiIAQ3JvbkV4cHJlc3Npb24AY3JvblBhcnRzIjthOjU6e2k6MDtzOjE6IjAiO2k6MTtzOjE6IjAiO2k6MjtzOjE6IioiO2k6MztzOjE6IioiO2k6NDtzOjE6IioiO31zOjI4OiIAQ3JvbkV4cHJlc3Npb24AZmllbGRGYWN0b3J5IjtPOjI3OiJDcm9uRXhwcmVzc2lvbl9GaWVsZEZhY3RvcnkiOjE6e3M6MzU6IgBDcm9uRXhwcmVzc2lvbl9GaWVsZEZhY3RvcnkAZmllbGRzIjthOjU6e2k6MDtPOjI3OiJDcm9uRXhwcmVzc2lvbl9NaW51dGVzRmllbGQiOjA6e31pOjE7TzoyNToiQ3JvbkV4cHJlc3Npb25fSG91cnNGaWVsZCI6MDp7fWk6MjtPOjMwOiJDcm9uRXhwcmVzc2lvbl9EYXlPZk1vbnRoRmllbGQiOjA6e31pOjM7TzoyNToiQ3JvbkV4cHJlc3Npb25fTW9udGhGaWVsZCI6MDp7fWk6NDtPOjI5OiJDcm9uRXhwcmVzc2lvbl9EYXlPZldlZWtGaWVsZCI6MDp7fX19fXM6NDU6IgBBY3Rpb25TY2hlZHVsZXJfQ3JvblNjaGVkdWxlAHN0YXJ0X3RpbWVzdGFtcCI7aToxNzY3MjI1NjAwO3M6MzQ6IgBBY3Rpb25TY2hlZHVsZXJfQ3JvblNjaGVkdWxlAGNyb24iO3I6NDt9';
+
+	public function setUp(): void {
+		global $wpdb;
+		$wpdb->query( "DELETE FROM {$wpdb->actionscheduler_actions}" );
+		ActionScheduler_Test_Evil_Gadget::$fired = false;
+		parent::setUp();
+	}
+
+	/**
+	 * Persist a real action, then overwrite its stored schedule blob with an arbitrary string,
+	 * simulating an attacker (or corruption) tampering with the serialized column.
+	 *
+	 * @param string $schedule_blob Raw value to store in the schedule column.
+	 * @return int Action ID.
+	 */
+	private function store_action_with_raw_schedule( $schedule_blob ) {
+		global $wpdb;
+
+		$store     = new ActionScheduler_DBStore();
+		$action    = new ActionScheduler_Action(
+			ActionScheduler_Callbacks::HOOK_WITH_CALLBACK,
+			array(),
+			new ActionScheduler_SimpleSchedule( as_get_datetime_object() )
+		);
+		$action_id = $store->save_action( $action );
+
+		$wpdb->update(
+			$wpdb->actionscheduler_actions,
+			array( 'schedule' => $schedule_blob ),
+			array( 'action_id' => $action_id ),
+			array( '%s' ),
+			array( '%d' )
+		);
+
+		return $action_id;
+	}
+
+	/**
+	 * THE VULNERABILITY. A tampered schedule blob referencing an arbitrary class must never
+	 * cause that class to be instantiated during deserialization.
+	 *
+	 * On trunk this test is RED: unserialize() instantiates the gadget and runs its __wakeup().
+	 */
+	public function test_arbitrary_class_is_not_instantiated_from_schedule_blob() {
+		$malicious = serialize( new ActionScheduler_Test_Evil_Gadget() ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
+		$action_id = $this->store_action_with_raw_schedule( $malicious );
+
+		$store = new ActionScheduler_DBStore();
+
+		// Fetching may legitimately throw/return a null action for an unusable schedule; that is
+		// fine. What must never happen is the gadget's __wakeup() side effect firing.
+		try {
+			$store->fetch_action( $action_id );
+		} catch ( Exception $e ) {
+			unset( $e ); // Rejecting the action is an acceptable outcome; we only assert on the side effect.
+		}
+
+		$this->assertFalse(
+			ActionScheduler_Test_Evil_Gadget::$fired,
+			'Deserializing a schedule blob instantiated an arbitrary class (object injection).'
+		);
+	}
+
+	/**
+	 * A gadget nested INSIDE an otherwise-valid schedule wrapper must also be blocked. This guards
+	 * against smuggling a gadget in via the recurrence/property of a legitimate schedule class.
+	 */
+	public function test_arbitrary_class_nested_in_valid_schedule_is_not_instantiated() {
+		$nul       = chr( 0 );
+		$prop_ts   = $nul . '*' . $nul . 'scheduled_timestamp'; // Protected property marker.
+		$prop_rec  = $nul . '*' . $nul . 'recurrence';          // Protected property marker.
+		$gadget    = 'ActionScheduler_Test_Evil_Gadget';
+		$container = 'ActionScheduler_IntervalSchedule';
+		$blob      = 'O:' . strlen( $container ) . ':"' . $container . '":2:{'
+			. 's:' . strlen( $prop_ts ) . ':"' . $prop_ts . '";i:' . ( time() + HOUR_IN_SECONDS ) . ';'
+			. 's:' . strlen( $prop_rec ) . ':"' . $prop_rec . '";'
+			. 'O:' . strlen( $gadget ) . ':"' . $gadget . '":0:{}'
+			. '}';
+		$action_id = $this->store_action_with_raw_schedule( $blob );
+
+		$store = new ActionScheduler_DBStore();
+		try {
+			$store->fetch_action( $action_id );
+		} catch ( Exception $e ) {
+			unset( $e ); // Rejecting the action is an acceptable outcome; we only assert on the side effect.
+		}
+
+		$this->assertFalse(
+			ActionScheduler_Test_Evil_Gadget::$fired,
+			'A gadget nested inside a valid schedule wrapper was instantiated.'
+		);
+	}
+
+	/**
+	 * The happy path must keep working: a simple schedule round-trips through the store unchanged.
+	 */
+	public function test_simple_schedule_round_trips() {
+		$time      = as_get_datetime_object( '2026-03-04 05:06:07' );
+		$store     = new ActionScheduler_DBStore();
+		$action    = new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, array(), new ActionScheduler_SimpleSchedule( $time ) );
+		$action_id = $store->save_action( $action );
+
+		$fetched  = $store->fetch_action( $action_id );
+		$schedule = $fetched->get_schedule();
+
+		$this->assertInstanceOf( 'ActionScheduler_SimpleSchedule', $schedule );
+		$this->assertEquals( $time->getTimestamp(), $schedule->get_date()->getTimestamp() );
+	}
+
+	/**
+	 * Cron schedules must round-trip, including their recurrence.
+	 */
+	public function test_cron_schedule_round_trips() {
+		$time      = as_get_datetime_object( '2026-01-01 00:00:00' );
+		$store     = new ActionScheduler_DBStore();
+		$action    = new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, array(), new ActionScheduler_CronSchedule( $time, '0 0 * * *' ) );
+		$action_id = $store->save_action( $action );
+
+		$fetched  = $store->fetch_action( $action_id );
+		$schedule = $fetched->get_schedule();
+
+		$this->assertInstanceOf( 'ActionScheduler_CronSchedule', $schedule );
+		$this->assertEquals( '0 0 * * *', $schedule->get_recurrence() );
+	}
+
+	/**
+	 * Existing rows serialized before this change still contain the full CronExpression object
+	 * graph. Those must continue to deserialize into a working schedule.
+	 */
+	public function test_legacy_cron_blob_still_unserializes() {
+		$action_id = $this->store_action_with_raw_schedule( base64_decode( self::LEGACY_CRON_BLOB_B64 ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
+
+		$store    = new ActionScheduler_DBStore();
+		$fetched  = $store->fetch_action( $action_id );
+		$schedule = $fetched->get_schedule();
+
+		$this->assertInstanceOf( 'ActionScheduler_CronSchedule', $schedule );
+		$this->assertEquals( '0 0 * * *', $schedule->get_recurrence() );
+	}
+
+	/**
+	 * A third party schedule class (implementing ActionScheduler_Schedule, defined outside AS)
+	 * must keep working without the vendor registering anything.
+	 */
+	public function test_third_party_schedule_class_round_trips() {
+		$timestamp = time() + DAY_IN_SECONDS;
+		$blob      = serialize( new ActionScheduler_Test_Custom_Schedule( $timestamp ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
+		$action_id = $this->store_action_with_raw_schedule( $blob );
+
+		$store    = new ActionScheduler_DBStore();
+		$fetched  = $store->fetch_action( $action_id );
+		$schedule = $fetched->get_schedule();
+
+		$this->assertInstanceOf( 'ActionScheduler_Test_Custom_Schedule', $schedule );
+		$this->assertEquals( $timestamp, $schedule->next()->getTimestamp() );
+	}
+
+	/**
+	 * The same protection must cover the legacy post-based store, whose schedule lives in post meta.
+	 *
+	 * On trunk this is RED: get_post_meta() runs the tampered blob through maybe_unserialize().
+	 */
+	public function test_wp_post_store_does_not_instantiate_arbitrary_class() {
+		$store     = new ActionScheduler_wpPostStore();
+		$action    = new ActionScheduler_Action(
+			ActionScheduler_Callbacks::HOOK_WITH_CALLBACK,
+			array(),
+			new ActionScheduler_SimpleSchedule( as_get_datetime_object() )
+		);
+		$action_id = $store->save_action( $action );
+
+		// Tamper the stored schedule meta with a gadget blob, bypassing the meta API's serialization.
+		global $wpdb;
+		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_value, WordPress.DB.SlowDBQuery.slow_db_query_meta_key, WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
+		$wpdb->update(
+			$wpdb->postmeta,
+			array( 'meta_value' => serialize( new ActionScheduler_Test_Evil_Gadget() ) ),
+			array(
+				'post_id'  => $action_id,
+				'meta_key' => ActionScheduler_wpPostStore::SCHEDULE_META_KEY,
+			),
+			array( '%s' ),
+			array( '%d', '%s' )
+		);
+		// phpcs:enable WordPress.DB.SlowDBQuery.slow_db_query_meta_value, WordPress.DB.SlowDBQuery.slow_db_query_meta_key, WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
+		clean_post_cache( $action_id );
+		wp_cache_delete( $action_id, 'post_meta' );
+
+		try {
+			$store->fetch_action( $action_id );
+		} catch ( Exception $e ) {
+			unset( $e ); // Rejecting the action is an acceptable outcome; we only assert on the side effect.
+		}
+
+		$this->assertFalse(
+			ActionScheduler_Test_Evil_Gadget::$fired,
+			'The post-based store instantiated an arbitrary class from a schedule blob.'
+		);
+	}
+
+	/**
+	 * The post-based store must still round-trip legitimate schedules after hardening.
+	 */
+	public function test_wp_post_store_round_trips_valid_schedule() {
+		$time      = as_get_datetime_object( '2026-05-06 07:08:09' );
+		$store     = new ActionScheduler_wpPostStore();
+		$action    = new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, array(), new ActionScheduler_SimpleSchedule( $time ) );
+		$action_id = $store->save_action( $action );
+
+		$fetched  = $store->fetch_action( $action_id );
+		$schedule = $fetched->get_schedule();
+
+		$this->assertInstanceOf( 'ActionScheduler_SimpleSchedule', $schedule );
+		$this->assertEquals( $time->getTimestamp(), $schedule->get_date()->getTimestamp() );
+	}
+}


### PR DESCRIPTION
Closes #1318

### Description

Scheduled actions store their schedule as a native PHP-serialized blob, and on read it is passed to `unserialize()` with no `allowed_classes` restriction. An attacker able to influence those stored bytes could make PHP instantiate an arbitrary class, running its `__wakeup()`/`__destruct()` magic methods (PHP object injection). The existing `ActionScheduler_Store::validate_schedule()` check runs only *after* `unserialize()` — i.e. after the damage is already done.

This moves the trust decision to *before* instantiation using a two-phase deserialization in a new `ActionScheduler_ScheduleDeserializer`:

1. **Parse inert.** `unserialize()` with `allowed_classes => false` — every object becomes a `__PHP_Incomplete_Class` placeholder, so no constructor, `__wakeup()`, `__destruct()`, or autoloading runs.
2. **Vet, then hydrate.** Only if the outermost class implements `ActionScheduler_Schedule`, and every nested class is on a small vetted allow-list (the bundled `CronExpression` family, filterable, plus any class implementing the schedule interface), re-run `unserialize()` restricted to exactly that verified set.

**Why the blast radius is minimal:**

- The allow-list is *derived, not declared* — any loaded schedule class, including third-party ones, is trusted automatically because it implements `ActionScheduler_Schedule`. Extenders need to do nothing.
- **No backward-compatibility window.** A schedule class that isn't loaded already produced a broken action before this change, so rejecting it here regresses nothing that previously worked. Legacy blobs carrying the full `CronExpression` object graph continue to deserialize unchanged.
- **No storage-format change and no migration** — existing rows are read exactly as before, only more safely.
- **No new failure mode.** Rejections reuse the existing corrupt-blob path (`ActionScheduler_NullSchedule` for canceled actions, `ActionScheduler_InvalidActionException` otherwise).
- **Shadow-mode rollout.** An `action_scheduler_unexpected_schedule_class` action fires for observability, and the `action_scheduler_enforce_schedule_allowed_classes` filter (default: enforce) lets site owners run report-only for a release before enforcing — without touching any stored data.

Both stores are covered: the default custom-table store (`ActionScheduler_DBStore`) and the legacy post store (`ActionScheduler_wpPostStore`, which now reads the raw serialized meta to bypass the meta API's implicit `unserialize()`).

**New extension points:**

- Filter `action_scheduler_allowed_nested_schedule_classes` — add supporting classes your custom schedule stores as properties.
- Filter `action_scheduler_enforce_schedule_allowed_classes` — return `false` for shadow mode.
- Action `action_scheduler_unexpected_schedule_class` — fires when a blob references an unexpected class.

### Testing Steps

Tests run inside a `wp-env` container (WordPress + PHP 8.3), which mounts this repo as a plugin.

**Prerequisites**
- Docker running
- `npx @wordpress/env start`

**Automated**
- Run the new suite:
  `npx @wordpress/env run tests-cli bash -c 'cd /var/www/html/wp-content/plugins/action-scheduler && ./vendor/bin/phpunit tests/phpunit/jobstore/ActionScheduler_ScheduleUnserialize_Test.php -c tests/phpunit.xml.dist'`
- [ ] Confirm it passes on this branch. The suite covers: a top-level gadget class, a gadget nested inside a valid schedule wrapper, and the legacy post-store path (all blocked), plus round-trips for `SimpleSchedule`, `CronSchedule`, a legacy `CronExpression`-object blob, and a third-party schedule class.
- [ ] Confirm the injection tests are RED on `trunk` (temporarily revert the two data-store files to their `trunk` state and re-run) — this demonstrates the vulnerability the change closes.
- Run the full suite to check for regressions:
  `npx @wordpress/env run tests-cli bash -c 'cd /var/www/html/wp-content/plugins/action-scheduler && ./vendor/bin/phpunit -c tests/phpunit.xml.dist'`
- [ ] Confirm no failures (1596 tests; only pre-existing PHPUnit deprecation warnings).

**Manual sanity**
- Schedule a recurring cron action and a one-off action, let them run, and confirm normal behavior is unchanged.
- [ ] Verify that tampering an action's stored `schedule` value with a blob naming an unrelated class results in the action being treated as invalid (not the class being instantiated).

---
🤖 Generated with [Claude Code](https://claude.ai/code)
