### PR TITLE
Add action IDs to admin list and search

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 4.1.0 - xxxx-xx-xx =
+* Enhancement - Display action IDs in the admin list and allow searching by action ID.
 * Use `wp_admin_notice()` to render admin notices, instead of custom HTML.
 * Fix an oversight in the lock implementation (used to rate-limit async request runners) that could result in a database error in unusual cases.
 * Add protections to guard against the risk of object-injection/deserialization attacks when retrieving stored schedule data.

--- a/classes/ActionScheduler_ListTable.php
+++ b/classes/ActionScheduler_ListTable.php
@@ -115,6 +115,12 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 			'group',
 		);
 
+		/*
+		 * Only the emptiness of this property matters here: it is what causes the search box to be
+		 * rendered. The individual entries are unused, because this class overrides prepare_items()
+		 * and delegates searching to the store, rather than using the parent's
+		 * get_items_query_search().
+		 */
 		$this->search_by = array(
 			'hook',
 			'args',

--- a/classes/ActionScheduler_ListTable.php
+++ b/classes/ActionScheduler_ListTable.php
@@ -330,6 +330,22 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 	}
 
 	/**
+	 * Render the hook name and action ID.
+	 *
+	 * @param array $row Action data.
+	 * @return string
+	 */
+	public function column_hook( $row ) {
+		$action_id = sprintf(
+			/* translators: %d: Action ID. */
+			__( 'ID: %d', 'action-scheduler' ),
+			absint( $row['ID'] )
+		);
+
+		return esc_html( $row['hook'] ) . '<br><small>' . esc_html( $action_id ) . '</small>' . $this->maybe_render_actions( $row, 'hook' );
+	}
+
+	/**
 	 * Only display row actions for pending actions.
 	 *
 	 * @param array  $row         Row to render.
@@ -666,7 +682,7 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 	 * Get the text to display in the search box on the list table.
 	 */
 	protected function get_search_box_button_text() {
-		return __( 'Search hook, args and claim ID', 'action-scheduler' );
+		return __( 'Search hook, args, action ID and claim ID', 'action-scheduler' );
 	}
 
 	/**

--- a/classes/data-stores/ActionScheduler_DBStore.php
+++ b/classes/data-stores/ActionScheduler_DBStore.php
@@ -648,10 +648,11 @@ AND args = %s
 				$sql_params[] = sprintf( '%%%s%%', $query['search'] );
 			}
 
-			$search_claim_id = (int) $query['search'];
-			if ( $search_claim_id ) {
-				$sql         .= ' OR a.claim_id = %d';
-				$sql_params[] = $search_claim_id;
+			$search_id = (int) $query['search'];
+			if ( $search_id ) {
+				$sql         .= ' OR a.action_id = %d OR a.claim_id = %d';
+				$sql_params[] = $search_id;
+				$sql_params[] = $search_id;
 			}
 
 			$sql .= ')';

--- a/classes/data-stores/ActionScheduler_wpPostStore.php
+++ b/classes/data-stores/ActionScheduler_wpPostStore.php
@@ -443,10 +443,18 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 		}
 
 		if ( ! empty( $query['search'] ) ) {
-			$sql .= ' AND (p.post_title LIKE %s OR p.post_content LIKE %s OR p.post_password LIKE %s)';
+			$sql .= ' AND (p.post_title LIKE %s OR p.post_content LIKE %s OR p.post_password LIKE %s';
 			for ( $i = 0; $i < 3; $i++ ) {
 				$sql_params[] = sprintf( '%%%s%%', $query['search'] );
 			}
+
+			$search_action_id = (int) $query['search'];
+			if ( $search_action_id ) {
+				$sql         .= ' OR p.ID = %d';
+				$sql_params[] = $search_action_id;
+			}
+
+			$sql .= ')';
 		}
 
 		if ( 'select' === $select_or_count ) {

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -12,10 +12,11 @@ The administration interface is accessible through both:
 
 Among other tasks, from the admin screen you can:
 
-* run a pending action
-* view the scheduled actions with a specific status, like the all actions which have failed or are in-progress (https://cldup.com/NNTwE88Xl8.png).
-* view the log entries for a specific action to find out why it failed.
-* sort scheduled actions by hook name, scheduled date, claim ID or group name.
+* Run a pending action.
+* View the scheduled actions with a specific status, like all actions which have failed or are in-progress [(screenshot)](https://cldup.com/NNTwE88Xl8.png).
+* View the log entries for a specific action to find out why it failed.
+* Sort scheduled actions by hook name, scheduled date, group, claim ID or status.
+* Search for actions by hook, args, action ID or claim ID.
 
 Still have questions? Check out the [FAQ](/faq).
 

--- a/tests/phpunit.xml.dist
+++ b/tests/phpunit.xml.dist
@@ -32,6 +32,7 @@
 			<file>./phpunit/logging/ActionScheduler_wpCommentLogger_Test.php</file>
 			<file>./phpunit/jobstore/ActionScheduler_wpPostStore_Test.php</file>
 			<file>./phpunit/jobstore/ActionScheduler_RecurringActionScheduler_Test.php</file>
+			<file>./phpunit/ActionScheduler_ListTable_Test.php</file>
 		</testsuite>
 	</testsuites>
 	<groups>

--- a/tests/phpunit/ActionScheduler_ListTable_Test.php
+++ b/tests/phpunit/ActionScheduler_ListTable_Test.php
@@ -16,7 +16,7 @@ class ActionScheduler_ListTable_Test extends ActionScheduler_UnitTestCase {
 			)
 		);
 
-		$this->assertStringContainsString( '&lt;script&gt;test&lt;/script&gt;', $output );
+		$this->assertStringContainsString( '&lt;script&gt;test&lt;/script&gt;', $output, 'HTML elements will be escaped' );
 		$this->assertStringContainsString( 'ID: 123', $output );
 		$this->assertStringNotContainsString( '<script>', $output );
 	}

--- a/tests/phpunit/ActionScheduler_ListTable_Test.php
+++ b/tests/phpunit/ActionScheduler_ListTable_Test.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * Tests for the Action Scheduler admin list table.
+ */
+class ActionScheduler_ListTable_Test extends ActionScheduler_UnitTestCase {
+
+	public function test_column_hook_displays_escaped_hook_and_action_id() {
+		$reflection = new ReflectionClass( ActionScheduler_ListTable::class );
+		$list_table = $reflection->newInstanceWithoutConstructor();
+		$output     = $list_table->column_hook(
+			array(
+				'ID'          => 123,
+				'hook'        => '<script>test</script>',
+				'status_name' => ActionScheduler_Store::STATUS_COMPLETE,
+			)
+		);
+
+		$this->assertStringContainsString( '&lt;script&gt;test&lt;/script&gt;', $output );
+		$this->assertStringContainsString( 'ID: 123', $output );
+		$this->assertStringNotContainsString( '<script>', $output );
+	}
+}

--- a/tests/phpunit/jobstore/AbstractStoreTest.php
+++ b/tests/phpunit/jobstore/AbstractStoreTest.php
@@ -115,6 +115,18 @@ abstract class AbstractStoreTest extends ActionScheduler_UnitTestCase {
 		);
 	}
 
+	public function test_query_actions_search_by_action_id() {
+		$store    = $this->get_store();
+		$schedule = new ActionScheduler_SimpleSchedule( as_get_datetime_object( 'tomorrow' ) );
+
+		$action_id       = $store->save_action( new ActionScheduler_Action( 'search_action_id', array( 'first' ), $schedule ) );
+		$other_action_id = $store->save_action( new ActionScheduler_Action( 'search_action_id', array( 'second' ), $schedule ) );
+		$results         = array_map( 'intval', $store->query_actions( array( 'search' => (string) $action_id ) ) );
+
+		$this->assertContains( $action_id, $results );
+		$this->assertNotContains( $other_action_id, $results );
+	}
+
 	// phpcs:ignore Squiz.PHP.CommentedOutCode.Found
 	// End tests for \ActionScheduler_Store::query_actions().
 


### PR DESCRIPTION
## Summary
- Show the action ID below each hook name.
- Allow searching by action ID in both stores.

Addresses part of #1261.

## Screenshots
### Before

<img width="1351" height="316" alt="image" src="https://github.com/user-attachments/assets/07046db0-4366-4f4a-98ab-e63391a4d788" />

### After

<img width="1355" height="328" alt="image" src="https://github.com/user-attachments/assets/df4948ce-22d1-4c51-9025-5a30b00bf84c" />

