### PR TITLE
Docs: Clarify --before parameter behavior in WP-CLI clean command

### DIFF
--- a/classes/WP_CLI/ActionScheduler_WPCLI_Clean_Command.php
+++ b/classes/WP_CLI/ActionScheduler_WPCLI_Clean_Command.php
@@ -19,7 +19,7 @@ class ActionScheduler_WPCLI_Clean_Command extends WP_CLI_Command {
 	 * : Only clean actions with the specified status. Defaults to Canceled, Completed. Define multiple statuses as a comma separated string (without spaces), e.g. `--status=complete,failed,canceled`
 	 *
 	 * [--before=<datestring>]
-	 * : Only delete actions with scheduled date older than this. Defaults to 31 days. e.g `--before='7 days ago'`, `--before='02-Feb-2020 20:20:20'`
+	 * : Only delete actions with a last modification date (attempt date) older than this. Defaults to 31 days. e.g `--before='7 days ago'`, `--before='02-Feb-2020 20:20:20'`
 	 *
 	 * [--pause=<seconds>]
 	 * : The number of seconds to pause between batches. Default no pause.

--- a/docs/wp-cli.md
+++ b/docs/wp-cli.md
@@ -25,7 +25,7 @@ These are the commands available to use with Action Scheduler:
   * `--batch-size` - This is the number of actions per status to clean in a single batch. Default is `20`.
   * `--batches` - This is the number of batches to process. Default 0 means that batches will continue to process until there are no more actions to delete.
   * `--status` - Process only actions with specific status or statuses. Default is `canceled` and `complete`. Define multiple statuses as a comma separated string (without spaces), e.g. `--status=complete,failed,canceled`
-  * `--before` - Process only actions with scheduled date older than this. Defaults to 31 days. e.g `--before='7 days ago'`, `--before='02-Feb-2020 20:20:20'`
+  * `--before` - Process only actions with a last modification date (attempt date) older than this. Defaults to 31 days. e.g `--before='7 days ago'`, `--before='02-Feb-2020 20:20:20'`
   * `--pause` - The number of seconds to pause between batches. Default no pause.
 
 * `action-scheduler migrate`


### PR DESCRIPTION
### Description
As discussed in #1348, changing the core date filtering logic from `last_attempt_gmt` to `scheduled_date_gmt` presents risks for the debugging window in delayed queues. 

Therefore, as suggested by @barryhughes, this PR treats the initial report as a documentation discrepancy and updates the WP-CLI `clean` command help text to accurately reflect the actual code behavior (filtering by the last modification/attempt date rather than the plan date).

### Related Issues
Part of #1107