### PR TITLE
[Performance] Use the WordPress caching layer for the option lock component.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@
 * Dev - Updates the `wpPostStore` to capture any database errors that might occur while claiming actions.
 * Performance - Reduce the number of SQL queries on Action Scheduler admin page.
 * Performance - Cache resolved group IDs to reduce the number of SQL queries.
+* Performance - Use the WordPress caching layer for the option lock component.
 
 = 4.0.0 - 2026-06-16 =
 * Breaking change: action args are taken into account when scheduling unique actions.

--- a/classes/ActionScheduler_OptionLock.php
+++ b/classes/ActionScheduler_OptionLock.php
@@ -54,7 +54,7 @@ class ActionScheduler_OptionLock extends ActionScheduler_Lock {
 			return $inserted;
 		}
 
-		if ( $this->get_expiration_from( $existing_lock_value ) > $now ) {
+		if ( $this->get_expiration_from( $existing_lock_value ) >= $now ) {
 			return false;
 		}
 

--- a/classes/ActionScheduler_OptionLock.php
+++ b/classes/ActionScheduler_OptionLock.php
@@ -27,13 +27,14 @@ class ActionScheduler_OptionLock extends ActionScheduler_Lock {
 	public function set( $lock_type ) {
 		global $wpdb;
 
+		$now                 = time();
 		$lock_key            = $this->get_key( $lock_type );
-		$existing_lock_value = $this->get_existing_lock( $lock_type );
-		$new_lock_value      = $this->new_lock_value( $lock_type );
+		$existing_lock_value = $this->get_existing_lock( $lock_type, $now );
+		$new_lock_value      = $this->new_lock_value( $lock_type, $now );
 
 		// The lock may not exist yet, or may have been deleted.
 		if ( null === $existing_lock_value ) {
-			return (bool) $wpdb->insert(
+			$inserted = (bool) $wpdb->insert(
 				$wpdb->options,
 				array(
 					'option_name'  => $lock_key,
@@ -41,14 +42,24 @@ class ActionScheduler_OptionLock extends ActionScheduler_Lock {
 					'autoload'     => 'no',
 				)
 			);
+
+			// Sync cache as necessary.
+			if ( $inserted ) {
+				$ttl = $this->get_expiration_from( $new_lock_value ) - $now;
+				if ( $ttl > 0 ) {
+					wp_cache_set( $lock_key, $new_lock_value, 'action_scheduler_locks', $ttl );
+				}
+			}
+
+			return $inserted;
 		}
 
-		if ( $this->get_expiration_from( $existing_lock_value ) >= time() ) {
+		if ( $this->get_expiration_from( $existing_lock_value ) > $now ) {
 			return false;
 		}
 
 		// Otherwise, try to obtain the lock.
-		return (bool) $wpdb->update(
+		$updated = (bool) $wpdb->update(
 			$wpdb->options,
 			array( 'option_value' => $new_lock_value ),
 			array(
@@ -56,6 +67,20 @@ class ActionScheduler_OptionLock extends ActionScheduler_Lock {
 				'option_value' => $existing_lock_value,
 			)
 		);
+
+		// Sync cache as necessary.
+		if ( $updated ) {
+			$ttl = $this->get_expiration_from( $new_lock_value ) - $now;
+			if ( $ttl > 0 ) {
+				wp_cache_set( $lock_key, $new_lock_value, 'action_scheduler_locks', $ttl );
+			}
+		} else {
+			// Compare-and-swap failed — another process acquired the lock between our read and write.
+			// Invalidate cache: the expired value may still be live in WP object cache (TTL=1 edge case) before the winner's wp_cache_set executes.
+			wp_cache_delete( $lock_key, 'action_scheduler_locks' );
+		}
+
+		return $updated;
 	}
 
 	/**
@@ -65,7 +90,7 @@ class ActionScheduler_OptionLock extends ActionScheduler_Lock {
 	 * @return bool|int False if no lock is set, otherwise the timestamp for when the lock is set to expire.
 	 */
 	public function get_expiration( $lock_type ) {
-		return $this->get_expiration_from( (string) $this->get_existing_lock( $lock_type ) );
+		return $this->get_expiration_from( (string) $this->get_existing_lock( $lock_type, time() ) );
 	}
 
 	/**
@@ -77,14 +102,15 @@ class ActionScheduler_OptionLock extends ActionScheduler_Lock {
 	 */
 	private function get_expiration_from( $lock_value ) {
 		$lock_string = explode( '|', $lock_value );
+		$count       = count( $lock_string );
 
 		// Old style lock?
-		if ( count( $lock_string ) === 1 && is_numeric( $lock_string[0] ) ) {
+		if ( 1 === $count && is_numeric( $lock_string[0] ) ) {
 			return (int) $lock_string[0];
 		}
 
 		// New style lock?
-		if ( count( $lock_string ) === 2 && is_numeric( $lock_string[1] ) ) {
+		if ( 2 === $count && is_numeric( $lock_string[1] ) ) {
 			return (int) $lock_string[1];
 		}
 
@@ -105,25 +131,39 @@ class ActionScheduler_OptionLock extends ActionScheduler_Lock {
 	 * Supplies the existing lock value, or null if not set.
 	 *
 	 * @param string $lock_type A string to identify different lock types.
+	 * @param int    $now       The timestamp to use.
 	 *
 	 * @return string|null
 	 */
-	private function get_existing_lock( $lock_type ) {
+	private function get_existing_lock( $lock_type, int $now ) {
 		global $wpdb;
 
+		$lock_key = $this->get_key( $lock_type );
+		$cached   = wp_cache_get( $lock_key, 'action_scheduler_locks' );
+		if ( false !== $cached ) {
+			return (string) $cached;
+		}
+
+		$value = null;
 		// Now grab the existing lock value, if there is one.
 		// get_var() returns null for the empty string ('') so we must use get_row().
 		$row = $wpdb->get_row(
 			$wpdb->prepare(
 				"SELECT option_value FROM $wpdb->options WHERE option_name = %s",
-				$this->get_key( $lock_type )
+				$lock_key
 			)
 		);
 
 		if ( $row ) {
-			return $row->option_value;
+			$value = $row->option_value;
+			// Sync cache as necessary.
+			$ttl = $this->get_expiration_from( $value ) - $now;
+			if ( $ttl > 0 ) {
+				wp_cache_set( $lock_key, $value, 'action_scheduler_locks', $ttl );
+			}
 		}
-		return null;
+
+		return $value;
 	}
 
 	/**
@@ -133,10 +173,11 @@ class ActionScheduler_OptionLock extends ActionScheduler_Lock {
 	 * Example: (string) "649de012e6b262.09774912|1688068114"
 	 *
 	 * @param string $lock_type A string to identify different lock types.
+	 * @param int    $now       The timestamp to use.
 	 *
 	 * @return string
 	 */
-	private function new_lock_value( $lock_type ) {
-		return uniqid( '', true ) . '|' . ( time() + $this->get_duration( $lock_type ) );
+	private function new_lock_value( $lock_type, int $now ): string {
+		return uniqid( '', true ) . '|' . ( $now + $this->get_duration( $lock_type ) );
 	}
 }

--- a/tests/phpunit/lock/ActionScheduler_OptionLock_Test.php
+++ b/tests/phpunit/lock/ActionScheduler_OptionLock_Test.php
@@ -112,4 +112,66 @@ class ActionScheduler_OptionLock_Test extends ActionScheduler_UnitTestCase {
 		// The stored value should now be a valid lock value with a future expiration timestamp.
 		$this->assertGreaterThan( time(), $lock->get_expiration( $type ), 'The recovered lock has a future expiration.' );
 	}
+
+	/**
+	 * A lock can be acquired when none is held.
+	 *
+	 * Covers: set() INSERT branch → success → cache populated; is_locked() false → true transition.
+	 */
+	public function test_lock_can_be_acquired() {
+		$lock      = ActionScheduler::lock();
+		$lock_type = uniqid( 'lock_test_', true );
+
+		$this->assertFalse( $lock->is_locked( $lock_type ), 'Lock should not be held before acquisition.' );
+
+		$acquired = $lock->set( $lock_type );
+
+		$this->assertTrue( $acquired, 'set() should return true when no lock is held.' );
+		$this->assertTrue( $lock->is_locked( $lock_type ), 'Lock should be held immediately after acquisition.' );
+		$this->assertGreaterThan( time(), $lock->get_expiration( $lock_type ), 'Lock expiration should be in the future.' );
+	}
+
+	/**
+	 * A lock cannot be re-acquired while the existing one is still active.
+	 *
+	 * Covers: set() branch where expiration > $now → returns false without touching DB; get_existing_lock() cache hit branch.
+	 */
+	public function test_lock_cannot_be_acquired_while_active() {
+		$lock      = ActionScheduler::lock();
+		$lock_type = uniqid( 'lock_test_', true );
+		$lock_key  = 'action_scheduler_lock_' . $lock_type;
+
+		$first_acquisition = $lock->set( $lock_type );
+		$this->assertTrue( $first_acquisition, 'First set() should succeed when no lock is held.' );
+		$cached_after_first = wp_cache_get( $lock_key, 'action_scheduler_locks' );
+		$this->assertNotFalse( $cached_after_first, 'Lock value should be present in object cache after acquisition.' );
+
+		$second_acquisition = $lock->set( $lock_type );
+		$this->assertFalse( $second_acquisition, 'Second set() should fail while the lock is still active.' );
+		$cached_after_second = wp_cache_get( $lock_key, 'action_scheduler_locks' );
+		$this->assertSame( $cached_after_first, $cached_after_second, 'Cache entry should be unchanged after a failed re-acquisition attempt.' );
+
+		$this->assertTrue( $lock->is_locked( $lock_type ), 'Lock should remain held after a failed re-acquisition attempt.' );
+	}
+
+	/**
+	 * When the cache is evicted for a live lock, get_existing_lock() reads from DB and re-populates the cache.
+	 *
+	 * Covers: get_existing_lock() cache miss → DB hit → TTL > 0 → wp_cache_set branch.
+	 */
+	public function test_cache_miss_repopulates_cache_for_an_active_lock() {
+		$lock      = ActionScheduler::lock();
+		$lock_type = uniqid( 'lock_test_', true );
+		$lock_key  = 'action_scheduler_lock_' . $lock_type;
+
+		$lock->set( $lock_type );
+
+		// Evict the cache entry to force a DB read on the next call.
+		wp_cache_delete( $lock_key, 'action_scheduler_locks' );
+		$this->assertFalse( wp_cache_get( $lock_key, 'action_scheduler_locks' ), 'Cache should be empty after explicit eviction.' );
+
+		// is_locked() must hit the DB, confirm the lock is live, and re-populate the cache.
+		$this->assertTrue( $lock->is_locked( $lock_type ), 'Lock should still be held after cache eviction.' );
+		$this->assertNotFalse( wp_cache_get( $lock_key, 'action_scheduler_locks' ), 'Cache should be re-populated after reading a live lock from the DB.' );
+	}
 }


### PR DESCRIPTION
Introduces the following changes to the `\ActionScheduler_OptionLock` component:

- Capture current timestamps once, where applicable, rather than using in-place calls (reliability).
- Use the WordPress cache for active locks to reduce SQL queries and decrease asynchronous dispatch latency during shutdown (micro-optimization).

Manual testing:
- Build the plugin and install it on a testing site as a standalone plugin
- Add the snippet below (AI-slop, but works), e.g., as a mu-plugin or to another place where it'll be executed
- Navigate to the admin area (with and without persistent object cache being active)
- Refresh the page to monitor and verify the lock acquisition

```php
add_action( 'admin_notices', function () {                                                                                                                                                                   
        $lock      = ActionScheduler::lock();                                                                                                                                                                  
        $lock_type = 'async-request-runner';                                                                                                                                                                   
        $is_locked  = $lock->is_locked( $lock_type );                                                                                                                                                          
        $expiration = $lock->get_expiration( $lock_type );
                                                                                                                                                                                                               
        $status = $is_locked                                                                                                                                                                                 
                ? sprintf(                                                                                                                                                                                     
                        '<strong>LOCKED</strong> — expires %s (in %ds)',                                                                                                                                     
                        esc_html( date( 'H:i:s', $expiration ) ),                                                                                                                                              
                        max( 0, $expiration - time() )                                                                                                                                                         
                )                                                                                                                                                                                              
                : '<strong>NOT LOCKED</strong>';                                                                                                                                                               
                                                                                                                                                                                                             
        printf(                                                                                                                                                                                                
                '<div class="notice notice-%s"><p>ActionScheduler lock <code>%s</code>: %s</p></div>',
                $is_locked ? 'warning' : 'info',                                                                                                                                                               
                esc_html( $lock_type ),                                                                                                                                                                      
                $status                                                                                                                                                                                        
        );                                                                                                                                                                                                     
  } );

```


