### PR TITLE
Fix default 'before' date in WP-CLI clean command #1343

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 4.1.0 - xxxx-xx-xx =
 * Use `wp_admin_notice()` to render admin notices, instead of custom HTML.
 * Fix an oversight in the lock implementation (used to rate-limit async request runners) that could result in a database error in unusual cases.
+* Fix the behavior of the `wp action-schedule clean` command so that the `--before` option correctly defaults to 31 days ago.
 * Dev - Updates the `wpPostStore` to capture any database errors that might occur while claiming actions.
 * Performance - Reduce the number of SQL queries on Action Scheduler admin page.
 * Performance - Cache resolved group IDs to reduce the number of SQL queries.

--- a/classes/WP_CLI/ActionScheduler_WPCLI_Clean_Command.php
+++ b/classes/WP_CLI/ActionScheduler_WPCLI_Clean_Command.php
@@ -36,7 +36,7 @@ class ActionScheduler_WPCLI_Clean_Command extends WP_CLI_Command {
 		$batches = absint( \WP_CLI\Utils\get_flag_value( $assoc_args, 'batches', 0 ) );
 		$status  = explode( ',', WP_CLI\Utils\get_flag_value( $assoc_args, 'status', '' ) );
 		$status  = array_filter( array_map( 'trim', $status ) );
-		$before  = \WP_CLI\Utils\get_flag_value( $assoc_args, 'before', '' );
+		$before  = \WP_CLI\Utils\get_flag_value( $assoc_args, 'before', '31 days ago' );
 		$sleep   = \WP_CLI\Utils\get_flag_value( $assoc_args, 'pause', 0 );
 
 		$batches_completed = 0;


### PR DESCRIPTION
### Description
Closes #1343

This PR fixes an issue where running the `wp action-scheduler clean` command without specifying the `--before` flag incorrectly deletes **all** completed/failed/cancelled actions instead of keeping the last 31 days of data as stated in the documentation.

### Cause of the bug
In `ActionScheduler_WPCLI_Clean_Command::clean()`, the default value for the `before` argument was set to an empty string `''`. When passed further down into `strtotime()`, this empty string evaluates to "now", causing the cleaner to wipe out even newly created/completed actions.

### Solution
Changed the default value from `''` to `'31 days ago'` to align the default CLI behavior with the plugin's default retention period and documentation.

### How to test
1. Create some fresh completed actions: 
   `wp eval 'for($i=0; $i<5; $i++) { $id = as_schedule_single_action(time(), "test", [], "test"); ActionScheduler::store()->mark_complete($id); }'`
2. Run the clean command without flags: `wp action-scheduler clean`
3. **Before this fix:** All 5 fresh actions are deleted (`5 actions deleted.`).
4. **After this fix:** The fresh actions are safely preserved (`0 batches processed.`).