### PR TITLE
Fix #1107: Purge orphan claims during queue cleaning pass

### DIFF
--- a/classes/ActionScheduler_QueueCleaner.php
+++ b/classes/ActionScheduler_QueueCleaner.php
@@ -254,6 +254,10 @@ class ActionScheduler_QueueCleaner {
 			as_schedule_single_action( time(), self::CONTINUE_SCHEDULED_CLEANER_HOOK, array(), 'ActionScheduler', $called_from_run, 0 );
 		}
 
+		// After batched deletions, remove claim records that are no longer referenced by any action.
+		// Done once per cleaning pass instead of once per deleted action.
+		$this->store->purge_orphan_claims();
+
 		return array_merge( array(), ...$deleted_actions );
 	}
 

--- a/classes/abstracts/ActionScheduler_Store.php
+++ b/classes/abstracts/ActionScheduler_Store.php
@@ -498,6 +498,15 @@ abstract class ActionScheduler_Store extends ActionScheduler_Store_Deprecated {
 	}
 
 	/**
+	 * Purge claim records that are no longer referenced by any action.
+	 *
+	 * @return int|false Number of orphan claims deleted, or false on failure.
+	 */
+	public function purge_orphan_claims() {
+		return 0;
+	}
+
+	/**
 	 * Get instance.
 	 *
 	 * @return ActionScheduler_Store

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -1179,6 +1179,7 @@ AND args = %s
 		global $wpdb;
 
 		$sql = "DELETE c FROM {$wpdb->actionscheduler_claims} c LEFT JOIN {$wpdb->actionscheduler_actions} a ON a.claim_id = c.claim_id WHERE a.action_id IS NULL";
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- No user input, no placeholders needed.
 		$deleted = $wpdb->query( $sql );
 
 		return false === $deleted ? false : (int) $deleted;

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -1166,6 +1166,25 @@ AND args = %s
 	}
 
 	/**
+	 * Purge claim records that are no longer referenced by any action.
+	 *
+	 * @return int|false Number of orphan claims deleted, or false on failure.
+	 */
+	public function purge_orphan_claims() {
+		/**
+		 * Global.
+		 *
+		 * @var \wpdb $wpdb
+		 */
+		global $wpdb;
+
+		$sql = "DELETE c FROM {$wpdb->actionscheduler_claims} c LEFT JOIN {$wpdb->actionscheduler_actions} a ON a.claim_id = c.claim_id WHERE a.action_id IS NULL";
+		$deleted = $wpdb->query( $sql );
+
+		return false === $deleted ? false : (int) $deleted;
+	}
+
+	/**
 	 * Return an action's claim ID, as stored in the claim_id column.
 	 *
 	 * @param string $action_id Action ID.

--- a/tests/phpunit/jobstore/ActionScheduler_DBStore_Test.php
+++ b/tests/phpunit/jobstore/ActionScheduler_DBStore_Test.php
@@ -137,7 +137,7 @@ class ActionScheduler_DBStore_Test extends AbstractStoreTest {
 	public function test_claim_actions() {
 		$created_actions = array();
 		$store           = new ActionScheduler_DBStore();
-		for ( $i = 3; $i > - 3; $i -- ) {
+		for ( $i = 3; $i > - 3; $i-- ) {
 			$time     = as_get_datetime_object( $i . ' hours' );
 			$schedule = new ActionScheduler_SimpleSchedule( $time );
 			$action   = new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, array( $i ), $schedule, 'my_group' );
@@ -189,7 +189,7 @@ class ActionScheduler_DBStore_Test extends AbstractStoreTest {
 			$unique_hook_two,
 		);
 
-		for ( $i = 3; $i > - 3; $i -- ) {
+		for ( $i = 3; $i > - 3; $i-- ) {
 			foreach ( $unique_hooks as $unique_hook ) {
 				$time      = as_get_datetime_object( $i . ' hours' );
 				$schedule  = new ActionScheduler_SimpleSchedule( $time );
@@ -231,7 +231,7 @@ class ActionScheduler_DBStore_Test extends AbstractStoreTest {
 			$unique_group_two,
 		);
 
-		for ( $i = 3; $i > - 3; $i -- ) {
+		for ( $i = 3; $i > - 3; $i-- ) {
 			foreach ( $unique_groups as $unique_group ) {
 				$time     = as_get_datetime_object( $i . ' hours' );
 				$schedule = new ActionScheduler_SimpleSchedule( $time );
@@ -323,7 +323,7 @@ class ActionScheduler_DBStore_Test extends AbstractStoreTest {
 			$unique_group_two,
 		);
 
-		for ( $i = 3; $i > - 3; $i -- ) {
+		for ( $i = 3; $i > - 3; $i-- ) {
 			foreach ( $unique_hooks as $unique_hook ) {
 				foreach ( $unique_groups as $unique_group ) {
 					$time      = as_get_datetime_object( $i . ' hours' );
@@ -438,7 +438,7 @@ class ActionScheduler_DBStore_Test extends AbstractStoreTest {
 
 		// This callback is used to simulate the unusual conditions whereby MySQL might unexpectedly return future
 		// actions, contrary to the conditions used by the store object when staking its claim.
-		$simulate_unexpected_db_behavior = function( $sql ) use ( $action_ids ) {
+		$simulate_unexpected_db_behavior = function ( $sql ) use ( $action_ids ) {
 			global $wpdb;
 
 			// Look out for the claim update query, ignore all others.
@@ -467,7 +467,7 @@ class ActionScheduler_DBStore_Test extends AbstractStoreTest {
 	public function test_duplicate_claim() {
 		$created_actions = array();
 		$store           = new ActionScheduler_DBStore();
-		for ( $i = 0; $i > - 3; $i -- ) {
+		for ( $i = 0; $i > - 3; $i-- ) {
 			$time     = as_get_datetime_object( $i . ' hours' );
 			$schedule = new ActionScheduler_SimpleSchedule( $time );
 			$action   = new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, array( $i ), $schedule, 'my_group' );
@@ -484,7 +484,7 @@ class ActionScheduler_DBStore_Test extends AbstractStoreTest {
 	public function test_release_claim() {
 		$created_actions = array();
 		$store           = new ActionScheduler_DBStore();
-		for ( $i = 0; $i > - 3; $i -- ) {
+		for ( $i = 0; $i > - 3; $i-- ) {
 			$time     = as_get_datetime_object( $i . ' hours' );
 			$schedule = new ActionScheduler_SimpleSchedule( $time );
 			$action   = new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, array( $i ), $schedule, 'my_group' );
@@ -501,13 +501,12 @@ class ActionScheduler_DBStore_Test extends AbstractStoreTest {
 		$this->assertCount( 3, $claim2->get_actions() );
 		$store->release_claim( $claim2 );
 		$this->assertCount( 0, $store->find_actions_by_claim_id( $claim1->get_id() ) );
-
 	}
 
 	public function test_search() {
 		$created_actions = array();
 		$store           = new ActionScheduler_DBStore();
-		for ( $i = - 3; $i <= 3; $i ++ ) {
+		for ( $i = - 3; $i <= 3; $i++ ) {
 			$time     = as_get_datetime_object( $i . ' hours' );
 			$schedule = new ActionScheduler_SimpleSchedule( $time );
 			$action   = new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, array( $i ), $schedule, 'my_group' );
@@ -761,9 +760,9 @@ class ActionScheduler_DBStore_Test extends AbstractStoreTest {
 		$this->original_wpdb = $wpdb;
 
 		$wpdb = $this->getMockBuilder( get_class( $wpdb ) )
-		             ->setMethods( [ 'db_server_info' ] )
-		             ->disableOriginalConstructor()
-		             ->getMock();
+					->setMethods( array( 'db_server_info' ) )
+					->disableOriginalConstructor()
+					->getMock();
 
 		$wpdb->method( 'db_server_info' )->willReturn( $db_server_info );
 
@@ -786,31 +785,31 @@ class ActionScheduler_DBStore_Test extends AbstractStoreTest {
 		return array(
 			'MySQL 5.6.1 does not support skip locked'    => array(
 				false,
-				'5.6.1'
+				'5.6.1',
 			),
 			'MySQL 8.0.0 does not support skip locked'    => array(
 				false,
-				'8.0.0'
+				'8.0.0',
 			),
 			'MySQL 8.0.1 does support skip locked'        => array(
 				true,
-				'8.0.1'
+				'8.0.1',
 			),
 			'MySQL 8.4.4 does support skip locked'        => array(
 				true,
-				'8.4.4'
+				'8.4.4',
 			),
 			'MariaDB 10.5.0 does not support skip locked' => array(
 				false,
-				$maria_db_prefix . '10.5.0-MariaDB'
+				$maria_db_prefix . '10.5.0-MariaDB',
 			),
 			'MariaDB 10.6.0 does support skip locked'     => array(
 				true,
-				$maria_db_prefix . '10.6.0-MariaDB'
+				$maria_db_prefix . '10.6.0-MariaDB',
 			),
 			'MariaDB 11.5.0 does support skip locked'     => array(
 				true,
-				$maria_db_prefix . '11.5.0-MariaDB'
+				$maria_db_prefix . '11.5.0-MariaDB',
 			),
 		);
 	}
@@ -1006,8 +1005,8 @@ class ActionScheduler_DBStore_Test extends AbstractStoreTest {
 		global $wpdb;
 		$store = new ActionScheduler_DBStore();
 
-		$schedule = new ActionScheduler_SimpleSchedule( as_get_datetime_object( '-1 hour' ) );
-		$action   = new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, array(), $schedule );
+		$schedule  = new ActionScheduler_SimpleSchedule( as_get_datetime_object( '-1 hour' ) );
+		$action    = new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, array(), $schedule );
 		$action_id = $store->save_action( $action );
 
 		$claim = $store->stake_claim();
@@ -1050,8 +1049,8 @@ class ActionScheduler_DBStore_Test extends AbstractStoreTest {
 		global $wpdb;
 		$store = new ActionScheduler_DBStore();
 
-		$schedule = new ActionScheduler_SimpleSchedule( as_get_datetime_object( '-1 hour' ) );
-		$action   = new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, array(), $schedule );
+		$schedule  = new ActionScheduler_SimpleSchedule( as_get_datetime_object( '-1 hour' ) );
+		$action    = new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, array(), $schedule );
 		$action_id = $store->save_action( $action );
 
 		$store->stake_claim();

--- a/tests/phpunit/jobstore/ActionScheduler_DBStore_Test.php
+++ b/tests/phpunit/jobstore/ActionScheduler_DBStore_Test.php
@@ -20,8 +20,9 @@ class ActionScheduler_DBStore_Test extends AbstractStoreTest {
 	public function setUp(): void {
 		global $wpdb;
 
-		// Delete all actions before each test.
+		// Delete all actions and orphan claims before each test.
 		$wpdb->query( "DELETE FROM {$wpdb->actionscheduler_actions}" );
+		$wpdb->query( "DELETE FROM {$wpdb->actionscheduler_claims}" );
 
 		parent::setUp();
 	}
@@ -951,5 +952,115 @@ class ActionScheduler_DBStore_Test extends AbstractStoreTest {
 		$this->assertSame( (int) wp_cache_get( 'cached_group', ActionScheduler_DBStore::GROUP_IDS_CACHE_GROUP ), $ids[0] );
 		$this->assertSame( (int) wp_cache_get( 'uncached_group', ActionScheduler_DBStore::GROUP_IDS_CACHE_GROUP ), $ids[1] );
 		$this->assertSame( (int) wp_cache_get( ActionScheduler_DBStore::GROUP_IDS_DEFAULT_CACHE_KEY, ActionScheduler_DBStore::GROUP_IDS_CACHE_GROUP ), $ids[2] );
+	}
+
+	/**
+	 * @testdox purge_orphan_claims() returns the number of removed orphan claims.
+	 */
+	public function test_purge_orphan_claims_returns_count() {
+		global $wpdb;
+
+		$store = new ActionScheduler_DBStore();
+
+		// Insert three raw claim rows with no referencing actions.
+		$wpdb->insert( $wpdb->actionscheduler_claims, array( 'date_created_gmt' => '2020-01-01 00:00:00' ) );
+		$wpdb->insert( $wpdb->actionscheduler_claims, array( 'date_created_gmt' => '2020-01-01 00:00:00' ) );
+		$wpdb->insert( $wpdb->actionscheduler_claims, array( 'date_created_gmt' => '2020-01-01 00:00:00' ) );
+
+		$deleted = $store->purge_orphan_claims();
+
+		$this->assertSame( 3, $deleted );
+		$this->assertSame( 0, (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->actionscheduler_claims}" ) );
+	}
+
+	/**
+	 * @testdox purge_orphan_claims() keeps claims that are still referenced by at least one action.
+	 */
+	public function test_purge_orphan_claims_keeps_referenced_claims() {
+		global $wpdb;
+		$store = new ActionScheduler_DBStore();
+
+		$schedule = new ActionScheduler_SimpleSchedule( as_get_datetime_object( '-1 hour' ) );
+		$action   = new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, array(), $schedule );
+		$store->save_action( $action );
+
+		$claim = $store->stake_claim();
+		$this->assertNotEmpty( $claim->get_id() );
+
+		// Add two orphan claims on top of the one referenced by the action.
+		$wpdb->insert( $wpdb->actionscheduler_claims, array( 'date_created_gmt' => '2020-01-01 00:00:00' ) );
+		$wpdb->insert( $wpdb->actionscheduler_claims, array( 'date_created_gmt' => '2020-01-01 00:00:00' ) );
+
+		$deleted = $store->purge_orphan_claims();
+
+		$this->assertSame( 2, $deleted );
+		$this->assertSame( 1, (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->actionscheduler_claims}" ) );
+		$remaining_claim_id = (int) $wpdb->get_var( "SELECT claim_id FROM {$wpdb->actionscheduler_claims}" );
+		$this->assertSame( (int) $claim->get_id(), $remaining_claim_id );
+	}
+
+	/**
+	 * @testdox purge_orphan_claims() removes the claim of a deleted action once no action references it.
+	 */
+	public function test_purge_orphan_claims_clears_claim_after_action_deletion() {
+		global $wpdb;
+		$store = new ActionScheduler_DBStore();
+
+		$schedule = new ActionScheduler_SimpleSchedule( as_get_datetime_object( '-1 hour' ) );
+		$action   = new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, array(), $schedule );
+		$action_id = $store->save_action( $action );
+
+		$claim = $store->stake_claim();
+		$this->assertContains( $action_id, $claim->get_actions() );
+
+		$store->delete_action( $action_id );
+
+		// After delete_action() the claim row is still present (purging happens in a batch pass).
+		$this->assertSame( 1, (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->actionscheduler_claims}" ) );
+
+		$deleted = $store->purge_orphan_claims();
+
+		$this->assertSame( 1, $deleted );
+		$this->assertSame( 0, (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->actionscheduler_claims}" ) );
+	}
+
+	/**
+	 * @testdox purge_orphan_claims() is a no-op when there are no orphan claims.
+	 */
+	public function test_purge_orphan_claims_is_noop_when_no_orphans() {
+		global $wpdb;
+		$store = new ActionScheduler_DBStore();
+
+		$schedule = new ActionScheduler_SimpleSchedule( as_get_datetime_object( '-1 hour' ) );
+		$action   = new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, array(), $schedule );
+		$store->save_action( $action );
+
+		$store->stake_claim();
+
+		$deleted = $store->purge_orphan_claims();
+
+		$this->assertSame( 0, $deleted );
+		$this->assertSame( 1, (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->actionscheduler_claims}" ) );
+	}
+
+	/**
+	 * @testdox delete_action() does not touch the claims table (the row is left for batch purging).
+	 */
+	public function test_delete_action_does_not_touch_claims_table() {
+		global $wpdb;
+		$store = new ActionScheduler_DBStore();
+
+		$schedule = new ActionScheduler_SimpleSchedule( as_get_datetime_object( '-1 hour' ) );
+		$action   = new ActionScheduler_Action( ActionScheduler_Callbacks::HOOK_WITH_CALLBACK, array(), $schedule );
+		$action_id = $store->save_action( $action );
+
+		$store->stake_claim();
+		$claims_before = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->actionscheduler_claims}" );
+
+		$store->delete_action( $action_id );
+
+		$claims_after = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->actionscheduler_claims}" );
+
+		$this->assertSame( $claims_before, $claims_after, 'delete_action() must not modify the claims table; orphan cleanup is done in a batch pass.' );
 	}
 }

--- a/tests/phpunit/runner/ActionScheduler_QueueCleaner_Test.php
+++ b/tests/phpunit/runner/ActionScheduler_QueueCleaner_Test.php
@@ -5,6 +5,69 @@
  */
 class ActionScheduler_QueueCleaner_Test extends ActionScheduler_UnitTestCase {
 
+	public function tearDown(): void {
+		parent::tearDown();
+		$wpdb = $GLOBALS['wpdb'];
+		$wpdb->query( "TRUNCATE TABLE {$wpdb->prefix}actionscheduler_actions" );
+		$wpdb->query( "TRUNCATE TABLE {$wpdb->prefix}actionscheduler_claims" );
+	}
+
+	/**
+	 * @testdox clean_actions() invokes purge_orphan_claims() once at the end of a cleaning pass.
+	 */
+	public function test_clean_actions_purges_orphan_claims_once() {
+		$store = $this->getMockBuilder( ActionScheduler_Store::class )->disableOriginalConstructor()->getMock();
+
+		// No actions to delete, so delete_action() is never called.
+		$store->expects( $this->never() )->method( 'delete_action' );
+
+		// But purge_orphan_claims() must be called exactly once, after the loop over statuses.
+		$store->expects( $this->once() )
+			->method( 'purge_orphan_claims' )
+			->willReturn( 0 );
+
+		// query_actions() returns 0 matching actions for every status, so no batches are processed.
+		$store->expects( $this->any() )
+			->method( 'query_actions' )
+			->willReturn( array() );
+
+		$statuses = array( 'complete', 'canceled' );
+		$cutoff   = as_get_datetime_object( '31 days ago' );
+
+		$cleaner = new ActionScheduler_QueueCleaner( $store );
+		$cleaner->clean_actions( $statuses, $cutoff, 100, 'CLI' );
+	}
+
+	/**
+	 * @testdox clean_actions() calls purge_orphan_claims() even when the cleaning pass actually deleted actions.
+	 */
+	public function test_clean_actions_purges_orphan_claims_after_real_deletions() {
+		$store = $this->getMockBuilder( ActionScheduler_Store::class )->disableOriginalConstructor()->getMock();
+
+		// Two fake action IDs will be deleted.
+		$store->expects( $this->exactly( 2 ) )
+			->method( 'delete_action' )
+			->willReturn( true );
+
+		// query_actions() returns two pending IDs, then an empty list so the loop terminates.
+		$store->expects( $this->any() )
+			->method( 'query_actions' )
+			->willReturnOnConsecutiveCalls( array( 1, 2 ), array() );
+
+		// purge_orphan_claims() is called exactly once after the loop finishes.
+		$store->expects( $this->once() )
+			->method( 'purge_orphan_claims' )
+			->willReturn( 1 );
+
+		$statuses = array( 'complete', 'canceled' );
+		$cutoff   = as_get_datetime_object( '31 days ago' );
+
+		$cleaner = new ActionScheduler_QueueCleaner( $store );
+		$deleted = $cleaner->clean_actions( $statuses, $cutoff, 20, 'CLI' );
+
+		$this->assertCount( 2, $deleted );
+	}
+
 	public function test_delete_old_actions() {
 		$store    = ActionScheduler::store();
 		$runner   = ActionScheduler_Mocker::get_queue_runner( $store );


### PR DESCRIPTION
### Description
Following up on the discussion in #1348 regarding issue #1107, this PR explicitly addresses the **accumulation of orphaned claim records** in the `actionscheduler_claims` table. 

As suggested by @barryhughes Barry, rather than checking and deleting claims dynamically during every single `delete_action()` call (which would introduce unwanted query overhead), this implementation handles the cleanup **batch-wise**. The orphan claims are now purged via a single optimized `LEFT JOIN` query at the very end of a queue cleaning pass in `ActionScheduler_QueueCleaner::clean_actions()`.

### Key Changes
1. **`ActionScheduler_Store` & `ActionScheduler_DBStore`**: Introduced `purge_orphan_claims()` which deletes rows from the claims table where no corresponding `action_id` exists.
2. **`ActionScheduler_QueueCleaner`**: Hooked the batch purge to run once per `clean_actions()` call execution loop.
3. **Test Suites**:
   - Added 5 new regression tests in `ActionScheduler_DBStore_Test` covering exact cleanup counts, referenced claim preservation, and no-op behavior.
   - Fixed database state leaking in `ActionScheduler_QueueCleaner_Test` via an explicit `: void` compatible `tearDown()` block ensuring clean runs.

### Related Issues
Fixes part of #1107 (Specifically point 4: "Old claims are not deleted too").

### How to test the changes
1. Run DBStore tests to ensure the core purging logic works seamlessly:
   ```bash
   vendor/bin/phpunit tests/phpunit/jobstore/ActionScheduler_DBStore_Test.php