### PR TITLE
Add light colour scheme for GitHub Pages docs site

### DIFF
--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -55,3 +55,60 @@ footer {
 		animation:octocat-wave 560ms ease-in-out
 	}
 }
+
+// Light colour scheme for visitors whose OS/browser prefers a light theme.
+// See https://github.com/woocommerce/action-scheduler/issues/1321.
+@media (prefers-color-scheme: light) {
+	body {
+		background: #ebf4fa;
+		color: #021b34;
+
+		h1, h2, h3, h4, h5 {
+			color: #036085;
+			text-shadow: none;
+		}
+
+		header h1 a {
+			color: #036085;
+			text-decoration: none;
+		}
+
+		header p:first-child a {
+			text-decoration: none;
+		}
+
+		header p:first-child a:hover {
+			text-decoration: underline;
+		}
+
+		header h2 {
+			color: #021b34;
+		}
+
+		a {
+			color: #036085;
+			text-decoration: underline;
+		}
+
+		a:hover {
+			color: #02384d;
+		}
+
+		ul li {
+			list-style-image: none;
+		}
+
+		code.highlighter-rouge {
+			background: #c4e2f5;
+			color: inherit;
+		}
+
+		header a.github-corner svg path {
+			fill: #c4e2f5;
+		}
+
+		header a.github-corner svg path.octo-body {
+			fill: #02506e;
+		}
+	}
+}


### PR DESCRIPTION
The current documentation site only renders in 'dark mode'. This isn't ideal for visitors who prefer a light mode, as detailed in the linked issue. Note that this change does not introduce a toggle as suggested, but instead tries to respect the OS-level light/dark mode setting.

<img width="4065" height="3264" alt="light-scheme" src="https://github.com/user-attachments/assets/fee27220-900a-4dcd-8802-10efdc2806b6" />

Closes #1321

---

- Testing this is more difficult than you might think (or, I'm missing a dimension about how to set it up) as the theme etc we see with the deployed site is not the result I get when previewing things locally/via Jekyll.
- However, we *can* simulate it by appending the CSS in the diff to the end of the current stylesheet (and then use browser dev tools to force light mode, depending on your OS configuration, etc).
