### PR TITLE
(Optional) improvements for handling a subset of deserialization errors

### DIFF
--- a/classes/ActionScheduler_AdminView.php
+++ b/classes/ActionScheduler_AdminView.php
@@ -306,19 +306,20 @@ class ActionScheduler_AdminView extends ActionScheduler_AdminView_Deprecated {
 			'_asnonce'
 		);
 
-		// Markup is kept out of the translatable strings: each translatable piece is plain text, escaped
-		// here, then interpolated into developer-controlled HTML. esc_html__() on the sentence also means
-		// a rogue translation cannot inject markup, so wp_kses() is unnecessary.
-		$as_label     = '<strong>' . esc_html__( 'Action Scheduler:', 'action-scheduler' ) . '</strong>';
-		$failed_link  = sprintf( '<a href="%s">%s</a>', esc_url( $failed_url ), esc_html__( 'failed', 'action-scheduler' ) );
-		$dismiss_link = sprintf( '<a href="%s">%s</a>', esc_url( $dismiss_url ), esc_html__( 'Dismiss', 'action-scheduler' ) );
-
+		// The whole sentence is one translatable string, so translators keep full context and natural
+		// word order. Only the HTML tags are pulled out as placeholders (opening/closing pairs) -- tags
+		// need no translation. esc_html__() on the sentence neutralizes any markup a rogue translation
+		// might contain (the %n$s tokens survive it), and each opening tag carries an escaped URL, so
+		// wp_kses() is unnecessary.
 		$message = sprintf(
-			/* translators: 1: a bold "Action Scheduler:" label, 2: a link reading "failed", 3: a link reading "Dismiss". */
-			esc_html__( '%1$s one or more scheduled actions could not be run because their schedule references an unrecognized class, and have been marked %2$s for your review. If an action is safe to run, use its Run link to force it. %3$s', 'action-scheduler' ),
-			$as_label,
-			$failed_link,
-			$dismiss_link
+			/* translators: 1$s/2$s: opening/closing bold tags around "Action Scheduler:". 3$s/4$s: opening/closing tags of a link (around "failed") to the failed actions screen. 5$s/6$s: opening/closing tags of the dismiss link (around "Dismiss"). */
+			esc_html__( '%1$sAction Scheduler:%2$s one or more scheduled actions could not be run because their schedule references an unrecognized class, and have been marked %3$sfailed%4$s for your review. If an action is safe to run, use its Run link to force it. %5$sDismiss%6$s', 'action-scheduler' ),
+			'<strong>',
+			'</strong>',
+			'<a href="' . esc_url( $failed_url ) . '">',
+			'</a>',
+			'<a href="' . esc_url( $dismiss_url ) . '">',
+			'</a>'
 		);
 
 		wp_admin_notice(

--- a/classes/ActionScheduler_AdminView.php
+++ b/classes/ActionScheduler_AdminView.php
@@ -306,18 +306,19 @@ class ActionScheduler_AdminView extends ActionScheduler_AdminView_Deprecated {
 			'_asnonce'
 		);
 
-		$message = wp_kses(
-			sprintf(
-				// translators: 1) link to the failed actions screen, 2) dismiss link.
-				__( '<strong>Action Scheduler:</strong> one or more scheduled actions could not be run because their schedule references an unrecognized class, and have been marked <a href="%1$s">failed</a> for your review. If an action is safe to run, use its <em>Run</em> link to force it. <a href="%2$s">Dismiss</a>', 'action-scheduler' ),
-				esc_url( $failed_url ),
-				esc_url( $dismiss_url )
-			),
-			array(
-				'strong' => array(),
-				'em'     => array(),
-				'a'      => array( 'href' => true ),
-			)
+		// Markup is kept out of the translatable strings: each translatable piece is plain text, escaped
+		// here, then interpolated into developer-controlled HTML. esc_html__() on the sentence also means
+		// a rogue translation cannot inject markup, so wp_kses() is unnecessary.
+		$as_label     = '<strong>' . esc_html__( 'Action Scheduler:', 'action-scheduler' ) . '</strong>';
+		$failed_link  = sprintf( '<a href="%s">%s</a>', esc_url( $failed_url ), esc_html__( 'failed', 'action-scheduler' ) );
+		$dismiss_link = sprintf( '<a href="%s">%s</a>', esc_url( $dismiss_url ), esc_html__( 'Dismiss', 'action-scheduler' ) );
+
+		$message = sprintf(
+			/* translators: 1: a bold "Action Scheduler:" label, 2: a link reading "failed", 3: a link reading "Dismiss". */
+			esc_html__( '%1$s one or more scheduled actions could not be run because their schedule references an unrecognized class, and have been marked %2$s for your review. If an action is safe to run, use its Run link to force it. %3$s', 'action-scheduler' ),
+			$as_label,
+			$failed_link,
+			$dismiss_link
 		);
 
 		wp_admin_notice(

--- a/classes/ActionScheduler_AdminView.php
+++ b/classes/ActionScheduler_AdminView.php
@@ -50,6 +50,10 @@ class ActionScheduler_AdminView extends ActionScheduler_AdminView_Deprecated {
 	 * @codeCoverageIgnore
 	 */
 	public function init() {
+		// Registered unconditionally: the failure is recorded from the queue runner, which usually
+		// runs outside the admin (cron/async), so the recorder must not sit behind the is_admin() guard.
+		add_action( 'action_scheduler_unrecognized_schedule_action', array( $this, 'note_unrecognized_schedule_failure' ) );
+
 		if ( is_admin() && ( ! defined( 'DOING_AJAX' ) || ! DOING_AJAX ) ) {
 
 			if ( class_exists( 'WooCommerce' ) ) {
@@ -60,6 +64,7 @@ class ActionScheduler_AdminView extends ActionScheduler_AdminView_Deprecated {
 
 			add_action( 'admin_menu', array( $this, 'register_menu' ) );
 			add_action( 'admin_notices', array( $this, 'maybe_check_pastdue_actions' ) );
+			add_action( 'admin_notices', array( $this, 'maybe_show_unrecognized_schedule_notice' ) );
 			add_action( 'current_screen', array( $this, 'add_help_tabs' ) );
 		}
 	}
@@ -239,6 +244,89 @@ class ActionScheduler_AdminView extends ActionScheduler_AdminView_Deprecated {
 
 		// Facilitate third-parties to evaluate and print notices.
 		do_action( 'action_scheduler_pastdue_actions_extra_notices', $query_args );
+	}
+
+	/**
+	 * Option flag set when one or more actions have been failed because their schedule referenced an
+	 * unrecognized class. Drives the review notice below.
+	 *
+	 * @var string
+	 */
+	const UNRECOGNIZED_SCHEDULE_NOTICE_OPTION = 'action_scheduler_unrecognized_schedule_failures';
+
+	/**
+	 * Record that an action was failed because its schedule referenced an unrecognized class, so an
+	 * admin notice can prompt an operator to review it.
+	 *
+	 * Fired from the queue runner, which usually runs outside the admin (cron/async), so this makes no
+	 * assumptions about admin context. The flag is not autoloaded.
+	 */
+	public function note_unrecognized_schedule_failure() {
+		if ( ! get_option( self::UNRECOGNIZED_SCHEDULE_NOTICE_OPTION ) ) {
+			update_option( self::UNRECOGNIZED_SCHEDULE_NOTICE_OPTION, 1, false );
+		}
+	}
+
+	/**
+	 * Action: admin_notices
+	 *
+	 * Prompt operators to review actions failed because their schedule could not be recognized, and
+	 * render until the operator dismisses the notice.
+	 */
+	public function maybe_show_unrecognized_schedule_notice() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		// Process an explicit dismissal.
+		if (
+			isset( $_GET['as_dismiss_unrecognized_schedule'], $_GET['_asnonce'] )
+			&& wp_verify_nonce( sanitize_key( wp_unslash( $_GET['_asnonce'] ) ), 'as_dismiss_unrecognized_schedule' )
+		) {
+			delete_option( self::UNRECOGNIZED_SCHEDULE_NOTICE_OPTION );
+			return;
+		}
+
+		if ( ! get_option( self::UNRECOGNIZED_SCHEDULE_NOTICE_OPTION ) ) {
+			return;
+		}
+
+		$failed_url = add_query_arg(
+			array(
+				'page'   => 'action-scheduler',
+				'status' => ActionScheduler_Store::STATUS_FAILED,
+				'order'  => 'asc',
+			),
+			admin_url( 'tools.php' )
+		);
+
+		$dismiss_url = wp_nonce_url(
+			add_query_arg( 'as_dismiss_unrecognized_schedule', '1' ),
+			'as_dismiss_unrecognized_schedule',
+			'_asnonce'
+		);
+
+		$message = wp_kses(
+			sprintf(
+				// translators: 1) link to the failed actions screen, 2) dismiss link.
+				__( '<strong>Action Scheduler:</strong> one or more scheduled actions could not be run because their schedule references an unrecognized class, and have been marked <a href="%1$s">failed</a> for your review. If an action is safe to run, use its <em>Run</em> link to force it. <a href="%2$s">Dismiss</a>', 'action-scheduler' ),
+				esc_url( $failed_url ),
+				esc_url( $dismiss_url )
+			),
+			array(
+				'strong' => array(),
+				'em'     => array(),
+				'a'      => array( 'href' => true ),
+			)
+		);
+
+		wp_admin_notice(
+			$message,
+			array(
+				'type'           => 'warning',
+				'paragraph_wrap' => true,
+			)
+		);
 	}
 
 	/**

--- a/classes/ActionScheduler_ListTable.php
+++ b/classes/ActionScheduler_ListTable.php
@@ -469,6 +469,10 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 
 		$schedule_display_string = '';
 
+		if ( is_a( $schedule, 'ActionScheduler_UnrecognizedSchedule' ) ) {
+			return __( 'Unrecognized schedule', 'action-scheduler' );
+		}
+
 		if ( is_a( $schedule, 'ActionScheduler_NullSchedule' ) ) {
 			return __( 'async', 'action-scheduler' );
 		}
@@ -570,7 +574,13 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 		try {
 			switch ( $row_action_type ) {
 				case 'run':
-					$this->runner->process_action( $action_id, 'Admin List Table' );
+					// A failed action is not pending, so it cannot be run on the normal path. Force it, so
+					// an operator can retry a failed action or flush one whose schedule was unrecognized.
+					if ( ActionScheduler_Store::STATUS_FAILED === $this->store->get_status( $action_id ) ) {
+						$this->runner->force_run_action( $action_id, 'Admin List Table' );
+					} else {
+						$this->runner->process_action( $action_id, 'Admin List Table' );
+					}
 					break;
 				case 'cancel':
 					$this->store->cancel_action( $action_id );

--- a/classes/ActionScheduler_ScheduleDeserializer.php
+++ b/classes/ActionScheduler_ScheduleDeserializer.php
@@ -305,6 +305,16 @@ class ActionScheduler_ScheduleDeserializer {
 		do_action( 'action_scheduler_unexpected_schedule_class', $offending_class, $this->outer_class, $this->potential_offenders, $rejected );
 
 		if ( $rejected ) {
+			// A recoverable ($shadow_eligible) rejection is a structurally-valid schedule that merely
+			// references an unrecognized class — not evidently dangerous, just unknown. Return it as an
+			// ActionScheduler_UnrecognizedSchedule placeholder so the action stays visible and can be
+			// routed to a failed state for operator review / forced re-run, rather than being treated as
+			// irretrievably corrupt (false) and silently cancelled. Structural rejections (a top-level
+			// non-schedule or an unwalkable graph) have no legitimate form and remain corrupt.
+			if ( $shadow_eligible ) {
+				return new ActionScheduler_UnrecognizedSchedule( $this->potential_offenders );
+			}
+
 			return false;
 		}
 

--- a/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php
+++ b/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php
@@ -58,6 +58,8 @@ abstract class ActionScheduler_Abstract_QueueRunner extends ActionScheduler_Abst
 	 * @param int    $action_id The action ID to process.
 	 * @param string $context Optional identifier for the context in which this action is being processed, e.g. 'WP CLI' or 'WP Cron'
 	 *                        Generally, this should be capitalised and not localised as it's a proper noun.
+	 * @param bool   $force   Run the action even if it is not pending, and skip the unrecognized-schedule
+	 *                        guard. Used by force_run_action() so an operator can flush stuck work.
 	 * @throws \Exception When error running action.
 	 */
 	public function process_action( $action_id, $context = '', $force = false ) {

--- a/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php
+++ b/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php
@@ -60,7 +60,7 @@ abstract class ActionScheduler_Abstract_QueueRunner extends ActionScheduler_Abst
 	 *                        Generally, this should be capitalised and not localised as it's a proper noun.
 	 * @throws \Exception When error running action.
 	 */
-	public function process_action( $action_id, $context = '' ) {
+	public function process_action( $action_id, $context = '', $force = false ) {
 		// Temporarily override the error handler while we process the current action.
 		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler
 		set_error_handler(
@@ -89,7 +89,9 @@ abstract class ActionScheduler_Abstract_QueueRunner extends ActionScheduler_Abst
 			try {
 				do_action( 'action_scheduler_before_execute', $action_id, $context );
 
-				if ( ActionScheduler_Store::STATUS_PENDING !== $this->store->get_status( $action_id ) ) {
+				// A forced run (e.g. a site operator using the admin "Run" link) executes the action even
+				// if it is not pending, so it can flush work that is otherwise stuck.
+				if ( ! $force && ActionScheduler_Store::STATUS_PENDING !== $this->store->get_status( $action_id ) ) {
 					$valid_action = false;
 					do_action( 'action_scheduler_execution_ignored', $action_id, $context );
 					return;
@@ -101,6 +103,15 @@ abstract class ActionScheduler_Abstract_QueueRunner extends ActionScheduler_Abst
 				if ( null === $action ) {
 					$valid_action = false;
 					$this->cancel_corrupted_action( $action_id );
+					return;
+				}
+
+				// An action whose schedule could not be recognized is not run automatically: we cannot
+				// know when it was meant to run, so we mark it failed for operator review rather than
+				// cancelling it. A forced run overrides this and executes the action's callback anyway.
+				if ( ! $force && $action->get_schedule() instanceof ActionScheduler_UnrecognizedSchedule ) {
+					$valid_action = false;
+					$this->fail_unrecognized_action( $action_id );
 					return;
 				}
 
@@ -124,6 +135,34 @@ abstract class ActionScheduler_Abstract_QueueRunner extends ActionScheduler_Abst
 
 		if ( isset( $action ) && is_a( $action, 'ActionScheduler_Action' ) && $action->get_schedule()->is_recurring() ) {
 			$this->schedule_next_instance( $action, $action_id );
+		}
+	}
+
+	/**
+	 * Force an action to run now, regardless of its current status.
+	 *
+	 * Intended for a site operator flushing stuck work from the admin list table — most usefully an
+	 * action that was failed because its schedule references an unrecognized class, which cannot be run
+	 * on the normal (automatic) path. A failed action would otherwise be fetched as a non-executable
+	 * ActionScheduler_FinishedAction, so for the duration of this run we map it back to an executable
+	 * action class. The action's callback runs; its (unreadable or valid) schedule is not consulted, so
+	 * no next instance of a recurring series is scheduled.
+	 *
+	 * @param int    $action_id Action ID.
+	 * @param string $context   Context in which the action is being run.
+	 * @return void
+	 */
+	public function force_run_action( $action_id, $context = '' ) {
+		$as_executable = static function ( $action_class, $status ) {
+			return ActionScheduler_Store::STATUS_FAILED === $status ? 'ActionScheduler_Action' : $action_class;
+		};
+
+		add_filter( 'action_scheduler_stored_action_class', $as_executable, 10, 2 );
+
+		try {
+			$this->process_action( $action_id, $context, true );
+		} finally {
+			remove_filter( 'action_scheduler_stored_action_class', $as_executable, 10 );
 		}
 	}
 
@@ -162,6 +201,34 @@ abstract class ActionScheduler_Abstract_QueueRunner extends ActionScheduler_Abst
 		ActionScheduler_Logger::instance()->log(
 			$action_id,
 			__( 'This action data appears to be corrupt. We are cancelling it to allow recurring actions to be re-created by extensions.', 'action-scheduler' )
+		);
+	}
+
+	/**
+	 * Marks an action failed because its schedule references a class Action Scheduler does not
+	 * recognize. Unlike a corrupt action, this is recoverable: an operator can review it and force it
+	 * to run, or make the referenced class available (via the
+	 * action_scheduler_allowed_nested_schedule_classes filter) and re-run it normally.
+	 *
+	 * @param int $action_id Action ID.
+	 * @return void
+	 */
+	private function fail_unrecognized_action( int $action_id ) {
+		$this->store->mark_failure( $action_id );
+
+		/**
+		 * Fires when an action is marked failed because its stored schedule references an unrecognized
+		 * class, rather than being run or cancelled.
+		 *
+		 * @since 4.1.0
+		 *
+		 * @param int $action_id Action ID.
+		 */
+		do_action( 'action_scheduler_unrecognized_schedule_action', $action_id );
+
+		ActionScheduler_Logger::instance()->log(
+			$action_id,
+			__( 'This action references a schedule that could not be recognized, so it has been marked as failed rather than run. Review it and, if it is safe, force it to run.', 'action-scheduler' )
 		);
 	}
 

--- a/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php
+++ b/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php
@@ -133,7 +133,10 @@ abstract class ActionScheduler_Abstract_QueueRunner extends ActionScheduler_Abst
 			restore_error_handler();
 		}
 
-		if ( isset( $action ) && is_a( $action, 'ActionScheduler_Action' ) && $action->get_schedule()->is_recurring() ) {
+		// A forced run flushes a single occurrence on an operator's request; it must not advance a
+		// recurring series. The next instance was already scheduled when the action first ran, so
+		// rescheduling here would create a duplicate.
+		if ( ! $force && isset( $action ) && is_a( $action, 'ActionScheduler_Action' ) && $action->get_schedule()->is_recurring() ) {
 			$this->schedule_next_instance( $action, $action_id );
 		}
 	}
@@ -147,6 +150,9 @@ abstract class ActionScheduler_Abstract_QueueRunner extends ActionScheduler_Abst
 	 * ActionScheduler_FinishedAction, so for the duration of this run we map it back to an executable
 	 * action class. The action's callback runs; its (unreadable or valid) schedule is not consulted, so
 	 * no next instance of a recurring series is scheduled.
+	 *
+	 * This executes an action regardless of status, so callers are responsible for authorizing the
+	 * request (the admin list table gates it behind a per-row nonce and the manage_options capability).
 	 *
 	 * @param int    $action_id Action ID.
 	 * @param string $context   Context in which the action is being run.

--- a/classes/schedules/ActionScheduler_UnrecognizedSchedule.php
+++ b/classes/schedules/ActionScheduler_UnrecognizedSchedule.php
@@ -26,6 +26,8 @@ class ActionScheduler_UnrecognizedSchedule extends ActionScheduler_NullSchedule 
 	protected $unrecognized_classes = array();
 
 	/**
+	 * Construct.
+	 *
 	 * @param string[] $unrecognized_classes Class names from the blob that could not be vetted.
 	 */
 	public function __construct( array $unrecognized_classes = array() ) {

--- a/classes/schedules/ActionScheduler_UnrecognizedSchedule.php
+++ b/classes/schedules/ActionScheduler_UnrecognizedSchedule.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * A placeholder schedule for a stored action whose real schedule could not be safely deserialized
+ * because it references one or more classes Action Scheduler does not recognize.
+ *
+ * Such a schedule is structurally valid (its outermost object implements ActionScheduler_Schedule)
+ * but nests a class outside the trusted allow-list — for example a support class shipped by an
+ * extension that is not currently loaded or allow-listed. It is not, in itself, evidently dangerous,
+ * so rather than silently cancelling the action (which loses it), we substitute this placeholder.
+ * That keeps the action visible so a site operator can review it, move it to a failed state, and — if
+ * appropriate — force it to run. @see https://github.com/woocommerce/action-scheduler/issues/1318
+ *
+ * It extends ActionScheduler_NullSchedule, so it carries no runnable date and is treated as a one-off
+ * (non-recurring) for scheduling purposes.
+ *
+ * @since 4.1.0
+ */
+class ActionScheduler_UnrecognizedSchedule extends ActionScheduler_NullSchedule {
+
+	/**
+	 * The class names discovered in the stored blob that Action Scheduler did not recognize.
+	 *
+	 * @var string[]
+	 */
+	protected $unrecognized_classes = array();
+
+	/**
+	 * @param string[] $unrecognized_classes Class names from the blob that could not be vetted.
+	 */
+	public function __construct( array $unrecognized_classes = array() ) {
+		parent::__construct();
+		$this->unrecognized_classes = array_values( array_unique( $unrecognized_classes ) );
+	}
+
+	/**
+	 * The unrecognized class names, for display and logging.
+	 *
+	 * @return string[]
+	 */
+	public function get_unrecognized_classes() {
+		return $this->unrecognized_classes;
+	}
+}

--- a/tests/phpunit.xml.dist
+++ b/tests/phpunit.xml.dist
@@ -18,6 +18,7 @@
 			<file phpVersion="5.6">./phpunit/jobstore/ActionScheduler_DBStoreMigrator_Test.php</file>
 			<file phpVersion="5.6">./phpunit/jobstore/ActionScheduler_DBStore_Test.php</file>
 			<file phpVersion="5.6">./phpunit/jobstore/ActionScheduler_ScheduleUnserialize_Test.php</file>
+			<file phpVersion="5.6">./phpunit/jobstore/ActionScheduler_UnrecognizedSchedule_Test.php</file>
 			<file phpVersion="5.6">./phpunit/jobstore/ActionScheduler_HybridStore_Test.php</file>
 			<file phpVersion="5.6">./phpunit/logging/ActionScheduler_DBLogger_Test.php</file>
 		</testsuite>

--- a/tests/phpunit/jobstore/ActionScheduler_ScheduleUnserialize_Test.php
+++ b/tests/phpunit/jobstore/ActionScheduler_ScheduleUnserialize_Test.php
@@ -370,10 +370,12 @@ class ActionScheduler_ScheduleUnserialize_Test extends ActionScheduler_UnitTestC
 	public function test_nested_allow_list_filter_is_honored_per_call() {
 		$blob = serialize( new ActionScheduler_Test_Custom_Schedule_With_Property( time() + DAY_IN_SECONDS, new ActionScheduler_Test_Schedule_Helper( 42 ) ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
 
-		// First call, no filter: the helper class is unexpected, so the blob is rejected.
-		$this->assertFalse(
+		// First call, no filter: the helper class is unexpected, so the blob yields the unrecognized
+		// placeholder (a valid schedule referencing an unknown class is recoverable, not corrupt).
+		$this->assertInstanceOf(
+			'ActionScheduler_UnrecognizedSchedule',
 			ActionScheduler_ScheduleDeserializer::unserialize( $blob ),
-			'An un-allow-listed nested support class should be rejected by default.'
+			'An un-allow-listed nested support class should yield an unrecognized-schedule placeholder.'
 		);
 
 		// Second call, with the helper allow-listed via the filter: the blob is accepted. This also
@@ -438,8 +440,9 @@ class ActionScheduler_ScheduleUnserialize_Test extends ActionScheduler_UnitTestC
 			array()
 		);
 
-		// First: a blob nesting a gadget (rejected, populating internal offender/seen state).
-		$this->assertFalse( $deserializer( $this->nested_gadget_blob() ) );
+		// First: a blob nesting a gadget (rejected to the unrecognized placeholder, populating internal
+		// offender/seen state).
+		$this->assertInstanceOf( 'ActionScheduler_UnrecognizedSchedule', $deserializer( $this->nested_gadget_blob() ) );
 
 		// Then: a clean third party schedule must still deserialize correctly.
 		$clean = serialize( new ActionScheduler_Test_Custom_Schedule( time() + HOUR_IN_SECONDS ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
@@ -458,7 +461,7 @@ class ActionScheduler_ScheduleUnserialize_Test extends ActionScheduler_UnitTestC
 		$blob = serialize( new ActionScheduler_Test_Custom_Schedule_With_Property( time() + DAY_IN_SECONDS, new ActionScheduler_Test_Schedule_Helper( 7 ) ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
 
 		$without = new ActionScheduler_ScheduleDeserializer( array(), array() );
-		$this->assertFalse( $without( $blob ), 'Nested support classes absent from the allow-list must be rejected.' );
+		$this->assertInstanceOf( 'ActionScheduler_UnrecognizedSchedule', $without( $blob ), 'Nested support classes absent from the allow-list yield an unrecognized-schedule placeholder.' );
 
 		$with = new ActionScheduler_ScheduleDeserializer(
 			array(),
@@ -548,7 +551,7 @@ class ActionScheduler_ScheduleUnserialize_Test extends ActionScheduler_UnitTestC
 
 		$result = ActionScheduler_ScheduleDeserializer::unserialize( $blob );
 
-		$this->assertFalse( $result );
+		$this->assertInstanceOf( 'ActionScheduler_UnrecognizedSchedule', $result );
 		$this->assertFalse(
 			ActionScheduler_Test_Evil_Gadget::$fired,
 			'A gadget nested in a third party schedule was instantiated.'
@@ -585,5 +588,28 @@ class ActionScheduler_ScheduleUnserialize_Test extends ActionScheduler_UnitTestC
 			unset( $e ); // A handled InvalidActionException is acceptable; an Error would have fataled above.
 		}
 		$this->assertNotNull( $fetched, 'Fetching a tampered action fataled instead of being handled.' );
+	}
+
+	/**
+	 * A structurally-valid schedule that merely nests an unrecognized class is recoverable: it yields an
+	 * ActionScheduler_UnrecognizedSchedule placeholder (carrying the offending class names) rather than
+	 * being treated as irretrievably corrupt. A structural rejection (top-level non-schedule) stays
+	 * corrupt (false).
+	 */
+	public function test_recoverable_schedule_yields_unrecognized_placeholder_but_structural_stays_corrupt() {
+		// Valid third party schedule nesting an unknown helper class -> recoverable.
+		$recoverable = serialize( new ActionScheduler_Test_Custom_Schedule_With_Property( time() + DAY_IN_SECONDS, new ActionScheduler_Test_Schedule_Helper( 1 ) ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
+		$schedule    = ActionScheduler_ScheduleDeserializer::unserialize( $recoverable );
+
+		$this->assertInstanceOf( 'ActionScheduler_UnrecognizedSchedule', $schedule );
+		$this->assertContains(
+			'ActionScheduler_Test_Schedule_Helper',
+			$schedule->get_unrecognized_classes(),
+			'The placeholder should record the unrecognized class name for operator review.'
+		);
+
+		// A bare top-level non-schedule is a structural rejection, not recoverable -> stays corrupt.
+		$structural = serialize( new ActionScheduler_Test_Evil_Gadget() ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
+		$this->assertFalse( ActionScheduler_ScheduleDeserializer::unserialize( $structural ) );
 	}
 }

--- a/tests/phpunit/jobstore/ActionScheduler_UnrecognizedSchedule_Test.php
+++ b/tests/phpunit/jobstore/ActionScheduler_UnrecognizedSchedule_Test.php
@@ -1,0 +1,114 @@
+<?php
+
+/**
+ * Tests for how the queue runner handles an action whose stored schedule references an unrecognized
+ * class: it is marked failed (for operator review) rather than cancelled, and a forced run executes
+ * its callback regardless of the unreadable schedule.
+ *
+ * @see https://github.com/woocommerce/action-scheduler/issues/1318
+ *
+ * @group tables
+ */
+class ActionScheduler_UnrecognizedSchedule_Test extends ActionScheduler_UnitTestCase {
+
+	public function setUp(): void {
+		global $wpdb;
+		$wpdb->query( "DELETE FROM {$wpdb->actionscheduler_actions}" );
+		parent::setUp();
+	}
+
+	/**
+	 * Persist a real, due, pending action, then overwrite its stored schedule with a blob that is a
+	 * valid outer schedule nesting an unrecognized class — which the deserializer resolves to an
+	 * ActionScheduler_UnrecognizedSchedule.
+	 *
+	 * @param string $hook Hook to schedule.
+	 * @return int Action ID.
+	 */
+	private function store_due_action_with_unrecognized_schedule( $hook ) {
+		global $wpdb;
+
+		$store     = new ActionScheduler_DBStore();
+		$action    = new ActionScheduler_Action( $hook, array(), new ActionScheduler_SimpleSchedule( as_get_datetime_object( '1 hour ago' ) ) );
+		$action_id = $store->save_action( $action );
+
+		// A valid third party schedule (a placeholder in the safe parse, so nothing is instantiated)
+		// whose property holds a class Action Scheduler does not recognize.
+		$nul       = chr( 0 );
+		$prop      = $nul . '*' . $nul . 'timestamp';
+		$container = 'ActionScheduler_Test_Custom_Schedule';
+		$unknown   = 'O:14:"Some_Unknown_X":0:{}';
+		$blob      = 'O:' . strlen( $container ) . ':"' . $container . '":1:{s:' . strlen( $prop ) . ':"' . $prop . '";' . $unknown . '}';
+
+		$wpdb->update(
+			$wpdb->actionscheduler_actions,
+			array( 'schedule' => $blob ),
+			array( 'action_id' => $action_id ),
+			array( '%s' ),
+			array( '%d' )
+		);
+
+		return $action_id;
+	}
+
+	/**
+	 * The deserializer resolves the tampered schedule to the placeholder, so the action fetches as a
+	 * normal (displayable) action rather than a null action.
+	 */
+	public function test_action_fetches_with_unrecognized_schedule_placeholder() {
+		$store     = new ActionScheduler_DBStore();
+		$action_id = $this->store_due_action_with_unrecognized_schedule( 'as_test_unrecognized_fetch' );
+
+		$fetched = $store->fetch_action( $action_id );
+
+		$this->assertNotInstanceOf( 'ActionScheduler_NullAction', $fetched );
+		$this->assertInstanceOf( 'ActionScheduler_UnrecognizedSchedule', $fetched->get_schedule() );
+	}
+
+	/**
+	 * Automatic processing must mark an unrecognized-schedule action failed (for review) rather than
+	 * running it or cancelling it.
+	 */
+	public function test_unrecognized_schedule_action_is_failed_not_run_or_cancelled() {
+		$hook = 'as_test_unrecognized_auto';
+		$ran  = 0;
+		add_action( $hook, function () use ( &$ran ) { ++$ran; } );
+
+		$store     = new ActionScheduler_DBStore();
+		$runner    = ActionScheduler_Mocker::get_queue_runner( $store );
+		$action_id = $this->store_due_action_with_unrecognized_schedule( $hook );
+
+		$runner->process_action( $action_id );
+
+		$this->assertSame( ActionScheduler_Store::STATUS_FAILED, $store->get_status( $action_id ), 'The action should be failed, not cancelled or run.' );
+		$this->assertSame( 0, $ran, 'An unrecognized-schedule action must not run automatically.' );
+
+		remove_all_actions( $hook );
+	}
+
+	/**
+	 * A forced run (as a site operator would trigger from the admin list table) executes the action's
+	 * callback despite the unreadable schedule, flushing the work, and completes the action.
+	 */
+	public function test_forced_run_executes_unrecognized_schedule_action() {
+		$hook = 'as_test_unrecognized_forced';
+		$ran  = 0;
+		add_action( $hook, function () use ( &$ran ) { ++$ran; } );
+
+		$store     = new ActionScheduler_DBStore();
+		$runner    = ActionScheduler_Mocker::get_queue_runner( $store );
+		$action_id = $this->store_due_action_with_unrecognized_schedule( $hook );
+
+		// First, automatic processing marks it failed.
+		$runner->process_action( $action_id );
+		$this->assertSame( ActionScheduler_Store::STATUS_FAILED, $store->get_status( $action_id ) );
+
+		// Then a forced run executes the callback and completes it.
+		$runner->force_run_action( $action_id, 'Test' );
+
+		$this->assertSame( 1, $ran, 'A forced run must execute the action callback.' );
+		$this->assertSame( ActionScheduler_Store::STATUS_COMPLETE, $store->get_status( $action_id ) );
+
+		remove_all_actions( $hook );
+	}
+}

--- a/tests/phpunit/jobstore/ActionScheduler_UnrecognizedSchedule_Test.php
+++ b/tests/phpunit/jobstore/ActionScheduler_UnrecognizedSchedule_Test.php
@@ -72,10 +72,20 @@ class ActionScheduler_UnrecognizedSchedule_Test extends ActionScheduler_UnitTest
 	public function test_unrecognized_schedule_action_is_failed_not_run_or_cancelled() {
 		$hook = 'as_test_unrecognized_auto';
 		$ran  = 0;
-		add_action( $hook, function () use ( &$ran ) { ++$ran; } );
+		add_action(
+			$hook,
+			function () use ( &$ran ) {
+				++$ran;
+			}
+		);
 
 		$notified = false;
-		add_action( 'action_scheduler_unrecognized_schedule_action', function () use ( &$notified ) { $notified = true; } );
+		add_action(
+			'action_scheduler_unrecognized_schedule_action',
+			function () use ( &$notified ) {
+				$notified = true;
+			}
+		);
 
 		$store     = new ActionScheduler_DBStore();
 		$runner    = ActionScheduler_Mocker::get_queue_runner( $store );
@@ -98,7 +108,12 @@ class ActionScheduler_UnrecognizedSchedule_Test extends ActionScheduler_UnitTest
 	public function test_forced_run_executes_unrecognized_schedule_action() {
 		$hook = 'as_test_unrecognized_forced';
 		$ran  = 0;
-		add_action( $hook, function () use ( &$ran ) { ++$ran; } );
+		add_action(
+			$hook,
+			function () use ( &$ran ) {
+				++$ran;
+			}
+		);
 
 		$store     = new ActionScheduler_DBStore();
 		$runner    = ActionScheduler_Mocker::get_queue_runner( $store );
@@ -136,7 +151,12 @@ class ActionScheduler_UnrecognizedSchedule_Test extends ActionScheduler_UnitTest
 	public function test_list_table_run_force_runs_a_failed_action() {
 		$hook = 'as_test_unrecognized_listtable';
 		$ran  = 0;
-		add_action( $hook, function () use ( &$ran ) { ++$ran; } );
+		add_action(
+			$hook,
+			function () use ( &$ran ) {
+				++$ran;
+			}
+		);
 
 		$store     = new ActionScheduler_DBStore();
 		$runner    = ActionScheduler_Mocker::get_queue_runner( $store );
@@ -178,7 +198,7 @@ class ActionScheduler_UnrecognizedSchedule_Test extends ActionScheduler_UnitTest
 
 		$this->assertFalse( (bool) get_option( $option ), 'A valid dismissal should clear the notice flag.' );
 
-		unset( $_GET['as_dismiss_unrecognized_schedule'], $_GET['_asnonce'] );
+		unset( $_GET['as_dismiss_unrecognized_schedule'], $_GET['_asnonce'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- test cleanup of simulated request state.
 	}
 
 	/**
@@ -215,7 +235,10 @@ class ActionScheduler_UnrecognizedSchedule_Test extends ActionScheduler_UnitTest
 		$action_id = $store->save_action( $action );
 		$store->mark_failure( $action_id );
 
-		$pending_query = array( 'hook' => $hook, 'status' => ActionScheduler_Store::STATUS_PENDING );
+		$pending_query = array(
+			'hook'   => $hook,
+			'status' => ActionScheduler_Store::STATUS_PENDING,
+		);
 		$this->assertSame( 0, (int) $store->query_actions( $pending_query, 'count' ) );
 
 		$runner->force_run_action( $action_id, 'Test' );

--- a/tests/phpunit/jobstore/ActionScheduler_UnrecognizedSchedule_Test.php
+++ b/tests/phpunit/jobstore/ActionScheduler_UnrecognizedSchedule_Test.php
@@ -111,4 +111,62 @@ class ActionScheduler_UnrecognizedSchedule_Test extends ActionScheduler_UnitTest
 
 		remove_all_actions( $hook );
 	}
+
+	/**
+	 * The admin list table renders an unrecognized schedule with a clear label rather than falling
+	 * through to the NullSchedule "async" display.
+	 */
+	public function test_list_table_displays_unrecognized_schedule() {
+		$list_table = $this->make_list_table();
+		$method     = new ReflectionMethod( $list_table, 'get_schedule_display_string' );
+		$method->setAccessible( true );
+
+		$this->assertSame( 'Unrecognized schedule', $method->invoke( $list_table, new ActionScheduler_UnrecognizedSchedule() ) );
+	}
+
+	/**
+	 * The list table "Run" row action force-runs a failed action (previously impossible), so an
+	 * operator can flush stuck work.
+	 */
+	public function test_list_table_run_force_runs_a_failed_action() {
+		$hook = 'as_test_unrecognized_listtable';
+		$ran  = 0;
+		add_action( $hook, function () use ( &$ran ) { ++$ran; } );
+
+		$store     = new ActionScheduler_DBStore();
+		$runner    = ActionScheduler_Mocker::get_queue_runner( $store );
+		$action_id = $this->store_due_action_with_unrecognized_schedule( $hook );
+
+		$runner->process_action( $action_id ); // Automatic pass marks it failed.
+		$this->assertSame( ActionScheduler_Store::STATUS_FAILED, $store->get_status( $action_id ) );
+
+		$list_table = $this->make_list_table( $store, $runner );
+		$method     = new ReflectionMethod( $list_table, 'process_row_action' );
+		$method->setAccessible( true );
+		$method->invoke( $list_table, $action_id, 'run' );
+
+		$this->assertSame( 1, $ran, 'The list table Run action should force-run a failed action.' );
+		$this->assertSame( ActionScheduler_Store::STATUS_COMPLETE, $store->get_status( $action_id ) );
+
+		remove_all_actions( $hook );
+	}
+
+	/**
+	 * Build a list table instance for tests, loading the WP_List_Table base if the admin context that
+	 * normally provides it has not been loaded.
+	 *
+	 * @param ActionScheduler_Store|null       $store  Store to use.
+	 * @param ActionScheduler_QueueRunner|null $runner Runner to use.
+	 * @return ActionScheduler_ListTable
+	 */
+	private function make_list_table( $store = null, $runner = null ) {
+		if ( ! class_exists( 'WP_List_Table' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/class-wp-list-table.php';
+		}
+
+		$store  = $store ? $store : new ActionScheduler_DBStore();
+		$runner = $runner ? $runner : ActionScheduler_Mocker::get_queue_runner( $store );
+
+		return new ActionScheduler_ListTable( $store, ActionScheduler_Logger::instance(), $runner );
+	}
 }

--- a/tests/phpunit/jobstore/ActionScheduler_UnrecognizedSchedule_Test.php
+++ b/tests/phpunit/jobstore/ActionScheduler_UnrecognizedSchedule_Test.php
@@ -74,6 +74,9 @@ class ActionScheduler_UnrecognizedSchedule_Test extends ActionScheduler_UnitTest
 		$ran  = 0;
 		add_action( $hook, function () use ( &$ran ) { ++$ran; } );
 
+		$notified = false;
+		add_action( 'action_scheduler_unrecognized_schedule_action', function () use ( &$notified ) { $notified = true; } );
+
 		$store     = new ActionScheduler_DBStore();
 		$runner    = ActionScheduler_Mocker::get_queue_runner( $store );
 		$action_id = $this->store_due_action_with_unrecognized_schedule( $hook );
@@ -82,8 +85,10 @@ class ActionScheduler_UnrecognizedSchedule_Test extends ActionScheduler_UnitTest
 
 		$this->assertSame( ActionScheduler_Store::STATUS_FAILED, $store->get_status( $action_id ), 'The action should be failed, not cancelled or run.' );
 		$this->assertSame( 0, $ran, 'An unrecognized-schedule action must not run automatically.' );
+		$this->assertTrue( $notified, 'The action_scheduler_unrecognized_schedule_action hook should fire.' );
 
 		remove_all_actions( $hook );
+		remove_all_actions( 'action_scheduler_unrecognized_schedule_action' );
 	}
 
 	/**
@@ -149,6 +154,49 @@ class ActionScheduler_UnrecognizedSchedule_Test extends ActionScheduler_UnitTest
 		$this->assertSame( ActionScheduler_Store::STATUS_COMPLETE, $store->get_status( $action_id ) );
 
 		remove_all_actions( $hook );
+	}
+
+	/**
+	 * The notice flag is set when an unrecognized-schedule failure is noted, and cleared by a valid
+	 * dismissal request.
+	 */
+	public function test_notice_flag_is_set_and_dismissed() {
+		$admin  = ActionScheduler_AdminView::instance();
+		$option = ActionScheduler_AdminView::UNRECOGNIZED_SCHEDULE_NOTICE_OPTION;
+		delete_option( $option );
+
+		$admin->note_unrecognized_schedule_failure();
+		$this->assertNotEmpty( get_option( $option ), 'Noting a failure should set the notice flag.' );
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		$_GET['as_dismiss_unrecognized_schedule'] = '1';
+		$_GET['_asnonce']                         = wp_create_nonce( 'as_dismiss_unrecognized_schedule' );
+
+		ob_start();
+		$admin->maybe_show_unrecognized_schedule_notice();
+		ob_end_clean();
+
+		$this->assertFalse( (bool) get_option( $option ), 'A valid dismissal should clear the notice flag.' );
+
+		unset( $_GET['as_dismiss_unrecognized_schedule'], $_GET['_asnonce'] );
+	}
+
+	/**
+	 * The notice renders for an administrator while the flag is set, and links to the failed actions
+	 * screen.
+	 */
+	public function test_notice_renders_for_admin_and_links_to_failed_actions() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		update_option( ActionScheduler_AdminView::UNRECOGNIZED_SCHEDULE_NOTICE_OPTION, 1, false );
+
+		ob_start();
+		ActionScheduler_AdminView::instance()->maybe_show_unrecognized_schedule_notice();
+		$html = ob_get_clean();
+
+		$this->assertStringContainsString( 'unrecognized class', $html );
+		$this->assertStringContainsString( 'status=failed', $html );
+
+		delete_option( ActionScheduler_AdminView::UNRECOGNIZED_SCHEDULE_NOTICE_OPTION );
 	}
 
 	/**

--- a/tests/phpunit/jobstore/ActionScheduler_UnrecognizedSchedule_Test.php
+++ b/tests/phpunit/jobstore/ActionScheduler_UnrecognizedSchedule_Test.php
@@ -200,6 +200,36 @@ class ActionScheduler_UnrecognizedSchedule_Test extends ActionScheduler_UnitTest
 	}
 
 	/**
+	 * Force-running a failed recurring action (with a still-valid schedule) must not schedule a
+	 * duplicate next instance — the series already advanced when the action first ran.
+	 */
+	public function test_forced_run_of_recurring_failed_action_does_not_reschedule() {
+		$hook = 'as_test_force_recurring';
+		add_action( $hook, '__return_true' );
+
+		$store  = new ActionScheduler_DBStore();
+		$runner = ActionScheduler_Mocker::get_queue_runner( $store );
+
+		$schedule  = new ActionScheduler_IntervalSchedule( as_get_datetime_object( '1 hour ago' ), HOUR_IN_SECONDS );
+		$action    = new ActionScheduler_Action( $hook, array(), $schedule );
+		$action_id = $store->save_action( $action );
+		$store->mark_failure( $action_id );
+
+		$pending_query = array( 'hook' => $hook, 'status' => ActionScheduler_Store::STATUS_PENDING );
+		$this->assertSame( 0, (int) $store->query_actions( $pending_query, 'count' ) );
+
+		$runner->force_run_action( $action_id, 'Test' );
+
+		$this->assertSame(
+			0,
+			(int) $store->query_actions( $pending_query, 'count' ),
+			'A forced run of a failed recurring action must not schedule a duplicate next instance.'
+		);
+
+		remove_all_actions( $hook );
+	}
+
+	/**
 	 * Build a list table instance for tests, loading the WP_List_Table base if the admin context that
 	 * normally provides it has not been loaded.
 	 *


### PR DESCRIPTION
- Still a draft
- Potential enhancement for https://github.com/woocommerce/action-scheduler/pull/1344